### PR TITLE
Remove duplicate -Wall flag

### DIFF
--- a/tasty-travis.hsfiles
+++ b/tasty-travis.hsfiles
@@ -34,7 +34,7 @@ library
 
 executable {{ name }}-exe
   default-language:  Haskell2010
-  ghc-options:       -Wall -Werror -O2 -Wall -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:       -Wall -Werror -O2 -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:    src-exe
   main-is:           Main.hs
   build-depends:     base >= 4.8 && < 5
@@ -43,7 +43,7 @@ executable {{ name }}-exe
 test-suite {{ name }}-test
   type:              exitcode-stdio-1.0
   default-language:  Haskell2010
-  ghc-options:       -Wall -Werror -O2 -Wall -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:       -Wall -Werror -O2 -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:    src-test
   main-is:           Main.hs
   build-depends:     base >= 4.8 && < 5
@@ -55,7 +55,7 @@ test-suite {{ name }}-test
 test-suite {{ name }}-doctest
   type:              exitcode-stdio-1.0
   default-language:  Haskell2010
-  ghc-options:       -Wall -Werror -O2 -Wall -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:       -Wall -Werror -O2 -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:    src-doctest
   main-is:           Main.hs
   build-depends:     base >= 4.8 && < 5
@@ -67,7 +67,7 @@ test-suite {{ name }}-doctest
 benchmark {{ name }}-benchmark
   type:              exitcode-stdio-1.0
   default-language:  Haskell2010
-  ghc-options:       -Wall -Werror -O2 -Wall -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:       -Wall -Werror -O2 -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:    src-benchmark
   main-is:           Main.hs
   build-depends:     base >= 4.8 && < 5


### PR DESCRIPTION
The `tasty-travis` template got into a state where it had 2 `-Wall` flags for each executable (exec, benchmark, test suites).