### PR TITLE
fix hspec.hsfiles to use package.yaml

### DIFF
--- a/hspec.hsfiles
+++ b/hspec.hsfiles
@@ -1,47 +1,55 @@
-{-# START_FILE {{name}}.cabal #-}
+{-# START_FILE package.yaml #-}
 name:                {{name}}
 version:             0.1.0.0
--- synopsis:
--- description:
-homepage:            https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme
+github:              "{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}"
 license:             BSD3
-license-file:        LICENSE
-author:              {{author-name}}{{^author-name}}Author name here{{/author-name}}
-maintainer:          {{author-email}}{{^author-email}}example@example.com{{/author-email}}
-copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2018{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}{{/copyright}}
-category:            {{category}}{{^category}}Web{{/category}}
-build-type:          Simple
-extra-source-files:  README.md
-cabal-version:       >=1.10
+author:              "{{author-name}}{{^author-name}}Author name here{{/author-name}}"
+maintainer:          "{{author-email}}{{^author-email}}example@example.com{{/author-email}}"
+copyright:           "{{copyright}}{{^copyright}}{{year}}{{^year}}2018{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}{{/copyright}}"
 
-library
-  hs-source-dirs:      src
-  exposed-modules:     Data.String.Strip
-  build-depends:       base >= 4.7 && < 5
-  default-language:    Haskell2010
+extra-source-files:
+- README.md
+- ChangeLog.md
 
-executable {{name}}
-  hs-source-dirs:      app
-  main-is:             Main.hs
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-  build-depends:       base
-                     , {{name}}
-  default-language:    Haskell2010
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            {{category}}{{^category}}Web{{/category}}
 
-test-suite {{name}}-test
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
-  main-is:             Spec.hs
-  build-depends:       base
-                     , {{name}}
-                     , hspec
-                     , QuickCheck
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-  default-language:    Haskell2010
+# To avoid duplicated efforts in documentation and dealing with the
+# complications of embedding Haddock markup inside cabal files, it is
+# common to point users to the README.md file.
+description:         Please see the README on GitHub at <https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}#readme>
 
-source-repository head
-  type:     git
-  location: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
+library:
+  source-dirs: src
+  exposed-modules:
+  - Data.String.Strip
+  dependencies:
+  - base >=4.7 && <5
+executables:
+  {{name}}:
+    main: Main.hs
+    source-dirs: app
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - base
+    - {{name}}
+tests:
+  {{name}}-test:
+    main: Spec.hs
+    source-dirs: test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - base
+    - {{name}}
+    - hspec
+    - QuickCheck
 
 {-# START_FILE Setup.hs #-}
 import Distribution.Simple
@@ -122,3 +130,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # {{name}}
 
 add description of {{name}} here
+
+{-# START_FILE .gitignore #-}
+.stack-work/
+{{name}}.cabal
+*~


### PR DESCRIPTION
fix "package name is not valid" failure when running `stack new foo hspec`