### PR TITLE
Use `year` tag and add mustache default values

### DIFF
--- a/chrisdone.hsfiles
+++ b/chrisdone.hsfiles
@@ -82,7 +82,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/chrisdone.hsfiles
+++ b/chrisdone.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 -- extra-source-files:
@@ -67,7 +67,7 @@ main :: IO ()
 main = someFunc
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 
@@ -82,7 +82,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}} nor the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/franklinchen.hsfiles
+++ b/franklinchen.hsfiles
@@ -15,7 +15,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Acme{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
@@ -107,7 +107,7 @@ main :: IO ()
 main = printf "2 + 3 = %d\n" (ourAdd 2 3)
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 
@@ -122,7 +122,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}} nor the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/franklinchen.hsfiles
+++ b/franklinchen.hsfiles
@@ -47,7 +47,7 @@ test-suite spec
                      , {{name}}
                      , hspec
                      , QuickCheck
-                     
+
 source-repository head
   type:     git
   location: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
@@ -87,7 +87,7 @@ spec =
 {-# START_FILE src/Lib.hs #-}
 -- | A library to do stuff.
 module Lib
-    ( 
+    (
       ourAdd
     ) where
 
@@ -122,7 +122,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/ghcjs-old-base.hsfiles
+++ b/ghcjs-old-base.hsfiles
@@ -70,7 +70,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/ghcjs-old-base.hsfiles
+++ b/ghcjs-old-base.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 -- extra-source-files:
@@ -55,7 +55,7 @@ foreign import javascript unsafe "window.alert($1)" js_alert :: JSString -> IO (
 someFunc :: IO ()
 someFunc = js_alert "Hello from GHCJS!"
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 
@@ -70,7 +70,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}} nor the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/ghcjs.hsfiles
+++ b/ghcjs.hsfiles
@@ -70,7 +70,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/ghcjs.hsfiles
+++ b/ghcjs.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 -- extra-source-files:
@@ -55,7 +55,7 @@ foreign import javascript unsafe "window.alert($1)" js_alert :: JSString -> IO (
 someFunc :: IO ()
 someFunc = js_alert "Hello from GHCJS!"
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 
@@ -70,7 +70,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}} nor the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/hakyll-template.hsfiles
+++ b/hakyll-template.hsfiles
@@ -311,7 +311,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/hakyll-template.hsfiles
+++ b/hakyll-template.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 cabal-version:       >=1.10
@@ -296,7 +296,7 @@ div.info {
 
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 
@@ -311,7 +311,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}} nor the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/haskeleton.hsfiles
+++ b/haskeleton.hsfiles
@@ -8,9 +8,9 @@ version:        0.0.0
 synopsis:       A new Haskeleton package.
 description:    {{ name }} is a new Haskeleton package.
 category:       Other
-homepage:       https://github.com/{{ github-username }}/{{ name }}#readme
-bug-reports:    https://github.com/{{ github-username }}/{{ name }}/issues
-maintainer:     {{ author-name }}
+homepage:       https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{ name }}#readme
+bug-reports:    https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{ name }}/issues
+maintainer:     {{author-name}}{{^author-name}}Author name here{{/author-name}}
 license:        MIT
 build-type:     Simple
 cabal-version:  >= 1.10
@@ -24,7 +24,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/{{ github-username }}/{{ name }}
+  location: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{ name }}
 
 library
   hs-source-dirs:
@@ -107,13 +107,13 @@ extra-source-files:
 - README.md
 - stack.yaml
 ghc-options: -Wall
-github: {{ github-username }}/{{ name }}
+github: {{github-username}}{{^github-username}}githubuser{{/github-username}}/{{ name }}
 library:
   dependencies:
   - base
   source-dirs: library
 license: MIT
-maintainer: {{ author-name }}
+maintainer: {{author-name}}{{^author-name}}Author name here{{/author-name}}
 name: {{ name }}
 synopsis: A new Haskeleton package.
 tests:
@@ -144,12 +144,12 @@ version: '0.0.0'
 The change log is available through the [releases on GitHub][].
 
 [Semantic Versioning]: http://semver.org/spec/v2.0.0.html
