### PR TITLE
Remove custom stack.yaml and allow tests

### DIFF
--- a/spock.hsfiles
+++ b/spock.hsfiles
@@ -22,21 +22,6 @@ executable {{name}}
                      , mtl
                      , text
 
-{-# START_FILE stack.yaml #-}
-resolver: lts-6.16
-packages:
-- '.'
-- location:
-    git: "https://github.com/agrafix/Spock.git"
-    commit: "HEAD"
-  subdirs:
-    - Spock
-    - Spock-core
-    - reroute
-extra-deps: []
-flags: {}
-extra-package-dbs: []
-
 {-# START_FILE Setup.hs #-}
 import Distribution.Simple
 main = defaultMain

--- a/test-templates.hs
+++ b/test-templates.hs
@@ -39,7 +39,6 @@ excluded =
   "ghcjs" : -- ghcjs takes too long to setup
   "quickcheck-test-framework" : -- test-suite fails (probably intentionally)
   "simple-hpack" : -- stack init fails on missing cabal file (fixed in stack on master)
-  "spock" : -- contains a stack file, makes `stack new` choke
   "tasty-discover" : -- contains a stack file, makes `stack new` choke
   "yesod-mongo" : -- needs a running db instance
   "yesod-mysql" : -- needs a running db instance


### PR DESCRIPTION
Now that LTS-7.1 is out we no longer need a custom stack.yaml. Also we can enable spock to be built in the test file.