### PR TITLE
Only fetch tables of type 'BASE TABLE' in tests

### DIFF
--- a/yesod-postgres.hsfiles
+++ b/yesod-postgres.hsfiles
@@ -10691,7 +10691,8 @@ getTables = do
     tables <- rawSql [st|
         SELECT table_name
         FROM information_schema.tables
-        WHERE table_schema = 'public';
+        WHERE table_schema = 'public'
+        AND table_type = 'BASE TABLE';
     |] []
 
     return $ map unSingle tables


### PR DESCRIPTION
If a user enables the `pg_stat_statements` Postgres extension, they will be met with the following error when they try to run their tests:

```
uncaught exception: SqlError SqlError {sqlState = "42809", sqlExecStatus
= FatalError, sqlErrorMsg = "\"pg_stat_statements\" is not a table",
sqlErrorDetail = "", sqlErrorHint = ""}
```

For the purposes of wiping the test database before each test run, I believe the user is only interested in the tables of type `BASE TABLE`.