### PR TITLE
Discourage uninformative boilerplate

### DIFF
--- a/chrisdone.hsfiles
+++ b/chrisdone.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/franklinchen.hsfiles
+++ b/franklinchen.hsfiles
@@ -8,7 +8,7 @@ TODO Description.
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            TODO Initial project template from stack
+-- synopsis:            TODO Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
 license:             BSD3

--- a/ghcjs-old-base.hsfiles
+++ b/ghcjs-old-base.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/ghcjs.hsfiles
+++ b/ghcjs.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/hakyll-template.hsfiles
+++ b/hakyll-template.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Hakyll project template from stack
+-- synopsis:            Hakyll project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/haskeleton.hsfiles
+++ b/haskeleton.hsfiles
@@ -5,7 +5,7 @@
 
 name:           {{ name }}
 version:        0.0.0
-synopsis:       A new Haskeleton package.
+-- synopsis:       A new Haskeleton package.
 description:    {{ name }} is a new Haskeleton package.
 category:       Other
 homepage:       https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{ name }}#readme
@@ -115,7 +115,7 @@ library:
 license: MIT
 maintainer: {{author-name}}{{^author-name}}Author name here{{/author-name}}
 name: {{ name }}
-synopsis: A new Haskeleton package.
+-- synopsis: A new Haskeleton package.
 tests:
   {{ name }}-test-suite:
     dependencies:

--- a/hspec.hsfiles
+++ b/hspec.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack, using hspec and quickcheck
+-- synopsis:            Initial project template from stack, using hspec and quickcheck
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/new-template.hsfiles
+++ b/new-template.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/protolude.hsfiles
+++ b/protolude.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/quickcheck-test-framework.hsfiles
+++ b/quickcheck-test-framework.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack, using test-framework with QuickCheck
+-- synopsis:            Initial project template from stack, using test-framework with QuickCheck
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/readme-lhs.hsfiles
+++ b/readme-lhs.hsfiles
@@ -46,7 +46,7 @@ filewatcher '**/*.{lhs,hs,cabal}' 'stack install && echo "built" && readme | pan
 {-# START_FILE {{name}}.cabal #-}
 name:                  {{name}}
 version:               0.1.0.0
-synopsis:              TODO Initial project template from stack
+-- synopsis:              TODO Initial project template from stack
 description:           readme.lhs
 homepage:              https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
 license:               BSD3

--- a/rubik.hsfiles
+++ b/rubik.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
 license:             ISC

--- a/scotty-hspec-wai.hsfiles
+++ b/scotty-hspec-wai.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/servant-docker.hsfiles
+++ b/servant-docker.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/servant.hsfiles
+++ b/servant.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/simple-hpack.hsfiles
+++ b/simple-hpack.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE package.yaml #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Simple project template from stack
+-- synopsis:            Simple project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/simple-library.hsfiles
+++ b/simple-library.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/simple.hsfiles
+++ b/simple.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Simple project template from stack
+-- synopsis:            Simple project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/spock.hsfiles
+++ b/spock.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/tasty-discover.hsfiles
+++ b/tasty-discover.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            tasty-discover based template from stack
+-- synopsis:            tasty-discover based template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/tasty-travis.hsfiles
+++ b/tasty-travis.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{ name }}.cabal #-}
 name:                {{ name }}
 version:             0.1.0.0
-synopsis:            Initial project template from stack
+-- synopsis:            Initial project template from stack
 description:         Please see README.md
 
 license:             ISC

--- a/unicode-syntax-exe.hsfiles
+++ b/unicode-syntax-exe.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            UnicodeSyntax executable template from stack
+-- synopsis:            UnicodeSyntax executable template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3

--- a/unicode-syntax-lib.hsfiles
+++ b/unicode-syntax-lib.hsfiles
@@ -1,7 +1,7 @@
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
-synopsis:            UnicodeSyntax library template from stack
+-- synopsis:            UnicodeSyntax library template from stack
 description:         Please see README.md
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3


### PR DESCRIPTION
**TL;DR:** `synopsis: Initial project template from stack` is worse than than no synopsis at all.

Highly Personal and Idiosyncratic Rambling: The only descriptive information about a package (other than its name)  `What's New` rss feed or at http://hackage.haskell.org/packages/ is the contents of the `synopsis` field in the cabal file.  I've noticed that an increasing number of packages seem to be summarized as `Initial project template from stack` (indeed, in between the time I started trying to figure out where to file this issue and the time I started writing this paragraph, at least one more has appeared).  So I checked:

```
% cabal list | fgrep Synopsis: | sort | uniq -c | sort -nr | head
  18     Synopsis: Initial project template from stack
  17     Synopsis: None
  11     Synopsis: Replaces/Enhances Text.Regex
   8     Synopsis: Conduits for tokenizing streams.
   5     Synopsis: A networked event handling framework for hooking into other
   5     Synopsis: (deprecated)
   4     Synopsis: Parse Google Protocol Buffer specifications
   4     Synopsis: Monadic parser combinators
   4     Synopsis: Make better services and clients.
   3     Synopsis: arbitrary precision real interval arithmetic
```

While 18 packages hardly represents an epidemic, stack template boilerplate has exceeded both the plethora of `Text.Regex` replacements and packages lacking synopses.  I hope that it's uncontroversial  to say that a meaningful synopsis is better than both nothing and the boilerplate.  I'm of the opinion that the boilerplate doesn't provide the information the `synopsis` field is intended to convey ("A very short description of the package, for use in a table of packages. This is your headline, so keep it short (one line) but as informative as possible. Save space by not including the package name or saying it’s written in Haskell.")  By that measure, the boilerplate is just another way to provide no synopsis, so it's no better than nothing.  Personally, I'd say it's worse than nothing, as I tend to be of the opinion that it's better to have as few ways to say nothing as possible, it hides the omission of the synopsis, and dilutes the utility of the synopsis field (anyone searching through synopses for packages related to "templates", "stack" or "initial" things will get these packages regardless of their relevance to the query).

The only uses for the boilerplate that I can think of are anthropology and publicity.  In the former case, I'd imagine a comment in the generated file (or at worst the `description` if it needs to be a formal component of the cabal syntax as it stands) or the README would do.  The latter case is me being cynical, and I can understand someone disagreeing with my feeling that it were inappropriate.  I may be missing other structural advantages.

So I think it would be better if the path of least resistance to generating and uploading packages discouraged (or didn't encourage) the addition of (in my opinion) useless-to-worse-than-useless metadata to the shared repository harder enough to keep it from happening as frequently.  I feel similarly but less strongly about `description`s that are just instructions to read the README somewhere else, especially when no such README exists.
