### PR TITLE
Bump up version bound for protolude

### DIFF
--- a/protolude.hsfiles
+++ b/protolude.hsfiles
@@ -20,7 +20,7 @@ library
   exposed-modules:     Lib
   other-modules:       Lib.Prelude
   build-depends:       base >= 4.7 && < 5
-                     , protolude >= 0.1.6 && < 0.2
+                     , protolude >= 0.1.6 && <= 0.2
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, NoImplicitPrelude
 
@@ -30,7 +30,7 @@ executable {{name}}-exe
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
                      , {{name}}
-                     , protolude >= 0.1.6 && < 0.2
+                     , protolude >= 0.1.6 && <= 0.2
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, NoImplicitPrelude
 
@@ -40,7 +40,7 @@ test-suite {{name}}-test
   main-is:             Spec.hs
   build-depends:       base
                      , {{name}}
-                     , protolude >= 0.1.6 && < 0.2
+                     , protolude >= 0.1.6 && <= 0.2
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, NoImplicitPrelude


### PR DESCRIPTION
In lts 10.x, protolude is version 0.2.