### PR TITLE
servant-docker: use a single COPY

### DIFF
--- a/servant-docker.hsfiles
+++ b/servant-docker.hsfiles
@@ -159,8 +159,7 @@ FROM haskell:8
 
 RUN mkdir -p /app/user
 WORKDIR /app/user
-COPY stack.yaml .
-COPY *.cabal ./
+COPY stack.yaml *.cabal ./
 
 RUN export PATH=$(stack path --local-bin):$PATH
 RUN stack build --dependencies-only


### PR DESCRIPTION
This way there is there one less intermediate image.