### PR TITLE
Ignore build output from a Hakyll executable

### DIFF
--- a/hakyll-template.hsfiles
+++ b/hakyll-template.hsfiles
@@ -40,6 +40,8 @@ cabal.sandbox.config
 *.aux
 *.hp
 .stack-work/
+_cache/
+_site/
 
 {-# START_FILE .ghci #-}
 :set -XOverloadedStrings


### PR DESCRIPTION
I added the _cache and _site directories to the .gitignore file.