### PR TITLE
Patch yesod templates so they don't require CSRF

### DIFF
--- a/yesod-minimal.hsfiles
+++ b/yesod-minimal.hsfiles
@@ -166,7 +166,6 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody encoded
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
             
             statusIs 200
 
@@ -183,7 +182,6 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody $ encode body
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
             statusIs 400
 
 

--- a/yesod-mongo.hsfiles
+++ b/yesod-mongo.hsfiles
@@ -9257,7 +9257,6 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody encoded
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
             
             statusIs 200
 
@@ -9274,7 +9273,6 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody $ encode body
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
             statusIs 400
 
 

--- a/yesod-mysql.hsfiles
+++ b/yesod-mysql.hsfiles
@@ -9289,7 +9289,6 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody encoded
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
             
             statusIs 200
 
@@ -9306,7 +9305,6 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody $ encode body
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
             statusIs 400
 
 

--- a/yesod-postgres-fay.hsfiles
+++ b/yesod-postgres-fay.hsfiles
@@ -9395,7 +9395,6 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody encoded
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
             
             statusIs 200
 
@@ -9412,7 +9411,6 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody $ encode body
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
             statusIs 400
 
 

--- a/yesod-postgres.hsfiles
+++ b/yesod-postgres.hsfiles
@@ -9277,7 +9277,6 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody encoded
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
             
             statusIs 200
 
@@ -9294,7 +9293,6 @@ spec = withApp $ do
                 setUrl CommentR
                 setRequestBody $ encode body
                 addRequestHeader ("Content-Type", "application/json")
-                addTokenFromCookie
             statusIs 400
 
 


### PR DESCRIPTION
The `Handler.Comment` specs fail, because of a call to `addTokenFromCookie`,
but no `defaultCsrfMiddleware` on `Foundation.hs` [1]

This removes all calls to `addTokenFromCookie` from the yesod templates'
tests.

This closes #71.

[1] - https://github.com/commercialhaskell/stack-templates/blob/master/yesod-postgres.hsfiles#L289

Also could be fixed with:

```
-    yesodMiddleware = defaultYesodMiddleware
+    yesodMiddleware = defaultYesodMiddleware . defaultCsrfMiddleware
```