### PR TITLE
Change in warp to be able to run under lts 5.4

### DIFF
--- a/yesod-hello-world.hsfiles
+++ b/yesod-hello-world.hsfiles
@@ -50,7 +50,7 @@ executable         {{name}}
                  , yaml                          >= 0.8        && < 0.9
                  , http-conduit                  >= 2.1        && < 2.2
                  , directory                     >= 1.1        && < 1.3
-                 , warp                          >= 3.0        && < 3.2
+                 , warp                          >= 3.0        && < 3.3
                  , data-default
                  , aeson                         >= 0.6        && < 0.10
                  , conduit                       >= 1.0        && < 2.0


### PR DESCRIPTION
Accepting warp 3.3 in order to being able to run yesod-hello-world template with latest lts 5.4 package collection