### PR TITLE
Add Gitlab template

### DIFF
--- a/gitlab.hsfiles
+++ b/gitlab.hsfiles
@@ -1,0 +1,140 @@
+{-# START_FILE {{name}}.cabal #-}
+name:                {{name}}
+version:             0.1.0.0
+-- synopsis:            Enter synopsis here
+-- description:         Enter description here
+homepage:            https://gitlab.com/{{gitlab-username}}{{^gitlab-username}}gitlabuser{{/gitlab-username}}/{{name}}
+license:             BSD3
+license-file:        LICENSE
+author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
+maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
+copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2017{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}{{/copyright}}
+category:            {{category}}{{^category}}Web{{/category}}
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+
+library
+  hs-source-dirs:      src
+  exposed-modules:     Lib
+  build-depends:       base >= 4.7 && < 5
+  default-language:    Haskell2010
+
+executable {{name}}
+  hs-source-dirs:      app
+  main-is:             Main.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , {{name}}
+  default-language:    Haskell2010
+
+test-suite {{name}}-test
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      test
+  main-is:             Spec.hs
+  build-depends:       base
+                     , {{name}}
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  default-language:    Haskell2010
+
+source-repository head
+  type:     git
+  location: https://gitlab.com/{{gitlab-username}}{{^gitlab-username}}gitlabuser{{/gitlab-username}}/{{name}}.git
+
+{-# START_FILE Setup.hs #-}
+import Distribution.Simple
+main = defaultMain
+
+{-# START_FILE test/Spec.hs #-}
+-- | vim: tabstop=8:expandtab:softtabstop=4:shiftwidth=4:shiftround:
+--
+-- Module      : Spec
+-- Copyright   : {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2017{{/year}}
+-- License     : BSD3
+-- Maintainer  : {{author-email}}{{^author-email}}example@example.com{{/author-email}}
+-- Stability   : provisional
+-- Portability : portable
+
+main :: IO ()
+main = putStrLn "Test suite not yet implemented"
+
+{-# START_FILE src/Lib.hs #-}
+-- | vim: tabstop=8:expandtab:softtabstop=4:shiftwidth=4:shiftround:
+--
+-- Module      : Lib
+-- Copyright   : {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2017{{/year}}
+-- License     : BSD3
+-- Maintainer  : {{author-email}}{{^author-email}}example@example.com{{/author-email}}
+-- Stability   : provisional
+-- Portability : portable
+
+module Lib
+    ( sayHello
+    ) where
+
+sayHello :: IO ()
+sayHello = putStrLn "Hello, World!"
+
+{-# START_FILE app/Main.hs #-}
+-- | vim: tabstop=8:expandtab:softtabstop=4:shiftwidth=4:shiftround:
+--
+-- Module      : Main
+-- Copyright   : {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2017{{/year}}
+-- License     : BSD3
+-- Maintainer  : {{author-email}}{{^author-email}}example@example.com{{/author-email}}
+-- Stability   : provisional
+-- Portability : portable
+
+module Main where
+
+import Lib
+
+main :: IO ()
+main = sayHello
+
+{-# START_FILE README.md #-}
+# {{name}}
+
+## Enter synopsis here
+
+Enter description here
+
+* Copyright: {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2017{{/year}}
+* License: BSD3
+* Maintainer: {{author-email}}{{^author-email}}example@example.com{{/author-email}}
+
+{-# START_FILE LICENSE #-}
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2017{{/year}}
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of {{author-name}}{{^author-name}}Author name here{{/author-name}} nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+{-# START_FILE .gitignore #-}
+.stack-work/
+

--- a/template-info.yaml
+++ b/template-info.yaml
@@ -13,6 +13,9 @@ ghcjs:
 ghcjs-old-base:
   description:
 
+gitlab:
+  description: a template for Gitlab
+
 hakyll-template:
   description: a static website compiler library
 


### PR DESCRIPTION
Hello,

I'd like to add a simple template for projects hosted on Gitlab.  I've added a couple extras like source file headers and vim modeline support based on information from the Haskell wiki.