-[releases on GitHub]: https://github.com/{{ github-username }}/{{ name }}/releases
+[releases on GitHub]: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{ name }}/releases
 
 {-# START_FILE LICENSE.md #-}
 [The MIT License (MIT)][]
 
-Copyright (c) {{ year }} {{ author-name }}
+Copyright (c) {{year}}{{^year}}2016{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -219,7 +219,7 @@ stack haddock
 
 Thanks again, and happy hacking!
 
-[{{ name }}]: https://github.com/{{ github-username }}/{{ name }}
+[{{ name }}]: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{ name }}
 
 {-# START_FILE Setup.hs #-}
 -- This script is used to build and install your package. Typically you don't

--- a/hspec.hsfiles
+++ b/hspec.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 -- extra-source-files:
@@ -88,7 +88,7 @@ main :: IO ()
 main = interact strip
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 

--- a/new-template.hsfiles
+++ b/new-template.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 -- extra-source-files:
@@ -66,7 +66,7 @@ main :: IO ()
 main = someFunc
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 

--- a/quickcheck-test-framework.hsfiles
+++ b/quickcheck-test-framework.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 -- extra-source-files:
@@ -87,7 +87,7 @@ main :: IO ()
 main = someFunc
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 

--- a/rubik.hsfiles
+++ b/rubik.hsfiles
@@ -8,7 +8,7 @@ license:             ISC
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Development{{/category}}
 build-type:          Simple
 -- extra-source-files:
@@ -105,7 +105,7 @@ main :: IO ()
 main = someFunc
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/scotty-hspec-wai.hsfiles
+++ b/scotty-hspec-wai.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 -- extra-source-files:
@@ -117,7 +117,7 @@ main :: IO ()
 main = runApp
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 

--- a/servant-docker.hsfiles
+++ b/servant-docker.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 -- extra-source-files:
@@ -103,7 +103,7 @@ main :: IO ()
 main = startApp
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 

--- a/servant.hsfiles
+++ b/servant.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 -- extra-source-files:
@@ -103,7 +103,7 @@ main :: IO ()
 main = startApp
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 

--- a/simple-hpack.hsfiles
+++ b/simple-hpack.hsfiles
@@ -45,7 +45,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/simple-hpack.hsfiles
+++ b/simple-hpack.hsfiles
@@ -7,7 +7,7 @@ homepage:            http://github.com/{{github-username}}{{^github-username}}gi
 license:             BSD3
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 
 dependencies:
@@ -30,7 +30,7 @@ main = do
   putStrLn "hello world"
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 
@@ -45,7 +45,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}} nor the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/simple.hsfiles
+++ b/simple.hsfiles
@@ -46,7 +46,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/simple.hsfiles
+++ b/simple.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 cabal-version:       >=1.10
@@ -31,7 +31,7 @@ main = do
   putStrLn "hello world"
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 
@@ -46,7 +46,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}} nor the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/tasty-discover.hsfiles
+++ b/tasty-discover.hsfiles
@@ -77,7 +77,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/tasty-discover.hsfiles
+++ b/tasty-discover.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 cabal-version:       >=1.10
@@ -62,7 +62,7 @@ flags: {}
 extra-package-dbs: []
 
 {-# START_FILE LICENSE #-}
-Copyright {{author-name}} (c) 2016
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 
@@ -77,7 +77,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}} nor the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/tasty-travis.hsfiles
+++ b/tasty-travis.hsfiles
@@ -8,7 +8,7 @@ license:             ISC
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}TODO:<example@example.com>{{/author-email}}
-copyright:           © {{year}}{{^}}2016{{/year}} {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
+copyright:           © {{year}}{{^year}}2016{{/year}} {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
 homepage:            http://github.com/{{github-username}}{{^github-username}}TODO:<githubuser>{{/github-username}}/{{name}}
 bug-reports:         http://github.com/{{github-username}}{{^github-username}}TODO:<githubuser>{{/github-username}}/{{name}}/issues
 
@@ -167,7 +167,7 @@ main :: IO ()
 main = defaultMain [bench "inc 41" (whnf inc (41 :: Int))]
 
 {-# START_FILE LICENSE #-}
-Copyright (c) {{year}}{{^}}2016{{/year}}, {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
+Copyright (c) {{year}}{{^year}}2016{{/year}}, {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/tasty-travis.hsfiles
+++ b/tasty-travis.hsfiles
@@ -238,7 +238,7 @@ Change log
 The change log is available [on GitHub][2].
 
 [1]: http://semver.org/spec/v2.0.0.html
-[2]: https://github.com/{{ github-username }}/{{ name }}/releases
+[2]: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{ name }}/releases
 
 ## v0.1.0.0
 
@@ -343,4 +343,3 @@ of your project but using `CamelCase`. Don't forget to change this name in all
 places where it is referenced (executable(s), test(s) and benchmark(s)).
 
 Thanks again, and happy hacking!
-

--- a/tasty-travis.hsfiles
+++ b/tasty-travis.hsfiles
@@ -8,7 +8,7 @@ license:             ISC
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}TODO:<example@example.com>{{/author-email}}
-copyright:           © 2016 {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
+copyright:           © {{year}}{{^}}2016{{/year}} {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
 homepage:            http://github.com/{{github-username}}{{^github-username}}TODO:<githubuser>{{/github-username}}/{{name}}
 bug-reports:         http://github.com/{{github-username}}{{^github-username}}TODO:<githubuser>{{/github-username}}/{{name}}/issues
 
@@ -167,7 +167,7 @@ main :: IO ()
 main = defaultMain [bench "inc 41" (whnf inc (41 :: Int))]
 
 {-# START_FILE LICENSE #-}
-Copyright (c) 2016, {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
+Copyright (c) {{year}}{{^}}2016{{/year}}, {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/unicode-syntax-exe.hsfiles
+++ b/unicode-syntax-exe.hsfiles
@@ -47,7 +47,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/unicode-syntax-exe.hsfiles
+++ b/unicode-syntax-exe.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENCE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 cabal-version:       >=1.10
@@ -32,7 +32,7 @@ main = do
   putStrLn "ᚣ"
 
 {-# START_FILE LICENCE #-}
-Copyright {{author-name}} © {{year}}
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} © {{year}}
 
 All rights reserved.
 
@@ -47,7 +47,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}} nor the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/unicode-syntax-lib.hsfiles
+++ b/unicode-syntax-lib.hsfiles
@@ -52,7 +52,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 

--- a/unicode-syntax-lib.hsfiles
+++ b/unicode-syntax-lib.hsfiles
@@ -8,7 +8,7 @@ license:             BSD3
 license-file:        LICENCE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}2016 Author Here{{/copyright}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2016{{/year}} {{authorName}}{{^authorName}}Author name here{{/authorName}}{{/copyright}}
 category:            {{category}}{{^category}}Data{{/category}}
 build-type:          Simple
 cabal-version:       >=1.10
@@ -21,7 +21,7 @@ library
   exposed-modules:     Library
   build-depends:       base
                      , base-unicode-symbols
-                     
+
 {-# START_FILE source/Library.hs #-}
 module Library where
 
@@ -37,7 +37,7 @@ data 𝕋 α β
 ϝ _ _ g (ℚ a b) = g a b
 
 {-# START_FILE LICENCE #-}
-Copyright {{author-name}} © {{year}}
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} © {{year}}{{^year}}2016{{/year}}
 
 All rights reserved.
 
@@ -52,7 +52,7 @@ modification, are permitted provided that the following conditions are met:
       disclaimer in the documentation and/or other materials provided
       with the distribution.
 
-    * Neither the name of {{author-name}} nor the names of other
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} the names of other
       contributors may be used to endorse or promote products derived
       from this software without specific prior written permission.
 


### PR DESCRIPTION
Hi,

So I've gone through and cleaned up a bit, making the following changes:

- Templates now use the `year` tag which is provided by stack. In the case that someone is using an older version of stack where this hasn't been implemented, it defaults to 2016.
- Parameters (with the exception of `name`) *should* have default values (unless I've missed one).

#28 can *probably* be closed now.