### PR TITLE
[simple-hpack] Use correct format to comment out keys in package.yaml

### DIFF
--- a/simple-hpack.hsfiles
+++ b/simple-hpack.hsfiles
@@ -1,8 +1,8 @@
 {-# START_FILE package.yaml #-}
 name:                {{name}}
 version:             0.1.0.0
--- synopsis:
--- description:
+#synopsis:
+#description:
 homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
 license:             BSD3
 author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}


### PR DESCRIPTION
This prevents the following warnings when building with Stack:

```
WARNING: Ignoring unknown field "-- description" in package description
WARNING: Ignoring unknown field "-- synopsis" in package description
```