### PR TITLE
servant-docker

### DIFF
--- a/servant-docker.hsfiles
+++ b/servant-docker.hsfiles
@@ -157,12 +157,12 @@ services:
 {-# START_FILE Dockerfile #-}
 FROM haskell:8
 
-RUN export PATH=$(stack path --local-bin):$PATH
-
 RUN mkdir -p /app/user
 WORKDIR /app/user
 COPY stack.yaml .
 COPY *.cabal ./
+
+RUN export PATH=$(stack path --local-bin):$PATH
 RUN stack build --dependencies-only
 
 COPY . /app/user


### PR DESCRIPTION
Run `stack path` after coping `stack.yaml`.  This ensures that the
resolver from stack.yaml is used.