### PR TITLE
Improve metadata for hackage

### DIFF
--- a/haskeleton.hsfiles
+++ b/haskeleton.hsfiles
@@ -8,8 +8,8 @@ github: "{{github-username}}{{^github-username}}githubuser{{/github-username}}/{
 license: MIT
 author: "{{author-name}}{{^author-name}}Author name here{{/author-name}}"
 maintainer: "{{author-name}}{{^author-name}}Author name here{{/author-name}}"
-synopsis: A new Haskeleton package.
-description: {{ name }} is a new Haskeleton package.
+# synopsis: A new Haskeleton package.
+# description: {{ name }} is a new Haskeleton package.
 # category: Other
 
 extra-source-files:

--- a/new-template.hsfiles
+++ b/new-template.hsfiles
@@ -12,7 +12,7 @@ extra-source-files:
 - ChangeLog.md
 
 # Metadata used when publishing your package
-synopsis:            Short description of your package
+# synopsis:            Short description of your package
 # category:            {{category}}{{^category}}Web{{/category}}
 
 # To avoid duplicated efforts in documentation and dealing with the


### PR DESCRIPTION
"Short description of your package" isn't really any more helpful than "Initial project template from stack".  Same concern as in https://github.com/commercialhaskell/stack-templates/pull/68