### PR TITLE
fixing double export

### DIFF
--- a/yesod-sqlite.hsfiles
+++ b/yesod-sqlite.hsfiles
@@ -10511,7 +10511,7 @@ module TestImport
     ) where
 
 import Application           (makeFoundation, makeLogWare)
-import ClassyPrelude         as X hiding (delete, deleteBy)
+import ClassyPrelude         as X hiding (delete, deleteBy, Handler)
 import Database.Persist      as X hiding (get)
 import Database.Persist.Sql  (SqlPersistM, SqlBackend, runSqlPersistMPool, rawExecute, rawSql, unSingle, connEscapeName)
 import Foundation            as X


### PR DESCRIPTION
 Conflicting exports for ‘Handler’:
       ‘module X’ exports ‘X.Handler’
         imported from ‘ClassyPrelude’ at test/TestImport.hs:7:1-59
         (and originally defined in ‘safe-exceptions-0.1.4.0:Control.Exception.Safe’)
       ‘module X’ exports ‘X.Handler’
         imported from ‘Foundation’ at test/TestImport.hs:10:1-33