### PR TITLE
Removes the project's cabal file from the gitignore

### DIFF
--- a/new-template.hsfiles
+++ b/new-template.hsfiles
@@ -114,5 +114,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 {-# START_FILE .gitignore #-}
 .stack-work/
-{{name}}.cabal
 *~


### PR DESCRIPTION
Seeing as this is the new default template, I don't really think that we should ignore the cabal file by default. 

While I almost always use hpack now, the cabal file is still the official package format, and so it seems worthwhile to keep around.