### PR TITLE
Use https for GitHub

### DIFF
--- a/chrisdone.hsfiles
+++ b/chrisdone.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/franklinchen.hsfiles
+++ b/franklinchen.hsfiles
@@ -10,7 +10,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            TODO Initial project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/ghcjs-old-base.hsfiles
+++ b/ghcjs-old-base.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/ghcjs.hsfiles
+++ b/ghcjs.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/hakyll-template.hsfiles
+++ b/hakyll-template.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Hakyll project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/hspec.hsfiles
+++ b/hspec.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack, using hspec and quickcheck
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/new-template.hsfiles
+++ b/new-template.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/quickcheck-test-framework.hsfiles
+++ b/quickcheck-test-framework.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack, using test-framework with QuickCheck
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/rubik.hsfiles
+++ b/rubik.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
 license:             ISC
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/scotty-hspec-wai.hsfiles
+++ b/scotty-hspec-wai.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/servant-docker.hsfiles
+++ b/servant-docker.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/servant.hsfiles
+++ b/servant.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/simple-hpack.hsfiles
+++ b/simple-hpack.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Simple project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}

--- a/simple-library.hsfiles
+++ b/simple-library.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Initial project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/simple.hsfiles
+++ b/simple.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            Simple project template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/tasty-discover.hsfiles
+++ b/tasty-discover.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            tasty-discover based template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/tasty-travis.hsfiles
+++ b/tasty-travis.hsfiles
@@ -9,8 +9,8 @@ license-file:        LICENSE
 author:              {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
 maintainer:          {{author-email}}{{^author-email}}TODO:<example@example.com>{{/author-email}}
 copyright:           © {{year}}{{^year}}2016{{/year}} {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
-homepage:            http://github.com/{{github-username}}{{^github-username}}TODO:<githubuser>{{/github-username}}/{{name}}
-bug-reports:         http://github.com/{{github-username}}{{^github-username}}TODO:<githubuser>{{/github-username}}/{{name}}/issues
+homepage:            https://github.com/{{github-username}}{{^github-username}}TODO:<githubuser>{{/github-username}}/{{name}}
+bug-reports:         https://github.com/{{github-username}}{{^github-username}}TODO:<githubuser>{{/github-username}}/{{name}}/issues
 
 category:            Test
 build-type:          Simple

--- a/unicode-syntax-exe.hsfiles
+++ b/unicode-syntax-exe.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            UnicodeSyntax executable template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENCE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}

--- a/unicode-syntax-lib.hsfiles
+++ b/unicode-syntax-lib.hsfiles
@@ -3,7 +3,7 @@ name:                {{name}}
 version:             0.1.0.0
 synopsis:            UnicodeSyntax library template from stack
 description:         Please see README.md
-homepage:            http://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 license-file:        LICENCE
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}


### PR DESCRIPTION
I couldn't figure out why http is used for GitHub URL.
Since http is redirected to https and it's securer, I prefer https for GitHub URL's protocol.