### PR TITLE
UnicodeSyntax

### DIFF
--- a/unicode-executable.hsfiles
+++ b/unicode-executable.hsfiles
@@ -32,7 +32,7 @@ main = do
   putStrLn "ᚣ"
 
 {-# START_FILE LICENCE #-}
-Copyright {{author-name}} © 2016
+Copyright {{author-name}} © {{year}}
 
 All rights reserved.
 

--- a/unicode-executable.hsfiles
+++ b/unicode-executable.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Unicode library template from stack
+synopsis:            Unicode executable template from stack
 description:         Please see README.md
 homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
@@ -9,32 +9,27 @@ license-file:        LICENCE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
 copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
-category:            {{category}}{{^category}}Data{{/category}}
+category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 cabal-version:       >=1.10
 
-library
+executable {{name}}
   hs-source-dirs:      source
   default-language:    Haskell2010
   default-extensions:  UnicodeSyntax
                      , OverloadedStrings
-  exposed-modules:     Library
+  main-is:             Main.hs
   build-depends:       base
                      , base-unicode-symbols
                      
-{-# START_FILE source/Library.hs #-}
-module Library where
+{-# START_FILE Setup.hs #-}
+import Distribution.Simple
+main = defaultMain
 
-data 𝕋 α β
-  = ℍ α
-  | ℙ β
-  | ℚ α β
-  deriving (Eq)
-
-ϝ ∷ (α → γ) → (β → γ) → (α → β → γ) → 𝕋 α β → γ
-ϝ l _ _ (ℍ a  ) = l a
-ϝ _ r _ (ℙ b  ) = r b
-ϝ _ _ g (ℚ a b) = g a b
+{-# START_FILE source/Main.hs #-}
+main ∷ IO ()
+main = do
+  putStrLn "ᚣ"
 
 {-# START_FILE LICENCE #-}
 Copyright {{author-name}} © 2016

--- a/unicode-library.hsfiles
+++ b/unicode-library.hsfiles
@@ -1,0 +1,70 @@
+{-# START_FILE {{name}}.cabal #-}
+name:                {{name}}
+version:             0.1.0.0
+synopsis:            Unicode library template from stack
+description:         Please see README.md
+homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+license:             BSD3
+license-file:        LICENCE
+author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
+maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
+copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+category:            {{category}}{{^category}}Data{{/category}}
+build-type:          Simple
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      source
+  default-language:    Haskell2010
+  default-extensions:  UnicodeSyntax
+                     , OverloadedStrings
+  exposed-modules:     Library
+  build-depends:       base
+                     , base-unicode-symbols
+                     
+
+{-# START_FILE source/Library.hs #-}
+module Library where
+
+data ⧓ α β
+  = ⬛ α
+  | ⬜ β
+  | ⧓ α β
+  deriving (Eq)
+
+⋈ ∷ (α → γ) → (β → γ) → (α → β → γ) → ⧓ α β → γ
+⋈ l _ _ (■ a  ) = l a
+⋈ _ r _ (□ b  ) = r b
+⋈ _ _ f (⧓ a b) = f a b
+
+{-# START_FILE LICENCE #-}
+Copyright {{author-name}} © 2016
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of {{author-name}} nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+This software is provided by the copyright holders and contributors
+“as is” and any express or implied warranties, including, but not
+limited to, the implied warranties of merchantability and fitness for
+a particular purpose are disclaimed. in no event shall the copyright
+owner or contributors be liable for any direct, indirect, incidental,
+special, exemplary, or consequential damages (including, but not
+limited to, procurement of substitute goods or services; loss of use,
+data, or profits; or business interruption) however caused and on any
+theory of liability, whether in contract, strict liability, or tort
+(including negligence or otherwise) arising in any way out of the use
+of this software, even if advised of the possibility of such damage.

--- a/unicode-library.hsfiles
+++ b/unicode-library.hsfiles
@@ -37,7 +37,7 @@ data 𝕋 α β
 ϝ _ _ g (ℚ a b) = g a b
 
 {-# START_FILE LICENCE #-}
-Copyright {{author-name}} © 2016
+Copyright {{author-name}} © {{year}}
 
 All rights reserved.
 


### PR DESCRIPTION
These two new templates provide a minimal project structure for `UnicodeSyntax`-enabled projects.
On the `unicode-library` template the example within is pretty ugly as far as naming choices go, but it showcases what kind of things can be done with it immediately.

This is an adaptation of what I use at work, minus common imports that might not be to everyone's taste.
It also lower cases the capitals at the end of the licence document for a more comfortable version — no more shouting at licencees :smiley:.