### PR TITLE
Adds `yesod-simple-rio` template

### DIFF
--- a/yesod-simple-rio.hsfiles
+++ b/yesod-simple-rio.hsfiles
@@ -1,0 +1,10350 @@
+{-# START_FILE .dir-locals.el #-}
+((haskell-mode . ((haskell-indent-spaces . 4)
+                  (haskell-process-use-ghci . t)))
+ (hamlet-mode . ((hamlet/basic-offset . 4)
+                 (haskell-process-use-ghci . t))))
+
+{-# START_FILE .gitignore #-}
+dist*
+static/tmp/
+static/combined/
+config/client_session_key.aes
+*.hi
+*.o
+*.sqlite3
+*.sqlite3-shm
+*.sqlite3-wal
+.hsenv*
+cabal-dev/
+.stack-work/
+.stack-work-devel/
+yesod-devel/
+.cabal-sandbox
+cabal.sandbox.config
+.DS_Store
+*.swp
+*.keter
+*~
+\#*
+{{name}}.cabal
+
+{-# START_FILE README.md #-}
+## Haskell Setup
+
+1. If you haven't already, [install Stack](https://haskell-lang.org/get-started)
+	* On POSIX systems, this is usually `curl -sSL https://get.haskellstack.org/ | sh`
+2. Install the `yesod` command line tool: `stack install yesod-bin --install-ghc`
+3. Build libraries: `stack build`
+
+If you have trouble, refer to the [Yesod Quickstart guide](https://www.yesodweb.com/page/quickstart) for additional detail.
+
+## Development
+
+Start a development server with:
+
+```
+stack exec -- yesod devel
+```
+
+As your code changes, your site will be automatically recompiled and redeployed to localhost.
+
+## Tests
+
+```
+stack test --flag {{name}}:library-only --flag {{name}}:dev
+```
+
+(Because `yesod devel` passes the `library-only` and `dev` flags, matching those flags means you don't need to recompile between tests and development, and it disables optimization to speed up your test compile times).
+
+## Documentation
+
+* Read the [Yesod Book](https://www.yesodweb.com/book) online for free
+* Check [Stackage](http://stackage.org/) for documentation on the packages in your LTS Haskell version, or [search it using Hoogle](https://www.stackage.org/lts/hoogle?q=). Tip: Your LTS version is in your `stack.yaml` file.
+* For local documentation, use:
+	* `stack haddock --open` to generate Haddock documentation for your dependencies, and open that documentation in a browser
+	* `stack hoogle <function, module or type signature>` to generate a Hoogle database and search for your query
+* The [Yesod cookbook](https://github.com/yesodweb/yesod-cookbook) has sample code for various needs
+
+## Getting Help
+
+* Ask questions on [Stack Overflow, using the Yesod or Haskell tags](https://stackoverflow.com/questions/tagged/yesod+haskell)
+* Ask the [Yesod Google Group](https://groups.google.com/forum/#!forum/yesodweb)
+* There are several chatrooms you can ask for help:
+	* For IRC, try Freenode#yesod and Freenode#haskell
+	* [Functional Programming Slack](https://fpchat-invite.herokuapp.com/), in the #haskell, #haskell-beginners, or #yesod channels.
+
+{-# START_FILE app/DevelMain.hs #-}
+-- | Running your app inside GHCi.
+--
+-- This option provides significantly faster code reload compared to
+-- @yesod devel@. However, you do not get automatic code reload
+-- (which may be a benefit, depending on your perspective). To use this:
+--
+-- 1. Start up GHCi
+--
+-- $ stack ghci {{name}}:lib --no-load --work-dir .stack-work-devel
+--
+-- 2. Load this module
+--
+-- > :l app/DevelMain.hs
+--
+-- 3. Run @update@
+--
+-- > DevelMain.update
+--
+-- 4. Your app should now be running, you can connect at http://localhost:3000
+--
+-- 5. Make changes to your code
+--
+-- 6. After saving your changes, reload by running:
+--
+-- > :r
+-- > DevelMain.update
+--
+-- You can also call @DevelMain.shutdown@ to stop the app
+--
+-- There is more information about this approach,
+-- on the wiki: https://github.com/yesodweb/yesod/wiki/ghci
+--
+-- WARNING: GHCi does not notice changes made to your template files.
+-- If you change a template, you'll need to either exit GHCi and reload,
+-- or manually @touch@ another Haskell module.
+
+module DevelMain where
+
+import Prelude
+import Application (getApplicationRepl, shutdownApp)
+
+import Control.Monad ((>=>))
+import Control.Concurrent
+import Data.IORef
+import Foreign.Store
+import Network.Wai.Handler.Warp
+import GHC.Word
+
+-- | Start or restart the server.
+-- newStore is from foreign-store.
+-- A Store holds onto some data across ghci reloads
+update :: IO ()
+update = do
+    mtidStore <- lookupStore tidStoreNum
+    case mtidStore of
+      -- no server running
+      Nothing -> do
+          done <- storeAction doneStore newEmptyMVar
+          tid <- start done
+          _ <- storeAction (Store tidStoreNum) (newIORef tid)
+          return ()
+      -- server is already running
+      Just tidStore -> restartAppInNewThread tidStore
+  where
+    doneStore :: Store (MVar ())
+    doneStore = Store 0
+
+    -- shut the server down with killThread and wait for the done signal
+    restartAppInNewThread :: Store (IORef ThreadId) -> IO ()
+    restartAppInNewThread tidStore = modifyStoredIORef tidStore $ \tid -> do
+        killThread tid
+        withStore doneStore takeMVar
+        readStore doneStore >>= start
+
+
+    -- | Start the server in a separate thread.
+    start :: MVar () -- ^ Written to when the thread is killed.
+          -> IO ThreadId
+    start done = do
+        (port, site, app) <- getApplicationRepl
+        forkFinally
+            (runSettings (setPort port defaultSettings) app)
+            -- Note that this implies concurrency
+            -- between shutdownApp and the next app that is starting.
+            -- Normally this should be fine
+            (\_ -> putMVar done () >> shutdownApp site)
+
+-- | kill the server
+shutdown :: IO ()
+shutdown = do
+    mtidStore <- lookupStore tidStoreNum
+    case mtidStore of
+      -- no server running
+      Nothing -> putStrLn "no Yesod app running"
+      Just tidStore -> do
+          withStore tidStore $ readIORef >=> killThread
+          putStrLn "Yesod app is shutdown"
+
+tidStoreNum :: Word32
+tidStoreNum = 1
+
+modifyStoredIORef :: Store (IORef a) -> (a -> IO a) -> IO ()
+modifyStoredIORef store f = withStore store $ \ref -> do
+    v <- readIORef ref
+    f v >>= writeIORef ref
+
+{-# START_FILE app/devel.hs #-}
+{-# LANGUAGE PackageImports #-}
+import "{{name}}" Application (develMain)
+import Prelude (IO)
+
+main :: IO ()
+main = develMain
+
+{-# START_FILE app/main.hs #-}
+import Prelude     (IO)
+import Application (appMain)
+
+main :: IO ()
+main = appMain
+
+{-# START_FILE BASE64 config/favicon.ico #-}
+AAABAAIAEBAAAAEAIABoBAAAJgAAABAQAgABAAEAsAAAAI4EAAAoAAAAEAAAACAAAAABACAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAApl4sAAAAAAAAAAAAAAAAAUEpGyNpSjaIg2NO2ZBvWfqTc13/
+jW1X9YNhTMZrSTNkUTMfDwAAAAAAAAAAAAAAAAAAAAAAAAAANR0NClk6JmF+W0Txj2xV/41qVP+M
+aVP/jGlS/4xpUv+MaVL/i2dQ/3pVPdNeOiEzQRsBAgAAAAAAAAAAMBgHAlIxG1h5UDb/h15D9n5W
+PPZ4TzXmeVE303hQNtV4UDbVeFA11XdQNdV5UTfbbUUpx1UsEBgAAAAAAAAFADIVAwlULxY/f1M1
+4dOffryecFHMXTIVhAAAAAURAAAOEwAADxQAAA8TAAAPEAAADigEABFNJAkZTSQJCRAHAQdKIARt
+OxUAC1kvE3qQYEDfzJt5wXtOL9pQJAa0UScKjVInCo1SJwqNUSYJjVElCY1RJQmLUSUHslEjBGcu
+EgAuVSQC/00eAGAYAAAPXzAQuLGAXs6ygV/PYTESwkMXAFRGHgI3Rx4BPEceATxHHQE7RBsBMkwf
+AqlUIQHgQhoAaVUhAP9TIQDhSBwAI0EXAD5xQSHbzJp4wJRiQtBRIgKuRxsAb0kdAGpJHQBqSR0A
+e04fAJNJHQClVCEA/0YcAIRVIgD/VSIA7E0fADQyDQAyaToa1MqXdMLJl3bBc0Ii6UscAJFFGgBE
+RRoAQUIZAFlRIADpVSIA/1UiAP9JHwN9WicG/1QhAIMAAAAMVywPoaBtTNi6imnEsIBfya9+Xc1m
+OBm2UycIilgqDYVVKQ2DVigJ4FwqCf5cKgr/Qx8GUGAwEc08EwAPTSgQY4dXN+LPnXy9g1c54XtM
+LevJl3a/k2RE3WY5Gv9mNxn/Zjga/2c5G/9oOhz/Zzka/DQYBRFZLRA1JhAAJHhML9XJlnTCqXxe
+zXFHLPtxRyv/n3BR2MuZd7uFWjzmc0gt/nRKLv90Sy//dUww/21CJcIAAAAATCsURXRONdR+Vjr5
+j2ZL5oJbQfN+Vz3/flg//4NcQfePZkrogVk/8n5YP/6BW0H/gVtD/oBaQf9qQCRIJAgAAFAxHRt4
+VDzVjWpS/4lmT/6LZ1D/jGlS/4xpU/6MaVL/i2hS/otpUv6Na1T+jmtV/o9tV/98Vj2cYzoeBgAA
+AAAGAgAAZ0cyMIVkTtqae2f/mXpm/5l5Zf6Zemb+mXpm/5p6Zv+ae2f+mnxp/5p7Z/+HZE2qdE84
+FAAAAAAAAAAAAAAAAAAAAABrTDgfhWVQnp2Abf+njHv/pot6/6aMev+njHv/qI18/5t+avOHZU9y
+fFc/DgAAAAAAAAAAJhABAAAAAAAAAAAAyqmXADYdCQNoSDQjh2hUbpd6aJ+Zfmurl3pnlYZkTlpw
+TDYTX0IxAbNeMwAAAAAAsoFfAPgfAADwBwAA4AMAAOH/AADwAQAAsPwAAJh4AAAYOAAAkAAAALAA
+AADgAAAAwAEAAMABAADgAwAA8A8AAP4/AAAoAAAAEAAAACAAAAABAAEAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAA////AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+
+{-# START_FILE config/keter.yml #-}
+# After you've edited this file, remove the following line to allow
+# `yesod keter` to build your bundle.
+user-edited: false
+
+# A Keter app is composed of 1 or more stanzas. The main stanza will define our
+# web application. See the Keter documentation for more information on
+# available stanzas.
+stanzas:
+
+  # Your Yesod application.
+  - type: webapp
+
+    # Name of your executable. You are unlikely to need to change this.
+    # Note that all file paths are relative to the keter.yml file.
+    #
+    # The path given is for Stack projects. If you're still using cabal, change
+    # to
+    # exec: ../dist/build/{{name}}/{{name}}
+    exec: ../dist/bin/{{name}}
+
+    # Command line options passed to your application.
+    args: []
+
+    hosts:
+      # You can specify one or more hostnames for your application to respond
+      # to. The primary hostname will be used for generating your application
+      # root.
+      - www.{{name}}.com
+
+    # Enable to force Keter to redirect to https
+    # Can be added to any stanza
+    requires-secure: false
+
+  # Static files.
+  - type: static-files
+    hosts:
+      - static.{{name}}.com
+    root: ../static
+
+    # Uncomment to turn on directory listings.
+    # directory-listing: true
+
+  # Redirect plain domain name to www.
+  - type: redirect
+
+    hosts:
+      - {{name}}.com
+    actions:
+      - host: www.{{name}}.com
+        # secure: false
+        # port: 80
+
+    # Uncomment to switch to a non-permanent redirect.
+    # status: 303
+
+# Use the following to automatically copy your bundle upon creation via `yesod
+# keter`. Uses `scp` internally, so you can set it to a remote destination
+# copy-to: user@host:/opt/keter/incoming/
+
+# You can pass arguments to `scp` used above. This example limits bandwidth to
+# 1024 Kbit/s and uses port 2222 instead of the default 22
+# copy-to-args:
+#   - "-l 1024"
+#   - "-P 2222"
+
+# If you would like to have Keter automatically create a PostgreSQL database
+# and set appropriate environment variables for it to be discovered, uncomment
+# the following line.
+# plugins:
+#   postgres: true
+
+{-# START_FILE config/robots.txt #-}
+User-agent: *
+
+{-# START_FILE config/routes #-}
+-- By default this file is used by `parseRoutesFile` in Foundation.hs
+-- Syntax for this file here: https://www.yesodweb.com/book/routing-and-handlers
+
+/static StaticR Static appStatic
+
+/favicon.ico FaviconR GET
+/robots.txt RobotsR GET
+
+/ HomeR GET POST
+
+/comments CommentR POST
+
+{-# START_FILE config/settings.yml #-}
+# Values formatted like "_env:YESOD_ENV_VAR_NAME:default_value" can be overridden by the specified environment variable.
+# See https://github.com/yesodweb/yesod/wiki/Configuration#overriding-configuration-values-with-environment-variables
+
+static-dir:     "_env:YESOD_STATIC_DIR:static"
+host:           "_env:YESOD_HOST:*4" # any IPv4 host
+port:           "_env:YESOD_PORT:3000" # NB: The port `yesod devel` uses is distinct from this value. Set the `yesod devel` port from the command line.
+ip-from-header: "_env:YESOD_IP_FROM_HEADER:false"
+
+# Default behavior: determine the application root from the request headers.
+# Uncomment to set an explicit approot
+#approot:        "_env:YESOD_APPROOT:http://localhost:3000"
+
+# By default, `yesod devel` runs in development, and built executables use
+# production settings (see below). To override this, use the following:
+#
+# development: false
+
+# Optional values with the following production defaults.
+# In development, they default to the inverse.
+#
+# development: false
+# detailed-logging: false
+# should-log-all: false
+# reload-templates: false
+# mutable-static: false
+# skip-combining: false
+
+copyright: Insert copyright statement here
+#analytics: UA-YOURCODE
+
+{-# START_FILE config/test-settings.yml #-}
+{}
+
+{-# START_FILE package.yaml #-}
+name:    {{name}}
+version: "0.0.0"
+
+dependencies:
+
+# Due to a bug in GHC 8.0.1, we block its usage
+# See: https://ghc.haskell.org/trac/ghc/ticket/12130
+- base >=4.8.2.0 && <4.9 || >=4.9.1.0 && <5
+
+- rio >= 0.1.8.0
+- aeson >=0.6 && <1.5
+- http-types
+- persistent
+- yaml >=0.8 && <0.12
+- yesod-newsfeed
+
+- yesod >=1.6 && <1.7
+- yesod-core >=1.6 && <1.7
+- yesod-static >=1.6 && <1.7
+- yesod-form >=1.6 && <1.7
+- bytestring >=0.9 && <0.11
+- text >=0.11 && <2.0
+- template-haskell
+- shakespeare >=2.0 && <2.1
+- hjsmin >=0.1 && <0.3
+- monad-control >=0.3 && <1.1
+- wai-extra >=3.0 && <3.1
+- http-client-tls >=0.3 && <0.4
+- http-conduit >=2.3 && <2.4
+- directory >=1.1 && <1.4
+- warp >=3.0 && <3.3
+- data-default
+- conduit >=1.0 && <2.0
+- monad-logger >=0.3 && <0.4
+- fast-logger >=2.2 && <2.5
+- wai-logger >=2.2 && <2.4
+- file-embed
+- safe
+- unordered-containers
+- containers
+- vector
+- time
+- case-insensitive
+- wai
+- foreign-store
+
+# The library contains all of our application code. The executable
+# defined below is just a thin wrapper.
+library:
+  source-dirs: src
+  when:
+  - condition: (flag(dev)) || (flag(library-only))
+    then:
+      ghc-options:
+      - -Wall
+      - -fwarn-tabs
+      - -O0
+      cpp-options: -DDEVELOPMENT
+    else:
+      ghc-options:
+      - -Wall
+      - -fwarn-tabs
+      - -O2
+
+# Runnable executable for our application
+executables:
+  {{name}}:
+    main: main.hs
+    source-dirs: app
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - {{name}}
+    when:
+    - condition: flag(library-only)
+      buildable: false
+
+# Test suite
+tests:
+  {{name}}-test:
+    main: Spec.hs
+    source-dirs: test
+    ghc-options: -Wall
+    dependencies:
+    - {{name}}
+    - hspec >=2.0.0
+    - yesod-test
+
+# Define flags used by "yesod devel" to make compilation faster
+flags:
+  library-only:
+    description: Build for use with "yesod devel"
+    manual: false
+    default: false
+  dev:
+    description: Turn on development settings, like auto-reload templates.
+    manual: false
+    default: false
+
+{-# START_FILE src/Application.hs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+module Application
+    ( getApplicationDev
+    , appMain
+    , develMain
+    , makeFoundation
+    , makeLogWare
+    -- * for DevelMain
+    , getApplicationRepl
+    , shutdownApp
+    -- * for GHCI
+    , handler
+    ) where
+
+import Control.Monad.Logger                 (liftLoc)
+import Import
+import Language.Haskell.TH.Syntax           (qLocation)
+import Network.HTTP.Client.TLS              (getGlobalManager)
+import Network.Wai (Middleware)
+import Network.Wai.Handler.Warp             (Settings, defaultSettings,
+                                             defaultShouldDisplayException,
+                                             runSettings, setHost,
+                                             setOnException, setPort, getPort)
+import Network.Wai.Middleware.RequestLogger (Destination (Logger),
+                                             IPAddrSource (..),
+                                             OutputFormat (..), destination,
+                                             mkRequestLogger, outputFormat)
+import System.Log.FastLogger                (defaultBufSize, newStdoutLoggerSet,
+                                             toLogStr)
+
+-- Import all relevant handler modules here.
+-- Don't forget to add new modules to your cabal file!
+import Handler.Common
+import Handler.Home
+import Handler.Comment
+
+-- This line actually creates our YesodDispatch instance. It is the second half
+-- of the call to mkYesodData which occurs in Foundation.hs. Please see the
+-- comments there for more details.
+mkYesodDispatch "App" resourcesApp
+
+-- | This function allocates resources (such as a database connection pool),
+-- performs initialization and returns a foundation datatype value. This is also
+-- the place to put your migrate statements to have automatic database
+-- migrations handled by Yesod.
+makeFoundation :: AppSettings -> IO App
+makeFoundation appSettings = do
+    -- Some basic initializations: HTTP connection manager, logger, and static
+    -- subsite.
+    appHttpManager <- getGlobalManager
+    appLogger <- newStdoutLoggerSet defaultBufSize >>= makeYesodLogger
+    appStatic <-
+        (if appMutableStatic appSettings then staticDevel else static)
+        (appStaticDir appSettings)
+
+    -- Return the foundation
+    return App {..}
+
+-- | Convert our foundation to a WAI Application by calling @toWaiAppPlain@ and
+-- applying some additional middlewares.
+makeApplication :: App -> IO Application
+makeApplication foundation = do
+    logWare <- makeLogWare foundation
+    -- Create the WAI application and apply middlewares
+    appPlain <- toWaiAppPlain foundation
+    return $ logWare $ defaultMiddlewaresNoLogging appPlain
+
+makeLogWare :: App -> IO Middleware
+makeLogWare foundation =
+    mkRequestLogger def
+        { outputFormat =
+            if appDetailedRequestLogging $ appSettings foundation
+                then Detailed True
+                else Apache
+                        (if appIpFromHeader $ appSettings foundation
+                            then FromFallback
+                            else FromSocket)
+        , destination = Logger $ loggerSet $ appLogger foundation
+        }
+
+
+-- | Warp settings for the given foundation value.
+warpSettings :: App -> Settings
+warpSettings foundation =
+      setPort (appPort $ appSettings foundation)
+    $ setHost (appHost $ appSettings foundation)
+    $ setOnException (\_req e ->
+        when (defaultShouldDisplayException e) $ messageLoggerSource
+            foundation
+            (appLogger foundation)
+            $(qLocation >>= liftLoc)
+            "yesod"
+            LevelError
+            (toLogStr $ "Exception from Warp: " ++ show e))
+      defaultSettings
+
+-- | For yesod devel, return the Warp settings and WAI Application.
+getApplicationDev :: IO (Settings, Application)
+getApplicationDev = do
+    settings <- getAppSettings
+    foundation <- makeFoundation settings
+    wsettings <- getDevSettings $ warpSettings foundation
+    app <- makeApplication foundation
+    return (wsettings, app)
+
+getAppSettings :: IO AppSettings
+getAppSettings = loadYamlSettings [configSettingsYml] [] useEnv
+
+-- | main function for use by yesod devel
+develMain :: IO ()
+develMain = develMainHelper getApplicationDev
+
+-- | The @main@ function for an executable running this site.
+appMain :: IO ()
+appMain = do
+    -- Get the settings from all relevant sources
+    settings <- loadYamlSettingsArgs
+        -- fall back to compile-time values, set to [] to require values at runtime
+        [configSettingsYmlValue]
+
+        -- allow environment variables to override
+        useEnv
+
+    -- Generate the foundation from the settings
+    foundation <- makeFoundation settings
+
+    -- Generate a WAI Application from the foundation
+    app <- makeApplication foundation
+
+    -- Run the application with Warp
+    runSettings (warpSettings foundation) app
+
+
+--------------------------------------------------------------
+-- Functions for DevelMain.hs (a way to run the app from GHCi)
+--------------------------------------------------------------
+getApplicationRepl :: IO (Int, App, Application)
+getApplicationRepl = do
+    settings <- getAppSettings
+    foundation <- makeFoundation settings
+    wsettings <- getDevSettings $ warpSettings foundation
+    app1 <- makeApplication foundation
+    return (getPort wsettings, foundation, app1)
+
+shutdownApp :: App -> IO ()
+shutdownApp _ = return ()
+
+
+---------------------------------------------
+-- Functions for use in development with GHCi
+---------------------------------------------
+
+-- | Run a handler
+handler :: Handler a -> IO a
+handler h = getAppSettings >>= makeFoundation >>= flip unsafeHandler h
+
+{-# START_FILE src/Foundation.hs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE InstanceSigs #-}
+
+module Foundation where
+
+import Import.NoFoundation
+import Control.Monad.Logger        (LogSource)
+import Text.Hamlet                 (hamletFile)
+import Text.Jasmine                (minifym)
+import Yesod.Core.Types            (Logger)
+import Yesod.Default.Util          (addStaticContentExternal)
+import qualified Yesod.Core.Unsafe as Unsafe
+import qualified Data.CaseInsensitive as CI
+import qualified Data.Text.Encoding as TE
+
+-- | The foundation datatype for your application. This can be a good place to
+-- keep settings and values requiring initialization before your application
+-- starts running, such as database connections. Every handler will have
+-- access to the data present here.
+data App = App
+    { appSettings    :: AppSettings
+    , appStatic      :: Static -- ^ Settings for static file serving.
+    , appHttpManager :: Manager
+    , appLogger      :: Logger
+    }
+
+data MenuItem = MenuItem
+    { menuItemLabel :: Text
+    , menuItemRoute :: Route App
+    , menuItemAccessCallback :: Bool
+    }
+
+data MenuTypes
+    = NavbarLeft MenuItem
+    | NavbarRight MenuItem
+
+-- This is where we define all of the routes in our application. For a full
+-- explanation of the syntax, please see:
+-- http://www.yesodweb.com/book/routing-and-handlers
+--
+-- Note that this is really half the story; in Application.hs, mkYesodDispatch
+-- generates the rest of the code. Please see the following documentation
+-- for an explanation for this split:
+-- http://www.yesodweb.com/book/scaffolding-and-the-site-template#scaffolding-and-the-site-template_foundation_and_application_modules
+--
+-- This function also generates the following type synonyms:
+-- type Handler = HandlerT App IO
+-- type Widget = WidgetT App IO ()
+mkYesodData "App" $(parseRoutesFile "config/routes")
+
+-- | A convenient synonym for creating forms.
+type Form x = Html -> MForm (HandlerFor App) (FormResult x, Widget)
+
+-- Please see the documentation for the Yesod typeclass. There are a number
+-- of settings which can be configured by overriding methods here.
+instance Yesod App where
+    -- Controls the base of generated URLs. For more information on modifying,
+    -- see: https://github.com/yesodweb/yesod/wiki/Overriding-approot
+    approot :: Approot App
+    approot = ApprootRequest $ \app req ->
+        case appRoot $ appSettings app of
+            Nothing -> getApprootText guessApproot app req
+            Just root -> root
+
+    -- Store session data on the client in encrypted cookies,
+    -- default session idle timeout is 120 minutes
+    makeSessionBackend :: App -> IO (Maybe SessionBackend)
+    makeSessionBackend _ = Just <$> defaultClientSessionBackend
+        120    -- timeout in minutes
+        "config/client_session_key.aes"
+
+    -- Yesod Middleware allows you to run code before and after each handler function.
+    -- The defaultYesodMiddleware adds the response header "Vary: Accept, Accept-Language" and performs authorization checks.
+    -- Some users may also want to add the defaultCsrfMiddleware, which:
+    --   a) Sets a cookie with a CSRF token in it.
+    --   b) Validates that incoming write requests include that token in either a header or POST parameter.
+    -- To add it, chain it together with the defaultMiddleware: yesodMiddleware = defaultYesodMiddleware . defaultCsrfMiddleware
+    -- For details, see the CSRF documentation in the Yesod.Core.Handler module of the yesod-core package.
+    yesodMiddleware :: ToTypedContent res => Handler res -> Handler res
+    yesodMiddleware = defaultYesodMiddleware
+
+    defaultLayout :: Widget -> Handler Html
+    defaultLayout widget = do
+        master <- getYesod
+        mmsg <- getMessage
+
+        mcurrentRoute <- getCurrentRoute
+
+        -- Get the breadcrumbs, as defined in the YesodBreadcrumbs instance.
+        (title, parents) <- breadcrumbs
+
+        -- Define the menu items of the header.
+        let menuItems =
+                [ NavbarLeft $ MenuItem
+                    { menuItemLabel = "Home"
+                    , menuItemRoute = HomeR
+                    , menuItemAccessCallback = True
+                    }
+                ]
+
+        let navbarLeftMenuItems = [x | NavbarLeft x <- menuItems]
+        let navbarRightMenuItems = [x | NavbarRight x <- menuItems]
+
+        let navbarLeftFilteredMenuItems = [x | x <- navbarLeftMenuItems, menuItemAccessCallback x]
+        let navbarRightFilteredMenuItems = [x | x <- navbarRightMenuItems, menuItemAccessCallback x]
+
+        -- We break up the default layout into two components:
+        -- default-layout is the contents of the body tag, and
+        -- default-layout-wrapper is the entire page. Since the final
+        -- value passed to hamletToRepHtml cannot be a widget, this allows
+        -- you to use normal widget features in default-layout.
+
+        pc <- widgetToPageContent $ do
+            addStylesheet $ StaticR css_bootstrap_css
+            $(widgetFile "default-layout")
+        withUrlRenderer $(hamletFile "templates/default-layout-wrapper.hamlet")
+
+    isAuthorized
+        :: Route App  -- ^ The route the user is visiting.
+        -> Bool       -- ^ Whether or not this is a "write" request.
+        -> Handler AuthResult
+    -- Routes not requiring authenitcation.
+    isAuthorized FaviconR _ = return Authorized
+    isAuthorized RobotsR _ = return Authorized
+    -- Default to Authorized for now.
+    isAuthorized _ _ = return Authorized
+
+    -- This function creates static content files in the static folder
+    -- and names them based on a hash of their content. This allows
+    -- expiration dates to be set far in the future without worry of
+    -- users receiving stale content.
+    addStaticContent
+        :: Text  -- ^ The file extension
+        -> Text -- ^ The MIME content type
+        -> LByteString -- ^ The contents of the file
+        -> Handler (Maybe (Either Text (Route App, [(Text, Text)])))
+    addStaticContent ext mime content = do
+        master <- getYesod
+        let staticDir = appStaticDir $ appSettings master
+        addStaticContentExternal
+            minifym
+            genFileName
+            staticDir
+            (StaticR . flip StaticRoute [])
+            ext
+            mime
+            content
+      where
+        -- Generate a unique filename based on the content itself
+        genFileName lbs = "autogen-" ++ base64md5 lbs
+
+    -- What messages should be logged. The following includes all messages when
+    -- in development, and warnings and errors in production.
+    shouldLogIO :: App -> LogSource -> LogLevel -> IO Bool
+    shouldLogIO app _source level =
+        return $
+        appShouldLogAll (appSettings app)
+            || level == LevelWarn
+            || level == LevelError
+
+    makeLogger :: App -> IO Logger
+    makeLogger = return . appLogger
+
+-- Define breadcrumbs.
+instance YesodBreadcrumbs App where
+    -- Takes the route that the user is currently on, and returns a tuple
+    -- of the 'Text' that you want the label to display, and a previous
+    -- breadcrumb route.
+    breadcrumb
+        :: Route App  -- ^ The route the user is visiting currently.
+        -> Handler (Text, Maybe (Route App))
+    breadcrumb HomeR = return ("Home", Nothing)
+    breadcrumb  _ = return ("home", Nothing)
+
+-- This instance is required to use forms. You can modify renderMessage to
+-- achieve customized and internationalized form validation messages.
+instance RenderMessage App FormMessage where
+    renderMessage :: App -> [Lang] -> FormMessage -> Text
+    renderMessage _ _ = defaultFormMessage
+
+-- Useful when writing code that is re-usable outside of the Handler context.
+-- An example is background jobs that send email.
+-- This can also be useful for writing code that works across multiple Yesod applications.
+instance HasHttpManager App where
+    getHttpManager :: App -> Manager
+    getHttpManager = appHttpManager
+
+unsafeHandler :: App -> Handler a -> IO a
+unsafeHandler = Unsafe.fakeHandlerGetLogger appLogger
+
+-- Note: Some functionality previously present in the scaffolding has been
+-- moved to documentation in the Wiki. Following are some hopefully helpful
+-- links:
+--
+-- https://github.com/yesodweb/yesod/wiki/Sending-email
+-- https://github.com/yesodweb/yesod/wiki/Serve-static-files-from-a-separate-domain
+-- https://github.com/yesodweb/yesod/wiki/i18n-messages-in-the-scaffolding
+
+{-# START_FILE src/Handler/Comment.hs #-}
+module Handler.Comment where
+
+import Import
+
+postCommentR :: Handler Value
+postCommentR =
+    error "The simple scaffolding does not support authentication or a database for storing comments"
+
+{-# START_FILE src/Handler/Common.hs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+-- | Common handler functions.
+module Handler.Common where
+
+import Data.FileEmbed (embedFile)
+import Import
+
+-- These handlers embed files in the executable at compile time to avoid a
+-- runtime dependency, and for efficiency.
+
+getFaviconR :: Handler TypedContent
+getFaviconR = do cacheSeconds $ 60 * 60 * 24 * 30 -- cache for a month
+                 return $ TypedContent "image/x-icon"
+                        $ toContent $(embedFile "config/favicon.ico")
+
+getRobotsR :: Handler TypedContent
+getRobotsR = return $ TypedContent typePlain
+                    $ toContent $(embedFile "config/robots.txt")
+
+{-# START_FILE src/Handler/Home.hs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+module Handler.Home where
+
+import Import
+import Yesod.Form.Bootstrap3 (BootstrapFormLayout (..), renderBootstrap3)
+import Text.Julius (RawJS (..))
+
+-- Define our data that will be used for creating the form.
+data FileForm = FileForm
+    { fileInfo :: FileInfo
+    , fileDescription :: Text
+    }
+
+-- This is a handler function for the GET request method on the HomeR
+-- resource pattern. All of your resource patterns are defined in
+-- config/routes
+--
+-- The majority of the code you will write in Yesod lives in these handler
+-- functions. You can spread them across multiple files if you are so
+-- inclined, or create a single monolithic file.
+getHomeR :: Handler Html
+getHomeR = do
+    (formWidget, formEnctype) <- generateFormPost sampleForm
+    let submission = Nothing :: Maybe FileForm
+        handlerName = "getHomeR" :: Text
+    defaultLayout $ do
+        let (commentFormId, commentTextareaId, commentListId) = commentIds
+        aDomId <- newIdent
+        setTitle "Welcome To Yesod!"
+        $(widgetFile "homepage")
+
+postHomeR :: Handler Html
+postHomeR = do
+    ((result, formWidget), formEnctype) <- runFormPost sampleForm
+    let handlerName = "postHomeR" :: Text
+        submission = case result of
+            FormSuccess res -> Just res
+            _ -> Nothing
+
+    defaultLayout $ do
+        let (commentFormId, commentTextareaId, commentListId) = commentIds
+        aDomId <- newIdent
+        setTitle "Welcome To Yesod!"
+        $(widgetFile "homepage")
+
+sampleForm :: Form FileForm
+sampleForm = renderBootstrap3 BootstrapBasicForm $ FileForm
+    <$> fileAFormReq "Choose a file"
+    <*> areq textField textSettings Nothing
+    -- Add attributes like the placeholder and CSS classes.
+    where textSettings = FieldSettings
+            { fsLabel = "What's on the file?"
+            , fsTooltip = Nothing
+            , fsId = Nothing
+            , fsName = Nothing
+            , fsAttrs =
+                [ ("class", "form-control")
+                , ("placeholder", "File description")
+                ]
+            }
+
+commentIds :: (Text, Text, Text)
+commentIds = ("js-commentForm", "js-createCommentTextarea", "js-commentList")
+
+{-# START_FILE src/Import.hs #-}
+module Import
+    ( module Import
+    ) where
+
+import Foundation            as Import
+import Import.NoFoundation   as Import
+
+{-# START_FILE src/Import/NoFoundation.hs #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Import.NoFoundation
+    ( module X
+    ) where
+
+import RIO.Yesod                    as X
+import Data.Default                 as X (Default (..))
+import Database.Persist.Sql         as X (runMigration)
+import Database.Persist.Sql         as X (SqlBackend, SqlPersistT)
+import Network.HTTP.Client.Conduit  as X hiding (Proxy(..))
+import Network.HTTP.Types           as X
+import Settings                     as X
+import Settings.StaticFiles         as X
+import Yesod                        as X hiding (Header, parseTime)
+import Yesod.Core.Types             as X (loggerSet)
+import Yesod.Default.Config2        as X
+import Yesod.Feed                   as X
+import Yesod.Static                 as X
+
+{-# START_FILE src/RIO/Yesod.hs #-}
+module RIO.Yesod
+  ( module RIO
+  ) where
+
+import RIO
+  hiding
+   ( Handler(..)
+   , LogLevel(..)
+   , LogSource
+   , logDebug
+   , logDebugS
+   , logError
+   , logErrorS
+   , logInfo
+   , logInfoS
+   , logOther
+   , logOtherS
+   , logWarn
+   , logWarnS
+   )
+
+{-# START_FILE src/Settings.hs #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+{-# LANGUAGE TemplateHaskell   #-}
+-- | Settings are centralized, as much as possible, into this file. This
+-- includes database connection settings, static file locations, etc.
+-- In addition, you can configure a number of different aspects of Yesod
+-- by overriding methods in the Yesod typeclass. That instance is
+-- declared in the Foundation.hs file.
+module Settings where
+
+import RIO.Yesod
+import qualified Control.Exception as Exception
+import Data.Aeson                  (Result (..), FromJSON(..), fromJSON,
+                                    withObject,(.:),(.!=),(.:?),Value(..))
+import Data.Default                (def)
+import Data.FileEmbed              (embedFile)
+import Data.Yaml                   (decodeEither')
+import Language.Haskell.TH.Syntax  (Exp, Name, Q)
+import Network.Wai.Handler.Warp    (HostPreference)
+import Yesod.Default.Config2       (applyEnvValue, configSettingsYml)
+import Yesod.Default.Util          (WidgetFileSettings, widgetFileNoReload,
+                                    widgetFileReload)
+import Yesod.Core.Types            (Route)
+import Yesod.Static                (CombineSettings,combineScripts',
+                                    combineStylesheets', Static)
+
+
+-- | Runtime settings to configure this application. These settings can be
+-- loaded from various sources: defaults, environment variables, config files,
+-- theoretically even a database.
+data AppSettings = AppSettings
+    { appStaticDir              :: String
+    -- ^ Directory from which to serve static files.
+    , appRoot                   :: Maybe Text
+    -- ^ Base for all generated URLs. If @Nothing@, determined
+    -- from the request headers.
+    , appHost                   :: HostPreference
+    -- ^ Host/interface the server should bind to.
+    , appPort                   :: Int
+    -- ^ Port to listen on
+    , appIpFromHeader           :: Bool
+    -- ^ Get the IP address from the header when logging. Useful when sitting
+    -- behind a reverse proxy.
+
+    , appDetailedRequestLogging :: Bool
+    -- ^ Use detailed request logging system
+    , appShouldLogAll           :: Bool
+    -- ^ Should all log messages be displayed?
+    , appReloadTemplates        :: Bool
+    -- ^ Use the reload version of templates
+    , appMutableStatic          :: Bool
+    -- ^ Assume that files in the static dir may change after compilation
+    , appSkipCombining          :: Bool
+    -- ^ Perform no stylesheet/script combining
+
+    -- Example app-specific configuration values.
+    , appCopyright              :: Text
+    -- ^ Copyright text to appear in the footer of the page
+    , appAnalytics              :: Maybe Text
+    -- ^ Google Analytics code
+    }
+
+instance FromJSON AppSettings where
+    parseJSON = withObject "AppSettings" $ \o -> do
+        let defaultDev =
+#ifdef DEVELOPMENT
+                True
+#else
+                False
+#endif
+        appStaticDir              <- o .: "static-dir"
+        appRoot                   <- o .:? "approot"
+        appHost                   <- fromString <$> o .: "host"
+        appPort                   <- o .: "port"
+        appIpFromHeader           <- o .: "ip-from-header"
+
+        dev                       <- o .:? "development"      .!= defaultDev
+
+        appDetailedRequestLogging <- o .:? "detailed-logging" .!= dev
+        appShouldLogAll           <- o .:? "should-log-all"   .!= dev
+        appReloadTemplates        <- o .:? "reload-templates" .!= dev
+        appMutableStatic          <- o .:? "mutable-static"   .!= dev
+        appSkipCombining          <- o .:? "skip-combining"   .!= dev
+
+        appCopyright              <- o .: "copyright"
+        appAnalytics              <- o .:? "analytics"
+
+        return AppSettings {..}
+
+-- | Settings for 'widgetFile', such as which template languages to support and
+-- default Hamlet settings.
+--
+-- For more information on modifying behavior, see:
+--
+-- https://github.com/yesodweb/yesod/wiki/Overriding-widgetFile
+widgetFileSettings :: WidgetFileSettings
+widgetFileSettings = def
+
+-- | How static files should be combined.
+combineSettings :: CombineSettings
+combineSettings = def
+
+-- The rest of this file contains settings which rarely need changing by a
+-- user.
+
+widgetFile :: String -> Q Exp
+widgetFile = (if appReloadTemplates compileTimeAppSettings
+                then widgetFileReload
+                else widgetFileNoReload)
+              widgetFileSettings
+
+-- | Raw bytes at compile time of @config/settings.yml@
+configSettingsYmlBS :: ByteString
+configSettingsYmlBS = $(embedFile configSettingsYml)
+
+-- | @config/settings.yml@, parsed to a @Value@.
+configSettingsYmlValue :: Value
+configSettingsYmlValue = either Exception.throw id
+                       $ decodeEither' configSettingsYmlBS
+
+-- | A version of @AppSettings@ parsed at compile time from @config/settings.yml@.
+compileTimeAppSettings :: AppSettings
+compileTimeAppSettings =
+    case fromJSON $ applyEnvValue False mempty configSettingsYmlValue of
+        Error e -> error e
+        Success settings -> settings
+
+-- The following two functions can be used to combine multiple CSS or JS files
+-- at compile time to decrease the number of http requests.
+-- Sample usage (inside a Widget):
+--
+-- > $(combineStylesheets 'StaticR [style1_css, style2_css])
+
+combineStylesheets :: Name -> [Route Static] -> Q Exp
+combineStylesheets = combineStylesheets'
+    (appSkipCombining compileTimeAppSettings)
+    combineSettings
+
+combineScripts :: Name -> [Route Static] -> Q Exp
+combineScripts = combineScripts'
+    (appSkipCombining compileTimeAppSettings)
+    combineSettings
+
+{-# START_FILE src/Settings/StaticFiles.hs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
+module Settings.StaticFiles where
+
+import Settings     (appStaticDir, compileTimeAppSettings)
+import Yesod.Static (staticFiles)
+
+-- This generates easy references to files in the static directory at compile time,
+-- giving you compile-time verification that referenced files exist.
+-- Warning: any files added to your static directory during run-time can't be
+-- accessed this way. You'll have to use their FilePath or URL to access them.
+--
+-- For example, to refer to @static/js/script.js@ via an identifier, you'd use:
+--
+--     js_script_js
+--
+-- If the identifier is not available, you may use:
+--
+--     StaticFile ["js", "script.js"] []
+staticFiles (appStaticDir compileTimeAppSettings)
+
+{-# START_FILE static/css/bootstrap.css #-}
+@import url("https://fonts.googleapis.com/css?family=Lato:400,700,400italic");
+/*!
+ * bootswatch v3.3.7
+ * Homepage: http://bootswatch.com
+ * Copyright 2012-2016 Thomas Park
+ * Licensed under MIT
+ * Based on Bootstrap
+*/
+/*!
+ * Bootstrap v3.3.7 (http://getbootstrap.com)
+ * Copyright 2011-2016 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ */
+/*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
+html {
+  font-family: sans-serif;
+  -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
+}
+body {
+  margin: 0;
+}
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+  vertical-align: baseline;
+}
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+[hidden],
+template {
+  display: none;
+}
+a {
+  background-color: transparent;
+}
+a:active,
+a:hover {
+  outline: 0;
+}
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+b,
+strong {
+  font-weight: bold;
+}
+dfn {
+  font-style: italic;
+}
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+mark {
+  background: #ff0;
+  color: #000;
+}
+small {
+  font-size: 80%;
+}
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sup {
+  top: -0.5em;
+}
+sub {
+  bottom: -0.25em;
+}
+img {
+  border: 0;
+}
+svg:not(:root) {
+  overflow: hidden;
+}
+figure {
+  margin: 1em 40px;
+}
+hr {
+  -webkit-box-sizing: content-box;
+     -moz-box-sizing: content-box;
+          box-sizing: content-box;
+  height: 0;
+}
+pre {
+  overflow: auto;
+}
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  font: inherit;
+  margin: 0;
+}
+button {
+  overflow: visible;
+}
+button,
+select {
+  text-transform: none;
+}
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  cursor: pointer;
+}
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+input {
+  line-height: normal;
+}
+input[type="checkbox"],
+input[type="radio"] {
+  -webkit-box-sizing: border-box;
+     -moz-box-sizing: border-box;
+          box-sizing: border-box;
+  padding: 0;
+}
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+input[type="search"] {
+  -webkit-appearance: textfield;
+  -webkit-box-sizing: content-box;
+     -moz-box-sizing: content-box;
+          box-sizing: content-box;
+}
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+legend {
+  border: 0;
+  padding: 0;
+}
+textarea {
+  overflow: auto;
+}
+optgroup {
+  font-weight: bold;
+}
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+td,
+th {
+  padding: 0;
+}
+/*! Source: https://github.com/h5bp/html5-boilerplate/blob/master/src/css/main.css */
+@media print {
+  *,
+  *:before,
+  *:after {
+    background: transparent !important;
+    color: #000 !important;
+    -webkit-box-shadow: none !important;
+            box-shadow: none !important;
+    text-shadow: none !important;
+  }
+  a,
+  a:visited {
+    text-decoration: underline;
+  }
+  a[href]:after {
+    content: " (" attr(href) ")";
+  }
+  abbr[title]:after {
+    content: " (" attr(title) ")";
+  }
+  a[href^="#"]:after,
+  a[href^="javascript:"]:after {
+    content: "";
+  }
+  pre,
+  blockquote {
+    border: 1px solid #999;
+    page-break-inside: avoid;
+  }
+  thead {
+    display: table-header-group;
+  }
+  tr,
+  img {
+    page-break-inside: avoid;
+  }
+  img {
+    max-width: 100% !important;
+  }
+  p,
+  h2,
+  h3 {
+    orphans: 3;
+    widows: 3;
+  }
+  h2,
+  h3 {
+    page-break-after: avoid;
+  }
+  .navbar {
+    display: none;
+  }
+  .btn > .caret,
+  .dropup > .btn > .caret {
+    border-top-color: #000 !important;
+  }
+  .label {
+    border: 1px solid #000;
+  }
+  .table {
+    border-collapse: collapse !important;
+  }
+  .table td,
+  .table th {
+    background-color: #fff !important;
+  }
+  .table-bordered th,
+  .table-bordered td {
+    border: 1px solid #ddd !important;
+  }
+}
+@font-face {
+  font-family: 'Glyphicons Halflings';
+  src: url('../fonts/glyphicons-halflings-regular.eot');
+  src: url('../fonts/glyphicons-halflings-regular.eot?#iefix') format('embedded-opentype'), url('../fonts/glyphicons-halflings-regular.woff2') format('woff2'), url('../fonts/glyphicons-halflings-regular.woff') format('woff'), url('../fonts/glyphicons-halflings-regular.ttf') format('truetype'), url('../fonts/glyphicons-halflings-regular.svg#glyphicons_halflingsregular') format('svg');
+}
+.glyphicon {
+  position: relative;
+  top: 1px;
+  display: inline-block;
+  font-family: 'Glyphicons Halflings';
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+.glyphicon-asterisk:before {
+  content: "\002a";
+}
+.glyphicon-plus:before {
+  content: "\002b";
+}
+.glyphicon-euro:before,
+.glyphicon-eur:before {
+  content: "\20ac";
+}
+.glyphicon-minus:before {
+  content: "\2212";
+}
+.glyphicon-cloud:before {
+  content: "\2601";
+}
+.glyphicon-envelope:before {
+  content: "\2709";
+}
+.glyphicon-pencil:before {
+  content: "\270f";
+}
+.glyphicon-glass:before {
+  content: "\e001";
+}
+.glyphicon-music:before {
+  content: "\e002";
+}
+.glyphicon-search:before {
+  content: "\e003";
+}
+.glyphicon-heart:before {
+  content: "\e005";
+}
+.glyphicon-star:before {
+  content: "\e006";
+}
+.glyphicon-star-empty:before {
+  content: "\e007";
+}
+.glyphicon-user:before {
+  content: "\e008";
+}
+.glyphicon-film:before {
+  content: "\e009";
+}
+.glyphicon-th-large:before {
+  content: "\e010";
+}
+.glyphicon-th:before {
+  content: "\e011";
+}
+.glyphicon-th-list:before {
+  content: "\e012";
+}
+.glyphicon-ok:before {
+  content: "\e013";
+}
+.glyphicon-remove:before {
+  content: "\e014";
+}
+.glyphicon-zoom-in:before {
+  content: "\e015";
+}
+.glyphicon-zoom-out:before {
+  content: "\e016";
+}
+.glyphicon-off:before {
+  content: "\e017";
+}
+.glyphicon-signal:before {
+  content: "\e018";
+}
+.glyphicon-cog:before {
+  content: "\e019";
+}
+.glyphicon-trash:before {
+  content: "\e020";
+}
+.glyphicon-home:before {
+  content: "\e021";
+}
+.glyphicon-file:before {
+  content: "\e022";
+}
+.glyphicon-time:before {
+  content: "\e023";
+}
+.glyphicon-road:before {
+  content: "\e024";
+}
+.glyphicon-download-alt:before {
+  content: "\e025";
+}
+.glyphicon-download:before {
+  content: "\e026";
+}
+.glyphicon-upload:before {
+  content: "\e027";
+}
+.glyphicon-inbox:before {
+  content: "\e028";
+}
+.glyphicon-play-circle:before {
+  content: "\e029";
+}
+.glyphicon-repeat:before {
+  content: "\e030";
+}
+.glyphicon-refresh:before {
+  content: "\e031";
+}
+.glyphicon-list-alt:before {
+  content: "\e032";
+}
+.glyphicon-lock:before {
+  content: "\e033";
+}
+.glyphicon-flag:before {
+  content: "\e034";
+}
+.glyphicon-headphones:before {
+  content: "\e035";
+}
+.glyphicon-volume-off:before {
+  content: "\e036";
+}
+.glyphicon-volume-down:before {
+  content: "\e037";
+}
+.glyphicon-volume-up:before {
+  content: "\e038";
+}
+.glyphicon-qrcode:before {
+  content: "\e039";
+}
+.glyphicon-barcode:before {
+  content: "\e040";
+}
+.glyphicon-tag:before {
+  content: "\e041";
+}
+.glyphicon-tags:before {
+  content: "\e042";
+}
+.glyphicon-book:before {
+  content: "\e043";
+}
+.glyphicon-bookmark:before {
+  content: "\e044";
+}
+.glyphicon-print:before {
+  content: "\e045";
+}
+.glyphicon-camera:before {
+  content: "\e046";
+}
+.glyphicon-font:before {
+  content: "\e047";
+}
+.glyphicon-bold:before {
+  content: "\e048";
+}
+.glyphicon-italic:before {
+  content: "\e049";
+}
+.glyphicon-text-height:before {
+  content: "\e050";
+}
+.glyphicon-text-width:before {
+  content: "\e051";
+}
+.glyphicon-align-left:before {
+  content: "\e052";
+}
+.glyphicon-align-center:before {
+  content: "\e053";
+}
+.glyphicon-align-right:before {
+  content: "\e054";
+}
+.glyphicon-align-justify:before {
+  content: "\e055";
+}
+.glyphicon-list:before {
+  content: "\e056";
+}
+.glyphicon-indent-left:before {
+  content: "\e057";
+}
+.glyphicon-indent-right:before {
+  content: "\e058";
+}
+.glyphicon-facetime-video:before {
+  content: "\e059";
+}
+.glyphicon-picture:before {
+  content: "\e060";
+}
+.glyphicon-map-marker:before {
+  content: "\e062";
+}
+.glyphicon-adjust:before {
+  content: "\e063";
+}
+.glyphicon-tint:before {
+  content: "\e064";
+}
+.glyphicon-edit:before {
+  content: "\e065";
+}
+.glyphicon-share:before {
+  content: "\e066";
+}
+.glyphicon-check:before {
+  content: "\e067";
+}
+.glyphicon-move:before {
+  content: "\e068";
+}
+.glyphicon-step-backward:before {
+  content: "\e069";
+}
+.glyphicon-fast-backward:before {
+  content: "\e070";
+}
+.glyphicon-backward:before {
+  content: "\e071";
+}
+.glyphicon-play:before {
+  content: "\e072";
+}
+.glyphicon-pause:before {
+  content: "\e073";
+}
+.glyphicon-stop:before {
+  content: "\e074";
+}
+.glyphicon-forward:before {
+  content: "\e075";
+}
+.glyphicon-fast-forward:before {
+  content: "\e076";
+}
+.glyphicon-step-forward:before {
+  content: "\e077";
+}
+.glyphicon-eject:before {
+  content: "\e078";
+}
+.glyphicon-chevron-left:before {
+  content: "\e079";
+}
+.glyphicon-chevron-right:before {
+  content: "\e080";
+}
+.glyphicon-plus-sign:before {
+  content: "\e081";
+}
+.glyphicon-minus-sign:before {
+  content: "\e082";
+}
+.glyphicon-remove-sign:before {
+  content: "\e083";
+}
+.glyphicon-ok-sign:before {
+  content: "\e084";
+}
+.glyphicon-question-sign:before {
+  content: "\e085";
+}
+.glyphicon-info-sign:before {
+  content: "\e086";
+}
+.glyphicon-screenshot:before {
+  content: "\e087";
+}
+.glyphicon-remove-circle:before {
+  content: "\e088";
+}
+.glyphicon-ok-circle:before {
+  content: "\e089";
+}
+.glyphicon-ban-circle:before {
+  content: "\e090";
+}
+.glyphicon-arrow-left:before {
+  content: "\e091";
+}
+.glyphicon-arrow-right:before {
+  content: "\e092";
+}
+.glyphicon-arrow-up:before {
+  content: "\e093";
+}
+.glyphicon-arrow-down:before {
+  content: "\e094";
+}
+.glyphicon-share-alt:before {
+  content: "\e095";
+}
+.glyphicon-resize-full:before {
+  content: "\e096";
+}
+.glyphicon-resize-small:before {
+  content: "\e097";
+}
+.glyphicon-exclamation-sign:before {
+  content: "\e101";
+}
+.glyphicon-gift:before {
+  content: "\e102";
+}
+.glyphicon-leaf:before {
+  content: "\e103";
+}
+.glyphicon-fire:before {
+  content: "\e104";
+}
+.glyphicon-eye-open:before {
+  content: "\e105";
+}
+.glyphicon-eye-close:before {
+  content: "\e106";
+}
+.glyphicon-warning-sign:before {
+  content: "\e107";
+}
+.glyphicon-plane:before {
+  content: "\e108";
+}
+.glyphicon-calendar:before {
+  content: "\e109";
+}
+.glyphicon-random:before {
+  content: "\e110";
+}
+.glyphicon-comment:before {
+  content: "\e111";
+}
+.glyphicon-magnet:before {
+  content: "\e112";
+}
+.glyphicon-chevron-up:before {
+  content: "\e113";
+}
+.glyphicon-chevron-down:before {
+  content: "\e114";
+}
+.glyphicon-retweet:before {
+  content: "\e115";
+}
+.glyphicon-shopping-cart:before {
+  content: "\e116";
+}
+.glyphicon-folder-close:before {
+  content: "\e117";
+}
+.glyphicon-folder-open:before {
+  content: "\e118";
+}
+.glyphicon-resize-vertical:before {
+  content: "\e119";
+}
+.glyphicon-resize-horizontal:before {
+  content: "\e120";
+}
+.glyphicon-hdd:before {
+  content: "\e121";
+}
+.glyphicon-bullhorn:before {
+  content: "\e122";
+}
+.glyphicon-bell:before {
+  content: "\e123";
+}
+.glyphicon-certificate:before {
+  content: "\e124";
+}
+.glyphicon-thumbs-up:before {
+  content: "\e125";
+}
+.glyphicon-thumbs-down:before {
+  content: "\e126";
+}
+.glyphicon-hand-right:before {
+  content: "\e127";
+}
+.glyphicon-hand-left:before {
+  content: "\e128";
+}
+.glyphicon-hand-up:before {
+  content: "\e129";
+}
+.glyphicon-hand-down:before {
+  content: "\e130";
+}
+.glyphicon-circle-arrow-right:before {
+  content: "\e131";
+}
+.glyphicon-circle-arrow-left:before {
+  content: "\e132";
+}
+.glyphicon-circle-arrow-up:before {
+  content: "\e133";
+}
+.glyphicon-circle-arrow-down:before {
+  content: "\e134";
+}
+.glyphicon-globe:before {
+  content: "\e135";
+}
+.glyphicon-wrench:before {
+  content: "\e136";
+}
+.glyphicon-tasks:before {
+  content: "\e137";
+}
+.glyphicon-filter:before {
+  content: "\e138";
+}
+.glyphicon-briefcase:before {
+  content: "\e139";
+}
+.glyphicon-fullscreen:before {
+  content: "\e140";
+}
+.glyphicon-dashboard:before {
+  content: "\e141";
+}
+.glyphicon-paperclip:before {
+  content: "\e142";
+}
+.glyphicon-heart-empty:before {
+  content: "\e143";
+}
+.glyphicon-link:before {
+  content: "\e144";
+}
+.glyphicon-phone:before {
+  content: "\e145";
+}
+.glyphicon-pushpin:before {
+  content: "\e146";
+}
+.glyphicon-usd:before {
+  content: "\e148";
+}
+.glyphicon-gbp:before {
+  content: "\e149";
+}
+.glyphicon-sort:before {
+  content: "\e150";
+}
+.glyphicon-sort-by-alphabet:before {
+  content: "\e151";
+}
+.glyphicon-sort-by-alphabet-alt:before {
+  content: "\e152";
+}
+.glyphicon-sort-by-order:before {
+  content: "\e153";
+}
+.glyphicon-sort-by-order-alt:before {
+  content: "\e154";
+}
+.glyphicon-sort-by-attributes:before {
+  content: "\e155";
+}
+.glyphicon-sort-by-attributes-alt:before {
+  content: "\e156";
+}
+.glyphicon-unchecked:before {
+  content: "\e157";
+}
+.glyphicon-expand:before {
+  content: "\e158";
+}
+.glyphicon-collapse-down:before {
+  content: "\e159";
+}
+.glyphicon-collapse-up:before {
+  content: "\e160";
+}
+.glyphicon-log-in:before {
+  content: "\e161";
+}
+.glyphicon-flash:before {
+  content: "\e162";
+}
+.glyphicon-log-out:before {
+  content: "\e163";
+}
+.glyphicon-new-window:before {
+  content: "\e164";
+}
+.glyphicon-record:before {
+  content: "\e165";
+}
+.glyphicon-save:before {
+  content: "\e166";
+}
+.glyphicon-open:before {
+  content: "\e167";
+}
+.glyphicon-saved:before {
+  content: "\e168";
+}
+.glyphicon-import:before {
+  content: "\e169";
+}
+.glyphicon-export:before {
+  content: "\e170";
+}
+.glyphicon-send:before {
+  content: "\e171";
+}
+.glyphicon-floppy-disk:before {
+  content: "\e172";
+}
+.glyphicon-floppy-saved:before {
+  content: "\e173";
+}
+.glyphicon-floppy-remove:before {
+  content: "\e174";
+}
+.glyphicon-floppy-save:before {
+  content: "\e175";
+}
+.glyphicon-floppy-open:before {
+  content: "\e176";
+}
+.glyphicon-credit-card:before {
+  content: "\e177";
+}
+.glyphicon-transfer:before {
+  content: "\e178";
+}
+.glyphicon-cutlery:before {
+  content: "\e179";
+}
+.glyphicon-header:before {
+  content: "\e180";
+}
+.glyphicon-compressed:before {
+  content: "\e181";
+}
+.glyphicon-earphone:before {
+  content: "\e182";
+}
+.glyphicon-phone-alt:before {
+  content: "\e183";
+}
+.glyphicon-tower:before {
+  content: "\e184";
+}
+.glyphicon-stats:before {
+  content: "\e185";
+}
+.glyphicon-sd-video:before {
+  content: "\e186";
+}
+.glyphicon-hd-video:before {
+  content: "\e187";
+}
+.glyphicon-subtitles:before {
+  content: "\e188";
+}
+.glyphicon-sound-stereo:before {
+  content: "\e189";
+}
+.glyphicon-sound-dolby:before {
+  content: "\e190";
+}
+.glyphicon-sound-5-1:before {
+  content: "\e191";
+}
+.glyphicon-sound-6-1:before {
+  content: "\e192";
+}
+.glyphicon-sound-7-1:before {
+  content: "\e193";
+}
+.glyphicon-copyright-mark:before {
+  content: "\e194";
+}
+.glyphicon-registration-mark:before {
+  content: "\e195";
+}
+.glyphicon-cloud-download:before {
+  content: "\e197";
+}
+.glyphicon-cloud-upload:before {
+  content: "\e198";
+}
+.glyphicon-tree-conifer:before {
+  content: "\e199";
+}
+.glyphicon-tree-deciduous:before {
+  content: "\e200";
+}
+.glyphicon-cd:before {
+  content: "\e201";
+}
+.glyphicon-save-file:before {
+  content: "\e202";
+}
+.glyphicon-open-file:before {
+  content: "\e203";
+}
+.glyphicon-level-up:before {
+  content: "\e204";
+}
+.glyphicon-copy:before {
+  content: "\e205";
+}
+.glyphicon-paste:before {
+  content: "\e206";
+}
+.glyphicon-alert:before {
+  content: "\e209";
+}
+.glyphicon-equalizer:before {
+  content: "\e210";
+}
+.glyphicon-king:before {
+  content: "\e211";
+}
+.glyphicon-queen:before {
+  content: "\e212";
+}
+.glyphicon-pawn:before {
+  content: "\e213";
+}
+.glyphicon-bishop:before {
+  content: "\e214";
+}
+.glyphicon-knight:before {
+  content: "\e215";
+}
+.glyphicon-baby-formula:before {
+  content: "\e216";
+}
+.glyphicon-tent:before {
+  content: "\26fa";
+}
+.glyphicon-blackboard:before {
+  content: "\e218";
+}
+.glyphicon-bed:before {
+  content: "\e219";
+}
+.glyphicon-apple:before {
+  content: "\f8ff";
+}
+.glyphicon-erase:before {
+  content: "\e221";
+}
+.glyphicon-hourglass:before {
+  content: "\231b";
+}
+.glyphicon-lamp:before {
+  content: "\e223";
+}
+.glyphicon-duplicate:before {
+  content: "\e224";
+}
+.glyphicon-piggy-bank:before {
+  content: "\e225";
+}
+.glyphicon-scissors:before {
+  content: "\e226";
+}
+.glyphicon-bitcoin:before {
+  content: "\e227";
+}
+.glyphicon-btc:before {
+  content: "\e227";
+}
+.glyphicon-xbt:before {
+  content: "\e227";
+}
+.glyphicon-yen:before {
+  content: "\00a5";
+}
+.glyphicon-jpy:before {
+  content: "\00a5";
+}
+.glyphicon-ruble:before {
+  content: "\20bd";
+}
+.glyphicon-rub:before {
+  content: "\20bd";
+}
+.glyphicon-scale:before {
+  content: "\e230";
+}
+.glyphicon-ice-lolly:before {
+  content: "\e231";
+}
+.glyphicon-ice-lolly-tasted:before {
+  content: "\e232";
+}
+.glyphicon-education:before {
+  content: "\e233";
+}
+.glyphicon-option-horizontal:before {
+  content: "\e234";
+}
+.glyphicon-option-vertical:before {
+  content: "\e235";
+}
+.glyphicon-menu-hamburger:before {
+  content: "\e236";
+}
+.glyphicon-modal-window:before {
+  content: "\e237";
+}
+.glyphicon-oil:before {
+  content: "\e238";
+}
+.glyphicon-grain:before {
+  content: "\e239";
+}
+.glyphicon-sunglasses:before {
+  content: "\e240";
+}
+.glyphicon-text-size:before {
+  content: "\e241";
+}
+.glyphicon-text-color:before {
+  content: "\e242";
+}
+.glyphicon-text-background:before {
+  content: "\e243";
+}
+.glyphicon-object-align-top:before {
+  content: "\e244";
+}
+.glyphicon-object-align-bottom:before {
+  content: "\e245";
+}
+.glyphicon-object-align-horizontal:before {
+  content: "\e246";
+}
+.glyphicon-object-align-left:before {
+  content: "\e247";
+}
+.glyphicon-object-align-vertical:before {
+  content: "\e248";
+}
+.glyphicon-object-align-right:before {
+  content: "\e249";
+}
+.glyphicon-triangle-right:before {
+  content: "\e250";
+}
+.glyphicon-triangle-left:before {
+  content: "\e251";
+}
+.glyphicon-triangle-bottom:before {
+  content: "\e252";
+}
+.glyphicon-triangle-top:before {
+  content: "\e253";
+}
+.glyphicon-console:before {
+  content: "\e254";
+}
+.glyphicon-superscript:before {
+  content: "\e255";
+}
+.glyphicon-subscript:before {
+  content: "\e256";
+}
+.glyphicon-menu-left:before {
+  content: "\e257";
+}
+.glyphicon-menu-right:before {
+  content: "\e258";
+}
+.glyphicon-menu-down:before {
+  content: "\e259";
+}
+.glyphicon-menu-up:before {
+  content: "\e260";
+}
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+*:before,
+*:after {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+html {
+  font-size: 10px;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
+body {
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 15px;
+  line-height: 1.42857143;
+  color: #2c3e50;
+  background-color: #ffffff;
+}
+input,
+button,
+select,
+textarea {
+  font-family: inherit;
+  font-size: inherit;
+  line-height: inherit;
+}
+a {
+  color: #18bc9c;
+  text-decoration: none;
+}
+a:hover,
+a:focus {
+  color: #18bc9c;
+  text-decoration: underline;
+}
+a:focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+figure {
+  margin: 0;
+}
+img {
+  vertical-align: middle;
+}
+.img-responsive,
+.thumbnail > img,
+.thumbnail a > img,
+.carousel-inner > .item > img,
+.carousel-inner > .item > a > img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+.img-rounded {
+  border-radius: 6px;
+}
+.img-thumbnail {
+  padding: 4px;
+  line-height: 1.42857143;
+  background-color: #ffffff;
+  border: 1px solid #ecf0f1;
+  border-radius: 4px;
+  -webkit-transition: all 0.2s ease-in-out;
+  -o-transition: all 0.2s ease-in-out;
+  transition: all 0.2s ease-in-out;
+  display: inline-block;
+  max-width: 100%;
+  height: auto;
+}
+.img-circle {
+  border-radius: 50%;
+}
+hr {
+  margin-top: 21px;
+  margin-bottom: 21px;
+  border: 0;
+  border-top: 1px solid #ecf0f1;
+}
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+.sr-only-focusable:active,
+.sr-only-focusable:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  clip: auto;
+}
+[role="button"] {
+  cursor: pointer;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.h1,
+.h2,
+.h3,
+.h4,
+.h5,
+.h6 {
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-weight: 400;
+  line-height: 1.1;
+  color: inherit;
+}
+h1 small,
+h2 small,
+h3 small,
+h4 small,
+h5 small,
+h6 small,
+.h1 small,
+.h2 small,
+.h3 small,
+.h4 small,
+.h5 small,
+.h6 small,
+h1 .small,
+h2 .small,
+h3 .small,
+h4 .small,
+h5 .small,
+h6 .small,
+.h1 .small,
+.h2 .small,
+.h3 .small,
+.h4 .small,
+.h5 .small,
+.h6 .small {
+  font-weight: normal;
+  line-height: 1;
+  color: #b4bcc2;
+}
+h1,
+.h1,
+h2,
+.h2,
+h3,
+.h3 {
+  margin-top: 21px;
+  margin-bottom: 10.5px;
+}
+h1 small,
+.h1 small,
+h2 small,
+.h2 small,
+h3 small,
+.h3 small,
+h1 .small,
+.h1 .small,
+h2 .small,
+.h2 .small,
+h3 .small,
+.h3 .small {
+  font-size: 65%;
+}
+h4,
+.h4,
+h5,
+.h5,
+h6,
+.h6 {
+  margin-top: 10.5px;
+  margin-bottom: 10.5px;
+}
+h4 small,
+.h4 small,
+h5 small,
+.h5 small,
+h6 small,
+.h6 small,
+h4 .small,
+.h4 .small,
+h5 .small,
+.h5 .small,
+h6 .small,
+.h6 .small {
+  font-size: 75%;
+}
+h1,
+.h1 {
+  font-size: 39px;
+}
+h2,
+.h2 {
+  font-size: 32px;
+}
+h3,
+.h3 {
+  font-size: 26px;
+}
+h4,
+.h4 {
+  font-size: 19px;
+}
+h5,
+.h5 {
+  font-size: 15px;
+}
+h6,
+.h6 {
+  font-size: 13px;
+}
+p {
+  margin: 0 0 10.5px;
+}
+.lead {
+  margin-bottom: 21px;
+  font-size: 17px;
+  font-weight: 300;
+  line-height: 1.4;
+}
+@media (min-width: 768px) {
+  .lead {
+    font-size: 22.5px;
+  }
+}
+small,
+.small {
+  font-size: 86%;
+}
+mark,
+.mark {
+  background-color: #f39c12;
+  padding: .2em;
+}
+.text-left {
+  text-align: left;
+}
+.text-right {
+  text-align: right;
+}
+.text-center {
+  text-align: center;
+}
+.text-justify {
+  text-align: justify;
+}
+.text-nowrap {
+  white-space: nowrap;
+}
+.text-lowercase {
+  text-transform: lowercase;
+}
+.text-uppercase {
+  text-transform: uppercase;
+}
+.text-capitalize {
+  text-transform: capitalize;
+}
+.text-muted {
+  color: #b4bcc2;
+}
+.text-primary {
+  color: #2c3e50;
+}
+a.text-primary:hover,
+a.text-primary:focus {
+  color: #1a242f;
+}
+.text-success {
+  color: #ffffff;
+}
+a.text-success:hover,
+a.text-success:focus {
+  color: #e6e6e6;
+}
+.text-info {
+  color: #ffffff;
+}
+a.text-info:hover,
+a.text-info:focus {
+  color: #e6e6e6;
+}
+.text-warning {
+  color: #ffffff;
+}
+a.text-warning:hover,
+a.text-warning:focus {
+  color: #e6e6e6;
+}
+.text-danger {
+  color: #ffffff;
+}
+a.text-danger:hover,
+a.text-danger:focus {
+  color: #e6e6e6;
+}
+.bg-primary {
+  color: #fff;
+  background-color: #2c3e50;
+}
+a.bg-primary:hover,
+a.bg-primary:focus {
+  background-color: #1a242f;
+}
+.bg-success {
+  background-color: #18bc9c;
+}
+a.bg-success:hover,
+a.bg-success:focus {
+  background-color: #128f76;
+}
+.bg-info {
+  background-color: #3498db;
+}
+a.bg-info:hover,
+a.bg-info:focus {
+  background-color: #217dbb;
+}
+.bg-warning {
+  background-color: #f39c12;
+}
+a.bg-warning:hover,
+a.bg-warning:focus {
+  background-color: #c87f0a;
+}
+.bg-danger {
+  background-color: #e74c3c;
+}
+a.bg-danger:hover,
+a.bg-danger:focus {
+  background-color: #d62c1a;
+}
+.page-header {
+  padding-bottom: 9.5px;
+  margin: 42px 0 21px;
+  border-bottom: 1px solid transparent;
+}
+ul,
+ol {
+  margin-top: 0;
+  margin-bottom: 10.5px;
+}
+ul ul,
+ol ul,
+ul ol,
+ol ol {
+  margin-bottom: 0;
+}
+.list-unstyled {
+  padding-left: 0;
+  list-style: none;
+}
+.list-inline {
+  padding-left: 0;
+  list-style: none;
+  margin-left: -5px;
+}
+.list-inline > li {
+  display: inline-block;
+  padding-left: 5px;
+  padding-right: 5px;
+}
+dl {
+  margin-top: 0;
+  margin-bottom: 21px;
+}
+dt,
+dd {
+  line-height: 1.42857143;
+}
+dt {
+  font-weight: bold;
+}
+dd {
+  margin-left: 0;
+}
+@media (min-width: 768px) {
+  .dl-horizontal dt {
+    float: left;
+    width: 160px;
+    clear: left;
+    text-align: right;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .dl-horizontal dd {
+    margin-left: 180px;
+  }
+}
+abbr[title],
+abbr[data-original-title] {
+  cursor: help;
+  border-bottom: 1px dotted #b4bcc2;
+}
+.initialism {
+  font-size: 90%;
+  text-transform: uppercase;
+}
+blockquote {
+  padding: 10.5px 21px;
+  margin: 0 0 21px;
+  font-size: 18.75px;
+  border-left: 5px solid #ecf0f1;
+}
+blockquote p:last-child,
+blockquote ul:last-child,
+blockquote ol:last-child {
+  margin-bottom: 0;
+}
+blockquote footer,
+blockquote small,
+blockquote .small {
+  display: block;
+  font-size: 80%;
+  line-height: 1.42857143;
+  color: #b4bcc2;
+}
+blockquote footer:before,
+blockquote small:before,
+blockquote .small:before {
+  content: '\2014 \00A0';
+}
+.blockquote-reverse,
+blockquote.pull-right {
+  padding-right: 15px;
+  padding-left: 0;
+  border-right: 5px solid #ecf0f1;
+  border-left: 0;
+  text-align: right;
+}
+.blockquote-reverse footer:before,
+blockquote.pull-right footer:before,
+.blockquote-reverse small:before,
+blockquote.pull-right small:before,
+.blockquote-reverse .small:before,
+blockquote.pull-right .small:before {
+  content: '';
+}
+.blockquote-reverse footer:after,
+blockquote.pull-right footer:after,
+.blockquote-reverse small:after,
+blockquote.pull-right small:after,
+.blockquote-reverse .small:after,
+blockquote.pull-right .small:after {
+  content: '\00A0 \2014';
+}
+address {
+  margin-bottom: 21px;
+  font-style: normal;
+  line-height: 1.42857143;
+}
+code,
+kbd,
+pre,
+samp {
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+}
+code {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  border-radius: 4px;
+}
+kbd {
+  padding: 2px 4px;
+  font-size: 90%;
+  color: #ffffff;
+  background-color: #333333;
+  border-radius: 3px;
+  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+          box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.25);
+}
+kbd kbd {
+  padding: 0;
+  font-size: 100%;
+  font-weight: bold;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+}
+pre {
+  display: block;
+  padding: 10px;
+  margin: 0 0 10.5px;
+  font-size: 14px;
+  line-height: 1.42857143;
+  word-break: break-all;
+  word-wrap: break-word;
+  color: #7b8a8b;
+  background-color: #ecf0f1;
+  border: 1px solid #cccccc;
+  border-radius: 4px;
+}
+pre code {
+  padding: 0;
+  font-size: inherit;
+  color: inherit;
+  white-space: pre-wrap;
+  background-color: transparent;
+  border-radius: 0;
+}
+.pre-scrollable {
+  max-height: 340px;
+  overflow-y: scroll;
+}
+.container {
+  margin-right: auto;
+  margin-left: auto;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+@media (min-width: 768px) {
+  .container {
+    width: 750px;
+  }
+}
+@media (min-width: 992px) {
+  .container {
+    width: 970px;
+  }
+}
+@media (min-width: 1200px) {
+  .container {
+    width: 1170px;
+  }
+}
+.container-fluid {
+  margin-right: auto;
+  margin-left: auto;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.row {
+  margin-left: -15px;
+  margin-right: -15px;
+}
+.col-xs-1, .col-sm-1, .col-md-1, .col-lg-1, .col-xs-2, .col-sm-2, .col-md-2, .col-lg-2, .col-xs-3, .col-sm-3, .col-md-3, .col-lg-3, .col-xs-4, .col-sm-4, .col-md-4, .col-lg-4, .col-xs-5, .col-sm-5, .col-md-5, .col-lg-5, .col-xs-6, .col-sm-6, .col-md-6, .col-lg-6, .col-xs-7, .col-sm-7, .col-md-7, .col-lg-7, .col-xs-8, .col-sm-8, .col-md-8, .col-lg-8, .col-xs-9, .col-sm-9, .col-md-9, .col-lg-9, .col-xs-10, .col-sm-10, .col-md-10, .col-lg-10, .col-xs-11, .col-sm-11, .col-md-11, .col-lg-11, .col-xs-12, .col-sm-12, .col-md-12, .col-lg-12 {
+  position: relative;
+  min-height: 1px;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
+  float: left;
+}
+.col-xs-12 {
+  width: 100%;
+}
+.col-xs-11 {
+  width: 91.66666667%;
+}
+.col-xs-10 {
+  width: 83.33333333%;
+}
+.col-xs-9 {
+  width: 75%;
+}
+.col-xs-8 {
+  width: 66.66666667%;
+}
+.col-xs-7 {
+  width: 58.33333333%;
+}
+.col-xs-6 {
+  width: 50%;
+}
+.col-xs-5 {
+  width: 41.66666667%;
+}
+.col-xs-4 {
+  width: 33.33333333%;
+}
+.col-xs-3 {
+  width: 25%;
+}
+.col-xs-2 {
+  width: 16.66666667%;
+}
+.col-xs-1 {
+  width: 8.33333333%;
+}
+.col-xs-pull-12 {
+  right: 100%;
+}
+.col-xs-pull-11 {
+  right: 91.66666667%;
+}
+.col-xs-pull-10 {
+  right: 83.33333333%;
+}
+.col-xs-pull-9 {
+  right: 75%;
+}
+.col-xs-pull-8 {
+  right: 66.66666667%;
+}
+.col-xs-pull-7 {
+  right: 58.33333333%;
+}
+.col-xs-pull-6 {
+  right: 50%;
+}
+.col-xs-pull-5 {
+  right: 41.66666667%;
+}
+.col-xs-pull-4 {
+  right: 33.33333333%;
+}
+.col-xs-pull-3 {
+  right: 25%;
+}
+.col-xs-pull-2 {
+  right: 16.66666667%;
+}
+.col-xs-pull-1 {
+  right: 8.33333333%;
+}
+.col-xs-pull-0 {
+  right: auto;
+}
+.col-xs-push-12 {
+  left: 100%;
+}
+.col-xs-push-11 {
+  left: 91.66666667%;
+}
+.col-xs-push-10 {
+  left: 83.33333333%;
+}
+.col-xs-push-9 {
+  left: 75%;
+}
+.col-xs-push-8 {
+  left: 66.66666667%;
+}
+.col-xs-push-7 {
+  left: 58.33333333%;
+}
+.col-xs-push-6 {
+  left: 50%;
+}
+.col-xs-push-5 {
+  left: 41.66666667%;
+}
+.col-xs-push-4 {
+  left: 33.33333333%;
+}
+.col-xs-push-3 {
+  left: 25%;
+}
+.col-xs-push-2 {
+  left: 16.66666667%;
+}
+.col-xs-push-1 {
+  left: 8.33333333%;
+}
+.col-xs-push-0 {
+  left: auto;
+}
+.col-xs-offset-12 {
+  margin-left: 100%;
+}
+.col-xs-offset-11 {
+  margin-left: 91.66666667%;
+}
+.col-xs-offset-10 {
+  margin-left: 83.33333333%;
+}
+.col-xs-offset-9 {
+  margin-left: 75%;
+}
+.col-xs-offset-8 {
+  margin-left: 66.66666667%;
+}
+.col-xs-offset-7 {
+  margin-left: 58.33333333%;
+}
+.col-xs-offset-6 {
+  margin-left: 50%;
+}
+.col-xs-offset-5 {
+  margin-left: 41.66666667%;
+}
+.col-xs-offset-4 {
+  margin-left: 33.33333333%;
+}
+.col-xs-offset-3 {
+  margin-left: 25%;
+}
+.col-xs-offset-2 {
+  margin-left: 16.66666667%;
+}
+.col-xs-offset-1 {
+  margin-left: 8.33333333%;
+}
+.col-xs-offset-0 {
+  margin-left: 0%;
+}
+@media (min-width: 768px) {
+  .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {
+    float: left;
+  }
+  .col-sm-12 {
+    width: 100%;
+  }
+  .col-sm-11 {
+    width: 91.66666667%;
+  }
+  .col-sm-10 {
+    width: 83.33333333%;
+  }
+  .col-sm-9 {
+    width: 75%;
+  }
+  .col-sm-8 {
+    width: 66.66666667%;
+  }
+  .col-sm-7 {
+    width: 58.33333333%;
+  }
+  .col-sm-6 {
+    width: 50%;
+  }
+  .col-sm-5 {
+    width: 41.66666667%;
+  }
+  .col-sm-4 {
+    width: 33.33333333%;
+  }
+  .col-sm-3 {
+    width: 25%;
+  }
+  .col-sm-2 {
+    width: 16.66666667%;
+  }
+  .col-sm-1 {
+    width: 8.33333333%;
+  }
+  .col-sm-pull-12 {
+    right: 100%;
+  }
+  .col-sm-pull-11 {
+    right: 91.66666667%;
+  }
+  .col-sm-pull-10 {
+    right: 83.33333333%;
+  }
+  .col-sm-pull-9 {
+    right: 75%;
+  }
+  .col-sm-pull-8 {
+    right: 66.66666667%;
+  }
+  .col-sm-pull-7 {
+    right: 58.33333333%;
+  }
+  .col-sm-pull-6 {
+    right: 50%;
+  }
+  .col-sm-pull-5 {
+    right: 41.66666667%;
+  }
+  .col-sm-pull-4 {
+    right: 33.33333333%;
+  }
+  .col-sm-pull-3 {
+    right: 25%;
+  }
+  .col-sm-pull-2 {
+    right: 16.66666667%;
+  }
+  .col-sm-pull-1 {
+    right: 8.33333333%;
+  }
+  .col-sm-pull-0 {
+    right: auto;
+  }
+  .col-sm-push-12 {
+    left: 100%;
+  }
+  .col-sm-push-11 {
+    left: 91.66666667%;
+  }
+  .col-sm-push-10 {
+    left: 83.33333333%;
+  }
+  .col-sm-push-9 {
+    left: 75%;
+  }
+  .col-sm-push-8 {
+    left: 66.66666667%;
+  }
+  .col-sm-push-7 {
+    left: 58.33333333%;
+  }
+  .col-sm-push-6 {
+    left: 50%;
+  }
+  .col-sm-push-5 {
+    left: 41.66666667%;
+  }
+  .col-sm-push-4 {
+    left: 33.33333333%;
+  }
+  .col-sm-push-3 {
+    left: 25%;
+  }
+  .col-sm-push-2 {
+    left: 16.66666667%;
+  }
+  .col-sm-push-1 {
+    left: 8.33333333%;
+  }
+  .col-sm-push-0 {
+    left: auto;
+  }
+  .col-sm-offset-12 {
+    margin-left: 100%;
+  }
+  .col-sm-offset-11 {
+    margin-left: 91.66666667%;
+  }
+  .col-sm-offset-10 {
+    margin-left: 83.33333333%;
+  }
+  .col-sm-offset-9 {
+    margin-left: 75%;
+  }
+  .col-sm-offset-8 {
+    margin-left: 66.66666667%;
+  }
+  .col-sm-offset-7 {
+    margin-left: 58.33333333%;
+  }
+  .col-sm-offset-6 {
+    margin-left: 50%;
+  }
+  .col-sm-offset-5 {
+    margin-left: 41.66666667%;
+  }
+  .col-sm-offset-4 {
+    margin-left: 33.33333333%;
+  }
+  .col-sm-offset-3 {
+    margin-left: 25%;
+  }
+  .col-sm-offset-2 {
+    margin-left: 16.66666667%;
+  }
+  .col-sm-offset-1 {
+    margin-left: 8.33333333%;
+  }
+  .col-sm-offset-0 {
+    margin-left: 0%;
+  }
+}
+@media (min-width: 992px) {
+  .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12 {
+    float: left;
+  }
+  .col-md-12 {
+    width: 100%;
+  }
+  .col-md-11 {
+    width: 91.66666667%;
+  }
+  .col-md-10 {
+    width: 83.33333333%;
+  }
+  .col-md-9 {
+    width: 75%;
+  }
+  .col-md-8 {
+    width: 66.66666667%;
+  }
+  .col-md-7 {
+    width: 58.33333333%;
+  }
+  .col-md-6 {
+    width: 50%;
+  }
+  .col-md-5 {
+    width: 41.66666667%;
+  }
+  .col-md-4 {
+    width: 33.33333333%;
+  }
+  .col-md-3 {
+    width: 25%;
+  }
+  .col-md-2 {
+    width: 16.66666667%;
+  }
+  .col-md-1 {
+    width: 8.33333333%;
+  }
+  .col-md-pull-12 {
+    right: 100%;
+  }
+  .col-md-pull-11 {
+    right: 91.66666667%;
+  }
+  .col-md-pull-10 {
+    right: 83.33333333%;
+  }
+  .col-md-pull-9 {
+    right: 75%;
+  }
+  .col-md-pull-8 {
+    right: 66.66666667%;
+  }
+  .col-md-pull-7 {
+    right: 58.33333333%;
+  }
+  .col-md-pull-6 {
+    right: 50%;
+  }
+  .col-md-pull-5 {
+    right: 41.66666667%;
+  }
+  .col-md-pull-4 {
+    right: 33.33333333%;
+  }
+  .col-md-pull-3 {
+    right: 25%;
+  }
+  .col-md-pull-2 {
+    right: 16.66666667%;
+  }
+  .col-md-pull-1 {
+    right: 8.33333333%;
+  }
+  .col-md-pull-0 {
+    right: auto;
+  }
+  .col-md-push-12 {
+    left: 100%;
+  }
+  .col-md-push-11 {
+    left: 91.66666667%;
+  }
+  .col-md-push-10 {
+    left: 83.33333333%;
+  }
+  .col-md-push-9 {
+    left: 75%;
+  }
+  .col-md-push-8 {
+    left: 66.66666667%;
+  }
+  .col-md-push-7 {
+    left: 58.33333333%;
+  }
+  .col-md-push-6 {
+    left: 50%;
+  }
+  .col-md-push-5 {
+    left: 41.66666667%;
+  }
+  .col-md-push-4 {
+    left: 33.33333333%;
+  }
+  .col-md-push-3 {
+    left: 25%;
+  }
+  .col-md-push-2 {
+    left: 16.66666667%;
+  }
+  .col-md-push-1 {
+    left: 8.33333333%;
+  }
+  .col-md-push-0 {
+    left: auto;
+  }
+  .col-md-offset-12 {
+    margin-left: 100%;
+  }
+  .col-md-offset-11 {
+    margin-left: 91.66666667%;
+  }
+  .col-md-offset-10 {
+    margin-left: 83.33333333%;
+  }
+  .col-md-offset-9 {
+    margin-left: 75%;
+  }
+  .col-md-offset-8 {
+    margin-left: 66.66666667%;
+  }
+  .col-md-offset-7 {
+    margin-left: 58.33333333%;
+  }
+  .col-md-offset-6 {
+    margin-left: 50%;
+  }
+  .col-md-offset-5 {
+    margin-left: 41.66666667%;
+  }
+  .col-md-offset-4 {
+    margin-left: 33.33333333%;
+  }
+  .col-md-offset-3 {
+    margin-left: 25%;
+  }
+  .col-md-offset-2 {
+    margin-left: 16.66666667%;
+  }
+  .col-md-offset-1 {
+    margin-left: 8.33333333%;
+  }
+  .col-md-offset-0 {
+    margin-left: 0%;
+  }
+}
+@media (min-width: 1200px) {
+  .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12 {
+    float: left;
+  }
+  .col-lg-12 {
+    width: 100%;
+  }
+  .col-lg-11 {
+    width: 91.66666667%;
+  }
+  .col-lg-10 {
+    width: 83.33333333%;
+  }
+  .col-lg-9 {
+    width: 75%;
+  }
+  .col-lg-8 {
+    width: 66.66666667%;
+  }
+  .col-lg-7 {
+    width: 58.33333333%;
+  }
+  .col-lg-6 {
+    width: 50%;
+  }
+  .col-lg-5 {
+    width: 41.66666667%;
+  }
+  .col-lg-4 {
+    width: 33.33333333%;
+  }
+  .col-lg-3 {
+    width: 25%;
+  }
+  .col-lg-2 {
+    width: 16.66666667%;
+  }
+  .col-lg-1 {
+    width: 8.33333333%;
+  }
+  .col-lg-pull-12 {
+    right: 100%;
+  }
+  .col-lg-pull-11 {
+    right: 91.66666667%;
+  }
+  .col-lg-pull-10 {
+    right: 83.33333333%;
+  }
+  .col-lg-pull-9 {
+    right: 75%;
+  }
+  .col-lg-pull-8 {
+    right: 66.66666667%;
+  }
+  .col-lg-pull-7 {
+    right: 58.33333333%;
+  }
+  .col-lg-pull-6 {
+    right: 50%;
+  }
+  .col-lg-pull-5 {
+    right: 41.66666667%;
+  }
+  .col-lg-pull-4 {
+    right: 33.33333333%;
+  }
+  .col-lg-pull-3 {
+    right: 25%;
+  }
+  .col-lg-pull-2 {
+    right: 16.66666667%;
+  }
+  .col-lg-pull-1 {
+    right: 8.33333333%;
+  }
+  .col-lg-pull-0 {
+    right: auto;
+  }
+  .col-lg-push-12 {
+    left: 100%;
+  }
+  .col-lg-push-11 {
+    left: 91.66666667%;
+  }
+  .col-lg-push-10 {
+    left: 83.33333333%;
+  }
+  .col-lg-push-9 {
+    left: 75%;
+  }
+  .col-lg-push-8 {
+    left: 66.66666667%;
+  }
+  .col-lg-push-7 {
+    left: 58.33333333%;
+  }
+  .col-lg-push-6 {
+    left: 50%;
+  }
+  .col-lg-push-5 {
+    left: 41.66666667%;
+  }
+  .col-lg-push-4 {
+    left: 33.33333333%;
+  }
+  .col-lg-push-3 {
+    left: 25%;
+  }
+  .col-lg-push-2 {
+    left: 16.66666667%;
+  }
+  .col-lg-push-1 {
+    left: 8.33333333%;
+  }
+  .col-lg-push-0 {
+    left: auto;
+  }
+  .col-lg-offset-12 {
+    margin-left: 100%;
+  }
+  .col-lg-offset-11 {
+    margin-left: 91.66666667%;
+  }
+  .col-lg-offset-10 {
+    margin-left: 83.33333333%;
+  }
+  .col-lg-offset-9 {
+    margin-left: 75%;
+  }
+  .col-lg-offset-8 {
+    margin-left: 66.66666667%;
+  }
+  .col-lg-offset-7 {
+    margin-left: 58.33333333%;
+  }
+  .col-lg-offset-6 {
+    margin-left: 50%;
+  }
+  .col-lg-offset-5 {
+    margin-left: 41.66666667%;
+  }
+  .col-lg-offset-4 {
+    margin-left: 33.33333333%;
+  }
+  .col-lg-offset-3 {
+    margin-left: 25%;
+  }
+  .col-lg-offset-2 {
+    margin-left: 16.66666667%;
+  }
+  .col-lg-offset-1 {
+    margin-left: 8.33333333%;
+  }
+  .col-lg-offset-0 {
+    margin-left: 0%;
+  }
+}
+table {
+  background-color: transparent;
+}
+caption {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  color: #b4bcc2;
+  text-align: left;
+}
+th {
+  text-align: left;
+}
+.table {
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: 21px;
+}
+.table > thead > tr > th,
+.table > tbody > tr > th,
+.table > tfoot > tr > th,
+.table > thead > tr > td,
+.table > tbody > tr > td,
+.table > tfoot > tr > td {
+  padding: 8px;
+  line-height: 1.42857143;
+  vertical-align: top;
+  border-top: 1px solid #ecf0f1;
+}
+.table > thead > tr > th {
+  vertical-align: bottom;
+  border-bottom: 2px solid #ecf0f1;
+}
+.table > caption + thead > tr:first-child > th,
+.table > colgroup + thead > tr:first-child > th,
+.table > thead:first-child > tr:first-child > th,
+.table > caption + thead > tr:first-child > td,
+.table > colgroup + thead > tr:first-child > td,
+.table > thead:first-child > tr:first-child > td {
+  border-top: 0;
+}
+.table > tbody + tbody {
+  border-top: 2px solid #ecf0f1;
+}
+.table .table {
+  background-color: #ffffff;
+}
+.table-condensed > thead > tr > th,
+.table-condensed > tbody > tr > th,
+.table-condensed > tfoot > tr > th,
+.table-condensed > thead > tr > td,
+.table-condensed > tbody > tr > td,
+.table-condensed > tfoot > tr > td {
+  padding: 5px;
+}
+.table-bordered {
+  border: 1px solid #ecf0f1;
+}
+.table-bordered > thead > tr > th,
+.table-bordered > tbody > tr > th,
+.table-bordered > tfoot > tr > th,
+.table-bordered > thead > tr > td,
+.table-bordered > tbody > tr > td,
+.table-bordered > tfoot > tr > td {
+  border: 1px solid #ecf0f1;
+}
+.table-bordered > thead > tr > th,
+.table-bordered > thead > tr > td {
+  border-bottom-width: 2px;
+}
+.table-striped > tbody > tr:nth-of-type(odd) {
+  background-color: #f9f9f9;
+}
+.table-hover > tbody > tr:hover {
+  background-color: #ecf0f1;
+}
+table col[class*="col-"] {
+  position: static;
+  float: none;
+  display: table-column;
+}
+table td[class*="col-"],
+table th[class*="col-"] {
+  position: static;
+  float: none;
+  display: table-cell;
+}
+.table > thead > tr > td.active,
+.table > tbody > tr > td.active,
+.table > tfoot > tr > td.active,
+.table > thead > tr > th.active,
+.table > tbody > tr > th.active,
+.table > tfoot > tr > th.active,
+.table > thead > tr.active > td,
+.table > tbody > tr.active > td,
+.table > tfoot > tr.active > td,
+.table > thead > tr.active > th,
+.table > tbody > tr.active > th,
+.table > tfoot > tr.active > th {
+  background-color: #ecf0f1;
+}
+.table-hover > tbody > tr > td.active:hover,
+.table-hover > tbody > tr > th.active:hover,
+.table-hover > tbody > tr.active:hover > td,
+.table-hover > tbody > tr:hover > .active,
+.table-hover > tbody > tr.active:hover > th {
+  background-color: #dde4e6;
+}
+.table > thead > tr > td.success,
+.table > tbody > tr > td.success,
+.table > tfoot > tr > td.success,
+.table > thead > tr > th.success,
+.table > tbody > tr > th.success,
+.table > tfoot > tr > th.success,
+.table > thead > tr.success > td,
+.table > tbody > tr.success > td,
+.table > tfoot > tr.success > td,
+.table > thead > tr.success > th,
+.table > tbody > tr.success > th,
+.table > tfoot > tr.success > th {
+  background-color: #18bc9c;
+}
+.table-hover > tbody > tr > td.success:hover,
+.table-hover > tbody > tr > th.success:hover,
+.table-hover > tbody > tr.success:hover > td,
+.table-hover > tbody > tr:hover > .success,
+.table-hover > tbody > tr.success:hover > th {
+  background-color: #15a589;
+}
+.table > thead > tr > td.info,
+.table > tbody > tr > td.info,
+.table > tfoot > tr > td.info,
+.table > thead > tr > th.info,
+.table > tbody > tr > th.info,
+.table > tfoot > tr > th.info,
+.table > thead > tr.info > td,
+.table > tbody > tr.info > td,
+.table > tfoot > tr.info > td,
+.table > thead > tr.info > th,
+.table > tbody > tr.info > th,
+.table > tfoot > tr.info > th {
+  background-color: #3498db;
+}
+.table-hover > tbody > tr > td.info:hover,
+.table-hover > tbody > tr > th.info:hover,
+.table-hover > tbody > tr.info:hover > td,
+.table-hover > tbody > tr:hover > .info,
+.table-hover > tbody > tr.info:hover > th {
+  background-color: #258cd1;
+}
+.table > thead > tr > td.warning,
+.table > tbody > tr > td.warning,
+.table > tfoot > tr > td.warning,
+.table > thead > tr > th.warning,
+.table > tbody > tr > th.warning,
+.table > tfoot > tr > th.warning,
+.table > thead > tr.warning > td,
+.table > tbody > tr.warning > td,
+.table > tfoot > tr.warning > td,
+.table > thead > tr.warning > th,
+.table > tbody > tr.warning > th,
+.table > tfoot > tr.warning > th {
+  background-color: #f39c12;
+}
+.table-hover > tbody > tr > td.warning:hover,
+.table-hover > tbody > tr > th.warning:hover,
+.table-hover > tbody > tr.warning:hover > td,
+.table-hover > tbody > tr:hover > .warning,
+.table-hover > tbody > tr.warning:hover > th {
+  background-color: #e08e0b;
+}
+.table > thead > tr > td.danger,
+.table > tbody > tr > td.danger,
+.table > tfoot > tr > td.danger,
+.table > thead > tr > th.danger,
+.table > tbody > tr > th.danger,
+.table > tfoot > tr > th.danger,
+.table > thead > tr.danger > td,
+.table > tbody > tr.danger > td,
+.table > tfoot > tr.danger > td,
+.table > thead > tr.danger > th,
+.table > tbody > tr.danger > th,
+.table > tfoot > tr.danger > th {
+  background-color: #e74c3c;
+}
+.table-hover > tbody > tr > td.danger:hover,
+.table-hover > tbody > tr > th.danger:hover,
+.table-hover > tbody > tr.danger:hover > td,
+.table-hover > tbody > tr:hover > .danger,
+.table-hover > tbody > tr.danger:hover > th {
+  background-color: #e43725;
+}
+.table-responsive {
+  overflow-x: auto;
+  min-height: 0.01%;
+}
+@media screen and (max-width: 767px) {
+  .table-responsive {
+    width: 100%;
+    margin-bottom: 15.75px;
+    overflow-y: hidden;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    border: 1px solid #ecf0f1;
+  }
+  .table-responsive > .table {
+    margin-bottom: 0;
+  }
+  .table-responsive > .table > thead > tr > th,
+  .table-responsive > .table > tbody > tr > th,
+  .table-responsive > .table > tfoot > tr > th,
+  .table-responsive > .table > thead > tr > td,
+  .table-responsive > .table > tbody > tr > td,
+  .table-responsive > .table > tfoot > tr > td {
+    white-space: nowrap;
+  }
+  .table-responsive > .table-bordered {
+    border: 0;
+  }
+  .table-responsive > .table-bordered > thead > tr > th:first-child,
+  .table-responsive > .table-bordered > tbody > tr > th:first-child,
+  .table-responsive > .table-bordered > tfoot > tr > th:first-child,
+  .table-responsive > .table-bordered > thead > tr > td:first-child,
+  .table-responsive > .table-bordered > tbody > tr > td:first-child,
+  .table-responsive > .table-bordered > tfoot > tr > td:first-child {
+    border-left: 0;
+  }
+  .table-responsive > .table-bordered > thead > tr > th:last-child,
+  .table-responsive > .table-bordered > tbody > tr > th:last-child,
+  .table-responsive > .table-bordered > tfoot > tr > th:last-child,
+  .table-responsive > .table-bordered > thead > tr > td:last-child,
+  .table-responsive > .table-bordered > tbody > tr > td:last-child,
+  .table-responsive > .table-bordered > tfoot > tr > td:last-child {
+    border-right: 0;
+  }
+  .table-responsive > .table-bordered > tbody > tr:last-child > th,
+  .table-responsive > .table-bordered > tfoot > tr:last-child > th,
+  .table-responsive > .table-bordered > tbody > tr:last-child > td,
+  .table-responsive > .table-bordered > tfoot > tr:last-child > td {
+    border-bottom: 0;
+  }
+}
+fieldset {
+  padding: 0;
+  margin: 0;
+  border: 0;
+  min-width: 0;
+}
+legend {
+  display: block;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 21px;
+  font-size: 22.5px;
+  line-height: inherit;
+  color: #2c3e50;
+  border: 0;
+  border-bottom: 1px solid transparent;
+}
+label {
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 5px;
+  font-weight: bold;
+}
+input[type="search"] {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+input[type="radio"],
+input[type="checkbox"] {
+  margin: 4px 0 0;
+  margin-top: 1px \9;
+  line-height: normal;
+}
+input[type="file"] {
+  display: block;
+}
+input[type="range"] {
+  display: block;
+  width: 100%;
+}
+select[multiple],
+select[size] {
+  height: auto;
+}
+input[type="file"]:focus,
+input[type="radio"]:focus,
+input[type="checkbox"]:focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+output {
+  display: block;
+  padding-top: 11px;
+  font-size: 15px;
+  line-height: 1.42857143;
+  color: #2c3e50;
+}
+.form-control {
+  display: block;
+  width: 100%;
+  height: 45px;
+  padding: 10px 15px;
+  font-size: 15px;
+  line-height: 1.42857143;
+  color: #2c3e50;
+  background-color: #ffffff;
+  background-image: none;
+  border: 1px solid #dce4ec;
+  border-radius: 4px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s;
+  -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+}
+.form-control:focus {
+  border-color: #2c3e50;
+  outline: 0;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(44, 62, 80, 0.6);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(44, 62, 80, 0.6);
+}
+.form-control::-moz-placeholder {
+  color: #acb6c0;
+  opacity: 1;
+}
+.form-control:-ms-input-placeholder {
+  color: #acb6c0;
+}
+.form-control::-webkit-input-placeholder {
+  color: #acb6c0;
+}
+.form-control::-ms-expand {
+  border: 0;
+  background-color: transparent;
+}
+.form-control[disabled],
+.form-control[readonly],
+fieldset[disabled] .form-control {
+  background-color: #ecf0f1;
+  opacity: 1;
+}
+.form-control[disabled],
+fieldset[disabled] .form-control {
+  cursor: not-allowed;
+}
+textarea.form-control {
+  height: auto;
+}
+input[type="search"] {
+  -webkit-appearance: none;
+}
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  input[type="date"].form-control,
+  input[type="time"].form-control,
+  input[type="datetime-local"].form-control,
+  input[type="month"].form-control {
+    line-height: 45px;
+  }
+  input[type="date"].input-sm,
+  input[type="time"].input-sm,
+  input[type="datetime-local"].input-sm,
+  input[type="month"].input-sm,
+  .input-group-sm input[type="date"],
+  .input-group-sm input[type="time"],
+  .input-group-sm input[type="datetime-local"],
+  .input-group-sm input[type="month"] {
+    line-height: 35px;
+  }
+  input[type="date"].input-lg,
+  input[type="time"].input-lg,
+  input[type="datetime-local"].input-lg,
+  input[type="month"].input-lg,
+  .input-group-lg input[type="date"],
+  .input-group-lg input[type="time"],
+  .input-group-lg input[type="datetime-local"],
+  .input-group-lg input[type="month"] {
+    line-height: 66px;
+  }
+}
+.form-group {
+  margin-bottom: 15px;
+}
+.radio,
+.checkbox {
+  position: relative;
+  display: block;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+.radio label,
+.checkbox label {
+  min-height: 21px;
+  padding-left: 20px;
+  margin-bottom: 0;
+  font-weight: normal;
+  cursor: pointer;
+}
+.radio input[type="radio"],
+.radio-inline input[type="radio"],
+.checkbox input[type="checkbox"],
+.checkbox-inline input[type="checkbox"] {
+  position: absolute;
+  margin-left: -20px;
+  margin-top: 4px \9;
+}
+.radio + .radio,
+.checkbox + .checkbox {
+  margin-top: -5px;
+}
+.radio-inline,
+.checkbox-inline {
+  position: relative;
+  display: inline-block;
+  padding-left: 20px;
+  margin-bottom: 0;
+  vertical-align: middle;
+  font-weight: normal;
+  cursor: pointer;
+}
+.radio-inline + .radio-inline,
+.checkbox-inline + .checkbox-inline {
+  margin-top: 0;
+  margin-left: 10px;
+}
+input[type="radio"][disabled],
+input[type="checkbox"][disabled],
+input[type="radio"].disabled,
+input[type="checkbox"].disabled,
+fieldset[disabled] input[type="radio"],
+fieldset[disabled] input[type="checkbox"] {
+  cursor: not-allowed;
+}
+.radio-inline.disabled,
+.checkbox-inline.disabled,
+fieldset[disabled] .radio-inline,
+fieldset[disabled] .checkbox-inline {
+  cursor: not-allowed;
+}
+.radio.disabled label,
+.checkbox.disabled label,
+fieldset[disabled] .radio label,
+fieldset[disabled] .checkbox label {
+  cursor: not-allowed;
+}
+.form-control-static {
+  padding-top: 11px;
+  padding-bottom: 11px;
+  margin-bottom: 0;
+  min-height: 36px;
+}
+.form-control-static.input-lg,
+.form-control-static.input-sm {
+  padding-left: 0;
+  padding-right: 0;
+}
+.input-sm {
+  height: 35px;
+  padding: 6px 9px;
+  font-size: 13px;
+  line-height: 1.5;
+  border-radius: 3px;
+}
+select.input-sm {
+  height: 35px;
+  line-height: 35px;
+}
+textarea.input-sm,
+select[multiple].input-sm {
+  height: auto;
+}
+.form-group-sm .form-control {
+  height: 35px;
+  padding: 6px 9px;
+  font-size: 13px;
+  line-height: 1.5;
+  border-radius: 3px;
+}
+.form-group-sm select.form-control {
+  height: 35px;
+  line-height: 35px;
+}
+.form-group-sm textarea.form-control,
+.form-group-sm select[multiple].form-control {
+  height: auto;
+}
+.form-group-sm .form-control-static {
+  height: 35px;
+  min-height: 34px;
+  padding: 7px 9px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.input-lg {
+  height: 66px;
+  padding: 18px 27px;
+  font-size: 19px;
+  line-height: 1.3333333;
+  border-radius: 6px;
+}
+select.input-lg {
+  height: 66px;
+  line-height: 66px;
+}
+textarea.input-lg,
+select[multiple].input-lg {
+  height: auto;
+}
+.form-group-lg .form-control {
+  height: 66px;
+  padding: 18px 27px;
+  font-size: 19px;
+  line-height: 1.3333333;
+  border-radius: 6px;
+}
+.form-group-lg select.form-control {
+  height: 66px;
+  line-height: 66px;
+}
+.form-group-lg textarea.form-control,
+.form-group-lg select[multiple].form-control {
+  height: auto;
+}
+.form-group-lg .form-control-static {
+  height: 66px;
+  min-height: 40px;
+  padding: 19px 27px;
+  font-size: 19px;
+  line-height: 1.3333333;
+}
+.has-feedback {
+  position: relative;
+}
+.has-feedback .form-control {
+  padding-right: 56.25px;
+}
+.form-control-feedback {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+  display: block;
+  width: 45px;
+  height: 45px;
+  line-height: 45px;
+  text-align: center;
+  pointer-events: none;
+}
+.input-lg + .form-control-feedback,
+.input-group-lg + .form-control-feedback,
+.form-group-lg .form-control + .form-control-feedback {
+  width: 66px;
+  height: 66px;
+  line-height: 66px;
+}
+.input-sm + .form-control-feedback,
+.input-group-sm + .form-control-feedback,
+.form-group-sm .form-control + .form-control-feedback {
+  width: 35px;
+  height: 35px;
+  line-height: 35px;
+}
+.has-success .help-block,
+.has-success .control-label,
+.has-success .radio,
+.has-success .checkbox,
+.has-success .radio-inline,
+.has-success .checkbox-inline,
+.has-success.radio label,
+.has-success.checkbox label,
+.has-success.radio-inline label,
+.has-success.checkbox-inline label {
+  color: #ffffff;
+}
+.has-success .form-control {
+  border-color: #ffffff;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-success .form-control:focus {
+  border-color: #e6e6e6;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ffffff;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ffffff;
+}
+.has-success .input-group-addon {
+  color: #ffffff;
+  border-color: #ffffff;
+  background-color: #18bc9c;
+}
+.has-success .form-control-feedback {
+  color: #ffffff;
+}
+.has-warning .help-block,
+.has-warning .control-label,
+.has-warning .radio,
+.has-warning .checkbox,
+.has-warning .radio-inline,
+.has-warning .checkbox-inline,
+.has-warning.radio label,
+.has-warning.checkbox label,
+.has-warning.radio-inline label,
+.has-warning.checkbox-inline label {
+  color: #ffffff;
+}
+.has-warning .form-control {
+  border-color: #ffffff;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-warning .form-control:focus {
+  border-color: #e6e6e6;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ffffff;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ffffff;
+}
+.has-warning .input-group-addon {
+  color: #ffffff;
+  border-color: #ffffff;
+  background-color: #f39c12;
+}
+.has-warning .form-control-feedback {
+  color: #ffffff;
+}
+.has-error .help-block,
+.has-error .control-label,
+.has-error .radio,
+.has-error .checkbox,
+.has-error .radio-inline,
+.has-error .checkbox-inline,
+.has-error.radio label,
+.has-error.checkbox label,
+.has-error.radio-inline label,
+.has-error.checkbox-inline label {
+  color: #ffffff;
+}
+.has-error .form-control {
+  border-color: #ffffff;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.has-error .form-control:focus {
+  border-color: #e6e6e6;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ffffff;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 6px #ffffff;
+}
+.has-error .input-group-addon {
+  color: #ffffff;
+  border-color: #ffffff;
+  background-color: #e74c3c;
+}
+.has-error .form-control-feedback {
+  color: #ffffff;
+}
+.has-feedback label ~ .form-control-feedback {
+  top: 26px;
+}
+.has-feedback label.sr-only ~ .form-control-feedback {
+  top: 0;
+}
+.help-block {
+  display: block;
+  margin-top: 5px;
+  margin-bottom: 10px;
+  color: #597ea2;
+}
+@media (min-width: 768px) {
+  .form-inline .form-group {
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .form-inline .form-control {
+    display: inline-block;
+    width: auto;
+    vertical-align: middle;
+  }
+  .form-inline .form-control-static {
+    display: inline-block;
+  }
+  .form-inline .input-group {
+    display: inline-table;
+    vertical-align: middle;
+  }
+  .form-inline .input-group .input-group-addon,
+  .form-inline .input-group .input-group-btn,
+  .form-inline .input-group .form-control {
+    width: auto;
+  }
+  .form-inline .input-group > .form-control {
+    width: 100%;
+  }
+  .form-inline .control-label {
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .form-inline .radio,
+  .form-inline .checkbox {
+    display: inline-block;
+    margin-top: 0;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .form-inline .radio label,
+  .form-inline .checkbox label {
+    padding-left: 0;
+  }
+  .form-inline .radio input[type="radio"],
+  .form-inline .checkbox input[type="checkbox"] {
+    position: relative;
+    margin-left: 0;
+  }
+  .form-inline .has-feedback .form-control-feedback {
+    top: 0;
+  }
+}
+.form-horizontal .radio,
+.form-horizontal .checkbox,
+.form-horizontal .radio-inline,
+.form-horizontal .checkbox-inline {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 11px;
+}
+.form-horizontal .radio,
+.form-horizontal .checkbox {
+  min-height: 32px;
+}
+.form-horizontal .form-group {
+  margin-left: -15px;
+  margin-right: -15px;
+}
+@media (min-width: 768px) {
+  .form-horizontal .control-label {
+    text-align: right;
+    margin-bottom: 0;
+    padding-top: 11px;
+  }
+}
+.form-horizontal .has-feedback .form-control-feedback {
+  right: 15px;
+}
+@media (min-width: 768px) {
+  .form-horizontal .form-group-lg .control-label {
+    padding-top: 19px;
+    font-size: 19px;
+  }
+}
+@media (min-width: 768px) {
+  .form-horizontal .form-group-sm .control-label {
+    padding-top: 7px;
+    font-size: 13px;
+  }
+}
+.btn {
+  display: inline-block;
+  margin-bottom: 0;
+  font-weight: normal;
+  text-align: center;
+  vertical-align: middle;
+  -ms-touch-action: manipulation;
+      touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 10px 15px;
+  font-size: 15px;
+  line-height: 1.42857143;
+  border-radius: 4px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+.btn:focus,
+.btn:active:focus,
+.btn.active:focus,
+.btn.focus,
+.btn:active.focus,
+.btn.active.focus {
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+.btn:hover,
+.btn:focus,
+.btn.focus {
+  color: #ffffff;
+  text-decoration: none;
+}
+.btn:active,
+.btn.active {
+  outline: 0;
+  background-image: none;
+  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+}
+.btn.disabled,
+.btn[disabled],
+fieldset[disabled] .btn {
+  cursor: not-allowed;
+  opacity: 0.65;
+  filter: alpha(opacity=65);
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+a.btn.disabled,
+fieldset[disabled] a.btn {
+  pointer-events: none;
+}
+.btn-default {
+  color: #ffffff;
+  background-color: #95a5a6;
+  border-color: #95a5a6;
+}
+.btn-default:focus,
+.btn-default.focus {
+  color: #ffffff;
+  background-color: #798d8f;
+  border-color: #566566;
+}
+.btn-default:hover {
+  color: #ffffff;
+  background-color: #798d8f;
+  border-color: #74898a;
+}
+.btn-default:active,
+.btn-default.active,
+.open > .dropdown-toggle.btn-default {
+  color: #ffffff;
+  background-color: #798d8f;
+  border-color: #74898a;
+}
+.btn-default:active:hover,
+.btn-default.active:hover,
+.open > .dropdown-toggle.btn-default:hover,
+.btn-default:active:focus,
+.btn-default.active:focus,
+.open > .dropdown-toggle.btn-default:focus,
+.btn-default:active.focus,
+.btn-default.active.focus,
+.open > .dropdown-toggle.btn-default.focus {
+  color: #ffffff;
+  background-color: #687b7c;
+  border-color: #566566;
+}
+.btn-default:active,
+.btn-default.active,
+.open > .dropdown-toggle.btn-default {
+  background-image: none;
+}
+.btn-default.disabled:hover,
+.btn-default[disabled]:hover,
+fieldset[disabled] .btn-default:hover,
+.btn-default.disabled:focus,
+.btn-default[disabled]:focus,
+fieldset[disabled] .btn-default:focus,
+.btn-default.disabled.focus,
+.btn-default[disabled].focus,
+fieldset[disabled] .btn-default.focus {
+  background-color: #95a5a6;
+  border-color: #95a5a6;
+}
+.btn-default .badge {
+  color: #95a5a6;
+  background-color: #ffffff;
+}
+.btn-primary {
+  color: #ffffff;
+  background-color: #2c3e50;
+  border-color: #2c3e50;
+}
+.btn-primary:focus,
+.btn-primary.focus {
+  color: #ffffff;
+  background-color: #1a242f;
+  border-color: #000000;
+}
+.btn-primary:hover {
+  color: #ffffff;
+  background-color: #1a242f;
+  border-color: #161f29;
+}
+.btn-primary:active,
+.btn-primary.active,
+.open > .dropdown-toggle.btn-primary {
+  color: #ffffff;
+  background-color: #1a242f;
+  border-color: #161f29;
+}
+.btn-primary:active:hover,
+.btn-primary.active:hover,
+.open > .dropdown-toggle.btn-primary:hover,
+.btn-primary:active:focus,
+.btn-primary.active:focus,
+.open > .dropdown-toggle.btn-primary:focus,
+.btn-primary:active.focus,
+.btn-primary.active.focus,
+.open > .dropdown-toggle.btn-primary.focus {
+  color: #ffffff;
+  background-color: #0d1318;
+  border-color: #000000;
+}
+.btn-primary:active,
+.btn-primary.active,
+.open > .dropdown-toggle.btn-primary {
+  background-image: none;
+}
+.btn-primary.disabled:hover,
+.btn-primary[disabled]:hover,
+fieldset[disabled] .btn-primary:hover,
+.btn-primary.disabled:focus,
+.btn-primary[disabled]:focus,
+fieldset[disabled] .btn-primary:focus,
+.btn-primary.disabled.focus,
+.btn-primary[disabled].focus,
+fieldset[disabled] .btn-primary.focus {
+  background-color: #2c3e50;
+  border-color: #2c3e50;
+}
+.btn-primary .badge {
+  color: #2c3e50;
+  background-color: #ffffff;
+}
+.btn-success {
+  color: #ffffff;
+  background-color: #18bc9c;
+  border-color: #18bc9c;
+}
+.btn-success:focus,
+.btn-success.focus {
+  color: #ffffff;
+  background-color: #128f76;
+  border-color: #0a4b3e;
+}
+.btn-success:hover {
+  color: #ffffff;
+  background-color: #128f76;
+  border-color: #11866f;
+}
+.btn-success:active,
+.btn-success.active,
+.open > .dropdown-toggle.btn-success {
+  color: #ffffff;
+  background-color: #128f76;
+  border-color: #11866f;
+}
+.btn-success:active:hover,
+.btn-success.active:hover,
+.open > .dropdown-toggle.btn-success:hover,
+.btn-success:active:focus,
+.btn-success.active:focus,
+.open > .dropdown-toggle.btn-success:focus,
+.btn-success:active.focus,
+.btn-success.active.focus,
+.open > .dropdown-toggle.btn-success.focus {
+  color: #ffffff;
+  background-color: #0e6f5c;
+  border-color: #0a4b3e;
+}
+.btn-success:active,
+.btn-success.active,
+.open > .dropdown-toggle.btn-success {
+  background-image: none;
+}
+.btn-success.disabled:hover,
+.btn-success[disabled]:hover,
+fieldset[disabled] .btn-success:hover,
+.btn-success.disabled:focus,
+.btn-success[disabled]:focus,
+fieldset[disabled] .btn-success:focus,
+.btn-success.disabled.focus,
+.btn-success[disabled].focus,
+fieldset[disabled] .btn-success.focus {
+  background-color: #18bc9c;
+  border-color: #18bc9c;
+}
+.btn-success .badge {
+  color: #18bc9c;
+  background-color: #ffffff;
+}
+.btn-info {
+  color: #ffffff;
+  background-color: #3498db;
+  border-color: #3498db;
+}
+.btn-info:focus,
+.btn-info.focus {
+  color: #ffffff;
+  background-color: #217dbb;
+  border-color: #16527a;
+}
+.btn-info:hover {
+  color: #ffffff;
+  background-color: #217dbb;
+  border-color: #2077b2;
+}
+.btn-info:active,
+.btn-info.active,
+.open > .dropdown-toggle.btn-info {
+  color: #ffffff;
+  background-color: #217dbb;
+  border-color: #2077b2;
+}
+.btn-info:active:hover,
+.btn-info.active:hover,
+.open > .dropdown-toggle.btn-info:hover,
+.btn-info:active:focus,
+.btn-info.active:focus,
+.open > .dropdown-toggle.btn-info:focus,
+.btn-info:active.focus,
+.btn-info.active.focus,
+.open > .dropdown-toggle.btn-info.focus {
+  color: #ffffff;
+  background-color: #1c699d;
+  border-color: #16527a;
+}
+.btn-info:active,
+.btn-info.active,
+.open > .dropdown-toggle.btn-info {
+  background-image: none;
+}
+.btn-info.disabled:hover,
+.btn-info[disabled]:hover,
+fieldset[disabled] .btn-info:hover,
+.btn-info.disabled:focus,
+.btn-info[disabled]:focus,
+fieldset[disabled] .btn-info:focus,
+.btn-info.disabled.focus,
+.btn-info[disabled].focus,
+fieldset[disabled] .btn-info.focus {
+  background-color: #3498db;
+  border-color: #3498db;
+}
+.btn-info .badge {
+  color: #3498db;
+  background-color: #ffffff;
+}
+.btn-warning {
+  color: #ffffff;
+  background-color: #f39c12;
+  border-color: #f39c12;
+}
+.btn-warning:focus,
+.btn-warning.focus {
+  color: #ffffff;
+  background-color: #c87f0a;
+  border-color: #7f5006;
+}
+.btn-warning:hover {
+  color: #ffffff;
+  background-color: #c87f0a;
+  border-color: #be780a;
+}
+.btn-warning:active,
+.btn-warning.active,
+.open > .dropdown-toggle.btn-warning {
+  color: #ffffff;
+  background-color: #c87f0a;
+  border-color: #be780a;
+}
+.btn-warning:active:hover,
+.btn-warning.active:hover,
+.open > .dropdown-toggle.btn-warning:hover,
+.btn-warning:active:focus,
+.btn-warning.active:focus,
+.open > .dropdown-toggle.btn-warning:focus,
+.btn-warning:active.focus,
+.btn-warning.active.focus,
+.open > .dropdown-toggle.btn-warning.focus {
+  color: #ffffff;
+  background-color: #a66908;
+  border-color: #7f5006;
+}
+.btn-warning:active,
+.btn-warning.active,
+.open > .dropdown-toggle.btn-warning {
+  background-image: none;
+}
+.btn-warning.disabled:hover,
+.btn-warning[disabled]:hover,
+fieldset[disabled] .btn-warning:hover,
+.btn-warning.disabled:focus,
+.btn-warning[disabled]:focus,
+fieldset[disabled] .btn-warning:focus,
+.btn-warning.disabled.focus,
+.btn-warning[disabled].focus,
+fieldset[disabled] .btn-warning.focus {
+  background-color: #f39c12;
+  border-color: #f39c12;
+}
+.btn-warning .badge {
+  color: #f39c12;
+  background-color: #ffffff;
+}
+.btn-danger {
+  color: #ffffff;
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+}
+.btn-danger:focus,
+.btn-danger.focus {
+  color: #ffffff;
+  background-color: #d62c1a;
+  border-color: #921e12;
+}
+.btn-danger:hover {
+  color: #ffffff;
+  background-color: #d62c1a;
+  border-color: #cd2a19;
+}
+.btn-danger:active,
+.btn-danger.active,
+.open > .dropdown-toggle.btn-danger {
+  color: #ffffff;
+  background-color: #d62c1a;
+  border-color: #cd2a19;
+}
+.btn-danger:active:hover,
+.btn-danger.active:hover,
+.open > .dropdown-toggle.btn-danger:hover,
+.btn-danger:active:focus,
+.btn-danger.active:focus,
+.open > .dropdown-toggle.btn-danger:focus,
+.btn-danger:active.focus,
+.btn-danger.active.focus,
+.open > .dropdown-toggle.btn-danger.focus {
+  color: #ffffff;
+  background-color: #b62516;
+  border-color: #921e12;
+}
+.btn-danger:active,
+.btn-danger.active,
+.open > .dropdown-toggle.btn-danger {
+  background-image: none;
+}
+.btn-danger.disabled:hover,
+.btn-danger[disabled]:hover,
+fieldset[disabled] .btn-danger:hover,
+.btn-danger.disabled:focus,
+.btn-danger[disabled]:focus,
+fieldset[disabled] .btn-danger:focus,
+.btn-danger.disabled.focus,
+.btn-danger[disabled].focus,
+fieldset[disabled] .btn-danger.focus {
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+}
+.btn-danger .badge {
+  color: #e74c3c;
+  background-color: #ffffff;
+}
+.btn-link {
+  color: #18bc9c;
+  font-weight: normal;
+  border-radius: 0;
+}
+.btn-link,
+.btn-link:active,
+.btn-link.active,
+.btn-link[disabled],
+fieldset[disabled] .btn-link {
+  background-color: transparent;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.btn-link,
+.btn-link:hover,
+.btn-link:focus,
+.btn-link:active {
+  border-color: transparent;
+}
+.btn-link:hover,
+.btn-link:focus {
+  color: #18bc9c;
+  text-decoration: underline;
+  background-color: transparent;
+}
+.btn-link[disabled]:hover,
+fieldset[disabled] .btn-link:hover,
+.btn-link[disabled]:focus,
+fieldset[disabled] .btn-link:focus {
+  color: #b4bcc2;
+  text-decoration: none;
+}
+.btn-lg,
+.btn-group-lg > .btn {
+  padding: 18px 27px;
+  font-size: 19px;
+  line-height: 1.3333333;
+  border-radius: 6px;
+}
+.btn-sm,
+.btn-group-sm > .btn {
+  padding: 6px 9px;
+  font-size: 13px;
+  line-height: 1.5;
+  border-radius: 3px;
+}
+.btn-xs,
+.btn-group-xs > .btn {
+  padding: 1px 5px;
+  font-size: 13px;
+  line-height: 1.5;
+  border-radius: 3px;
+}
+.btn-block {
+  display: block;
+  width: 100%;
+}
+.btn-block + .btn-block {
+  margin-top: 5px;
+}
+input[type="submit"].btn-block,
+input[type="reset"].btn-block,
+input[type="button"].btn-block {
+  width: 100%;
+}
+.fade {
+  opacity: 0;
+  -webkit-transition: opacity 0.15s linear;
+  -o-transition: opacity 0.15s linear;
+  transition: opacity 0.15s linear;
+}
+.fade.in {
+  opacity: 1;
+}
+.collapse {
+  display: none;
+}
+.collapse.in {
+  display: block;
+}
+tr.collapse.in {
+  display: table-row;
+}
+tbody.collapse.in {
+  display: table-row-group;
+}
+.collapsing {
+  position: relative;
+  height: 0;
+  overflow: hidden;
+  -webkit-transition-property: height, visibility;
+  -o-transition-property: height, visibility;
+     transition-property: height, visibility;
+  -webkit-transition-duration: 0.35s;
+  -o-transition-duration: 0.35s;
+     transition-duration: 0.35s;
+  -webkit-transition-timing-function: ease;
+  -o-transition-timing-function: ease;
+     transition-timing-function: ease;
+}
+.caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 2px;
+  vertical-align: middle;
+  border-top: 4px dashed;
+  border-top: 4px solid \9;
+  border-right: 4px solid transparent;
+  border-left: 4px solid transparent;
+}
+.dropup,
+.dropdown {
+  position: relative;
+}
+.dropdown-toggle:focus {
+  outline: 0;
+}
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 160px;
+  padding: 5px 0;
+  margin: 2px 0 0;
+  list-style: none;
+  font-size: 15px;
+  text-align: left;
+  background-color: #ffffff;
+  border: 1px solid #cccccc;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  -webkit-background-clip: padding-box;
+          background-clip: padding-box;
+}
+.dropdown-menu.pull-right {
+  right: 0;
+  left: auto;
+}
+.dropdown-menu .divider {
+  height: 1px;
+  margin: 9.5px 0;
+  overflow: hidden;
+  background-color: #e5e5e5;
+}
+.dropdown-menu > li > a {
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 1.42857143;
+  color: #7b8a8b;
+  white-space: nowrap;
+}
+.dropdown-menu > li > a:hover,
+.dropdown-menu > li > a:focus {
+  text-decoration: none;
+  color: #ffffff;
+  background-color: #2c3e50;
+}
+.dropdown-menu > .active > a,
+.dropdown-menu > .active > a:hover,
+.dropdown-menu > .active > a:focus {
+  color: #ffffff;
+  text-decoration: none;
+  outline: 0;
+  background-color: #2c3e50;
+}
+.dropdown-menu > .disabled > a,
+.dropdown-menu > .disabled > a:hover,
+.dropdown-menu > .disabled > a:focus {
+  color: #b4bcc2;
+}
+.dropdown-menu > .disabled > a:hover,
+.dropdown-menu > .disabled > a:focus {
+  text-decoration: none;
+  background-color: transparent;
+  background-image: none;
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  cursor: not-allowed;
+}
+.open > .dropdown-menu {
+  display: block;
+}
+.open > a {
+  outline: 0;
+}
+.dropdown-menu-right {
+  left: auto;
+  right: 0;
+}
+.dropdown-menu-left {
+  left: 0;
+  right: auto;
+}
+.dropdown-header {
+  display: block;
+  padding: 3px 20px;
+  font-size: 13px;
+  line-height: 1.42857143;
+  color: #b4bcc2;
+  white-space: nowrap;
+}
+.dropdown-backdrop {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+  z-index: 990;
+}
+.pull-right > .dropdown-menu {
+  right: 0;
+  left: auto;
+}
+.dropup .caret,
+.navbar-fixed-bottom .dropdown .caret {
+  border-top: 0;
+  border-bottom: 4px dashed;
+  border-bottom: 4px solid \9;
+  content: "";
+}
+.dropup .dropdown-menu,
+.navbar-fixed-bottom .dropdown .dropdown-menu {
+  top: auto;
+  bottom: 100%;
+  margin-bottom: 2px;
+}
+@media (min-width: 768px) {
+  .navbar-right .dropdown-menu {
+    left: auto;
+    right: 0;
+  }
+  .navbar-right .dropdown-menu-left {
+    left: 0;
+    right: auto;
+  }
+}
+.btn-group,
+.btn-group-vertical {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+}
+.btn-group > .btn,
+.btn-group-vertical > .btn {
+  position: relative;
+  float: left;
+}
+.btn-group > .btn:hover,
+.btn-group-vertical > .btn:hover,
+.btn-group > .btn:focus,
+.btn-group-vertical > .btn:focus,
+.btn-group > .btn:active,
+.btn-group-vertical > .btn:active,
+.btn-group > .btn.active,
+.btn-group-vertical > .btn.active {
+  z-index: 2;
+}
+.btn-group .btn + .btn,
+.btn-group .btn + .btn-group,
+.btn-group .btn-group + .btn,
+.btn-group .btn-group + .btn-group {
+  margin-left: -1px;
+}
+.btn-toolbar {
+  margin-left: -5px;
+}
+.btn-toolbar .btn,
+.btn-toolbar .btn-group,
+.btn-toolbar .input-group {
+  float: left;
+}
+.btn-toolbar > .btn,
+.btn-toolbar > .btn-group,
+.btn-toolbar > .input-group {
+  margin-left: 5px;
+}
+.btn-group > .btn:not(:first-child):not(:last-child):not(.dropdown-toggle) {
+  border-radius: 0;
+}
+.btn-group > .btn:first-child {
+  margin-left: 0;
+}
+.btn-group > .btn:first-child:not(:last-child):not(.dropdown-toggle) {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.btn-group > .btn:last-child:not(:first-child),
+.btn-group > .dropdown-toggle:not(:first-child) {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+.btn-group > .btn-group {
+  float: left;
+}
+.btn-group > .btn-group:not(:first-child):not(:last-child) > .btn {
+  border-radius: 0;
+}
+.btn-group > .btn-group:first-child:not(:last-child) > .btn:last-child,
+.btn-group > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.btn-group > .btn-group:last-child:not(:first-child) > .btn:first-child {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+.btn-group .dropdown-toggle:active,
+.btn-group.open .dropdown-toggle {
+  outline: 0;
+}
+.btn-group > .btn + .dropdown-toggle {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.btn-group > .btn-lg + .dropdown-toggle {
+  padding-left: 12px;
+  padding-right: 12px;
+}
+.btn-group.open .dropdown-toggle {
+  -webkit-box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+  box-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
+}
+.btn-group.open .dropdown-toggle.btn-link {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.btn .caret {
+  margin-left: 0;
+}
+.btn-lg .caret {
+  border-width: 5px 5px 0;
+  border-bottom-width: 0;
+}
+.dropup .btn-lg .caret {
+  border-width: 0 5px 5px;
+}
+.btn-group-vertical > .btn,
+.btn-group-vertical > .btn-group,
+.btn-group-vertical > .btn-group > .btn {
+  display: block;
+  float: none;
+  width: 100%;
+  max-width: 100%;
+}
+.btn-group-vertical > .btn-group > .btn {
+  float: none;
+}
+.btn-group-vertical > .btn + .btn,
+.btn-group-vertical > .btn + .btn-group,
+.btn-group-vertical > .btn-group + .btn,
+.btn-group-vertical > .btn-group + .btn-group {
+  margin-top: -1px;
+  margin-left: 0;
+}
+.btn-group-vertical > .btn:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+.btn-group-vertical > .btn:first-child:not(:last-child) {
+  border-top-right-radius: 4px;
+  border-top-left-radius: 4px;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.btn-group-vertical > .btn:last-child:not(:first-child) {
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+.btn-group-vertical > .btn-group:not(:first-child):not(:last-child) > .btn {
+  border-radius: 0;
+}
+.btn-group-vertical > .btn-group:first-child:not(:last-child) > .btn:last-child,
+.btn-group-vertical > .btn-group:first-child:not(:last-child) > .dropdown-toggle {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.btn-group-vertical > .btn-group:last-child:not(:first-child) > .btn:first-child {
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}
+.btn-group-justified {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: separate;
+}
+.btn-group-justified > .btn,
+.btn-group-justified > .btn-group {
+  float: none;
+  display: table-cell;
+  width: 1%;
+}
+.btn-group-justified > .btn-group .btn {
+  width: 100%;
+}
+.btn-group-justified > .btn-group .dropdown-menu {
+  left: auto;
+}
+[data-toggle="buttons"] > .btn input[type="radio"],
+[data-toggle="buttons"] > .btn-group > .btn input[type="radio"],
+[data-toggle="buttons"] > .btn input[type="checkbox"],
+[data-toggle="buttons"] > .btn-group > .btn input[type="checkbox"] {
+  position: absolute;
+  clip: rect(0, 0, 0, 0);
+  pointer-events: none;
+}
+.input-group {
+  position: relative;
+  display: table;
+  border-collapse: separate;
+}
+.input-group[class*="col-"] {
+  float: none;
+  padding-left: 0;
+  padding-right: 0;
+}
+.input-group .form-control {
+  position: relative;
+  z-index: 2;
+  float: left;
+  width: 100%;
+  margin-bottom: 0;
+}
+.input-group .form-control:focus {
+  z-index: 3;
+}
+.input-group-lg > .form-control,
+.input-group-lg > .input-group-addon,
+.input-group-lg > .input-group-btn > .btn {
+  height: 66px;
+  padding: 18px 27px;
+  font-size: 19px;
+  line-height: 1.3333333;
+  border-radius: 6px;
+}
+select.input-group-lg > .form-control,
+select.input-group-lg > .input-group-addon,
+select.input-group-lg > .input-group-btn > .btn {
+  height: 66px;
+  line-height: 66px;
+}
+textarea.input-group-lg > .form-control,
+textarea.input-group-lg > .input-group-addon,
+textarea.input-group-lg > .input-group-btn > .btn,
+select[multiple].input-group-lg > .form-control,
+select[multiple].input-group-lg > .input-group-addon,
+select[multiple].input-group-lg > .input-group-btn > .btn {
+  height: auto;
+}
+.input-group-sm > .form-control,
+.input-group-sm > .input-group-addon,
+.input-group-sm > .input-group-btn > .btn {
+  height: 35px;
+  padding: 6px 9px;
+  font-size: 13px;
+  line-height: 1.5;
+  border-radius: 3px;
+}
+select.input-group-sm > .form-control,
+select.input-group-sm > .input-group-addon,
+select.input-group-sm > .input-group-btn > .btn {
+  height: 35px;
+  line-height: 35px;
+}
+textarea.input-group-sm > .form-control,
+textarea.input-group-sm > .input-group-addon,
+textarea.input-group-sm > .input-group-btn > .btn,
+select[multiple].input-group-sm > .form-control,
+select[multiple].input-group-sm > .input-group-addon,
+select[multiple].input-group-sm > .input-group-btn > .btn {
+  height: auto;
+}
+.input-group-addon,
+.input-group-btn,
+.input-group .form-control {
+  display: table-cell;
+}
+.input-group-addon:not(:first-child):not(:last-child),
+.input-group-btn:not(:first-child):not(:last-child),
+.input-group .form-control:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+.input-group-addon,
+.input-group-btn {
+  width: 1%;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+.input-group-addon {
+  padding: 10px 15px;
+  font-size: 15px;
+  font-weight: normal;
+  line-height: 1;
+  color: #2c3e50;
+  text-align: center;
+  background-color: #ecf0f1;
+  border: 1px solid #dce4ec;
+  border-radius: 4px;
+}
+.input-group-addon.input-sm {
+  padding: 6px 9px;
+  font-size: 13px;
+  border-radius: 3px;
+}
+.input-group-addon.input-lg {
+  padding: 18px 27px;
+  font-size: 19px;
+  border-radius: 6px;
+}
+.input-group-addon input[type="radio"],
+.input-group-addon input[type="checkbox"] {
+  margin-top: 0;
+}
+.input-group .form-control:first-child,
+.input-group-addon:first-child,
+.input-group-btn:first-child > .btn,
+.input-group-btn:first-child > .btn-group > .btn,
+.input-group-btn:first-child > .dropdown-toggle,
+.input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle),
+.input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+.input-group-addon:first-child {
+  border-right: 0;
+}
+.input-group .form-control:last-child,
+.input-group-addon:last-child,
+.input-group-btn:last-child > .btn,
+.input-group-btn:last-child > .btn-group > .btn,
+.input-group-btn:last-child > .dropdown-toggle,
+.input-group-btn:first-child > .btn:not(:first-child),
+.input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+.input-group-addon:last-child {
+  border-left: 0;
+}
+.input-group-btn {
+  position: relative;
+  font-size: 0;
+  white-space: nowrap;
+}
+.input-group-btn > .btn {
+  position: relative;
+}
+.input-group-btn > .btn + .btn {
+  margin-left: -1px;
+}
+.input-group-btn > .btn:hover,
+.input-group-btn > .btn:focus,
+.input-group-btn > .btn:active {
+  z-index: 2;
+}
+.input-group-btn:first-child > .btn,
+.input-group-btn:first-child > .btn-group {
+  margin-right: -1px;
+}
+.input-group-btn:last-child > .btn,
+.input-group-btn:last-child > .btn-group {
+  z-index: 2;
+  margin-left: -1px;
+}
+.nav {
+  margin-bottom: 0;
+  padding-left: 0;
+  list-style: none;
+}
+.nav > li {
+  position: relative;
+  display: block;
+}
+.nav > li > a {
+  position: relative;
+  display: block;
+  padding: 10px 15px;
+}
+.nav > li > a:hover,
+.nav > li > a:focus {
+  text-decoration: none;
+  background-color: #ecf0f1;
+}
+.nav > li.disabled > a {
+  color: #b4bcc2;
+}
+.nav > li.disabled > a:hover,
+.nav > li.disabled > a:focus {
+  color: #b4bcc2;
+  text-decoration: none;
+  background-color: transparent;
+  cursor: not-allowed;
+}
+.nav .open > a,
+.nav .open > a:hover,
+.nav .open > a:focus {
+  background-color: #ecf0f1;
+  border-color: #18bc9c;
+}
+.nav .nav-divider {
+  height: 1px;
+  margin: 9.5px 0;
+  overflow: hidden;
+  background-color: #e5e5e5;
+}
+.nav > li > a > img {
+  max-width: none;
+}
+.nav-tabs {
+  border-bottom: 1px solid #ecf0f1;
+}
+.nav-tabs > li {
+  float: left;
+  margin-bottom: -1px;
+}
+.nav-tabs > li > a {
+  margin-right: 2px;
+  line-height: 1.42857143;
+  border: 1px solid transparent;
+  border-radius: 4px 4px 0 0;
+}
+.nav-tabs > li > a:hover {
+  border-color: #ecf0f1 #ecf0f1 #ecf0f1;
+}
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > a:hover,
+.nav-tabs > li.active > a:focus {
+  color: #2c3e50;
+  background-color: #ffffff;
+  border: 1px solid #ecf0f1;
+  border-bottom-color: transparent;
+  cursor: default;
+}
+.nav-tabs.nav-justified {
+  width: 100%;
+  border-bottom: 0;
+}
+.nav-tabs.nav-justified > li {
+  float: none;
+}
+.nav-tabs.nav-justified > li > a {
+  text-align: center;
+  margin-bottom: 5px;
+}
+.nav-tabs.nav-justified > .dropdown .dropdown-menu {
+  top: auto;
+  left: auto;
+}
+@media (min-width: 768px) {
+  .nav-tabs.nav-justified > li {
+    display: table-cell;
+    width: 1%;
+  }
+  .nav-tabs.nav-justified > li > a {
+    margin-bottom: 0;
+  }
+}
+.nav-tabs.nav-justified > li > a {
+  margin-right: 0;
+  border-radius: 4px;
+}
+.nav-tabs.nav-justified > .active > a,
+.nav-tabs.nav-justified > .active > a:hover,
+.nav-tabs.nav-justified > .active > a:focus {
+  border: 1px solid #ecf0f1;
+}
+@media (min-width: 768px) {
+  .nav-tabs.nav-justified > li > a {
+    border-bottom: 1px solid #ecf0f1;
+    border-radius: 4px 4px 0 0;
+  }
+  .nav-tabs.nav-justified > .active > a,
+  .nav-tabs.nav-justified > .active > a:hover,
+  .nav-tabs.nav-justified > .active > a:focus {
+    border-bottom-color: #ffffff;
+  }
+}
+.nav-pills > li {
+  float: left;
+}
+.nav-pills > li > a {
+  border-radius: 4px;
+}
+.nav-pills > li + li {
+  margin-left: 2px;
+}
+.nav-pills > li.active > a,
+.nav-pills > li.active > a:hover,
+.nav-pills > li.active > a:focus {
+  color: #ffffff;
+  background-color: #2c3e50;
+}
+.nav-stacked > li {
+  float: none;
+}
+.nav-stacked > li + li {
+  margin-top: 2px;
+  margin-left: 0;
+}
+.nav-justified {
+  width: 100%;
+}
+.nav-justified > li {
+  float: none;
+}
+.nav-justified > li > a {
+  text-align: center;
+  margin-bottom: 5px;
+}
+.nav-justified > .dropdown .dropdown-menu {
+  top: auto;
+  left: auto;
+}
+@media (min-width: 768px) {
+  .nav-justified > li {
+    display: table-cell;
+    width: 1%;
+  }
+  .nav-justified > li > a {
+    margin-bottom: 0;
+  }
+}
+.nav-tabs-justified {
+  border-bottom: 0;
+}
+.nav-tabs-justified > li > a {
+  margin-right: 0;
+  border-radius: 4px;
+}
+.nav-tabs-justified > .active > a,
+.nav-tabs-justified > .active > a:hover,
+.nav-tabs-justified > .active > a:focus {
+  border: 1px solid #ecf0f1;
+}
+@media (min-width: 768px) {
+  .nav-tabs-justified > li > a {
+    border-bottom: 1px solid #ecf0f1;
+    border-radius: 4px 4px 0 0;
+  }
+  .nav-tabs-justified > .active > a,
+  .nav-tabs-justified > .active > a:hover,
+  .nav-tabs-justified > .active > a:focus {
+    border-bottom-color: #ffffff;
+  }
+}
+.tab-content > .tab-pane {
+  display: none;
+}
+.tab-content > .active {
+  display: block;
+}
+.nav-tabs .dropdown-menu {
+  margin-top: -1px;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}
+.navbar {
+  position: relative;
+  min-height: 60px;
+  margin-bottom: 21px;
+  border: 1px solid transparent;
+}
+@media (min-width: 768px) {
+  .navbar {
+    border-radius: 4px;
+  }
+}
+@media (min-width: 768px) {
+  .navbar-header {
+    float: left;
+  }
+}
+.navbar-collapse {
+  overflow-x: visible;
+  padding-right: 15px;
+  padding-left: 15px;
+  border-top: 1px solid transparent;
+  -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+          box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  -webkit-overflow-scrolling: touch;
+}
+.navbar-collapse.in {
+  overflow-y: auto;
+}
+@media (min-width: 768px) {
+  .navbar-collapse {
+    width: auto;
+    border-top: 0;
+    -webkit-box-shadow: none;
+            box-shadow: none;
+  }
+  .navbar-collapse.collapse {
+    display: block !important;
+    height: auto !important;
+    padding-bottom: 0;
+    overflow: visible !important;
+  }
+  .navbar-collapse.in {
+    overflow-y: visible;
+  }
+  .navbar-fixed-top .navbar-collapse,
+  .navbar-static-top .navbar-collapse,
+  .navbar-fixed-bottom .navbar-collapse {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}
+.navbar-fixed-top .navbar-collapse,
+.navbar-fixed-bottom .navbar-collapse {
+  max-height: 340px;
+}
+@media (max-device-width: 480px) and (orientation: landscape) {
+  .navbar-fixed-top .navbar-collapse,
+  .navbar-fixed-bottom .navbar-collapse {
+    max-height: 200px;
+  }
+}
+.container > .navbar-header,
+.container-fluid > .navbar-header,
+.container > .navbar-collapse,
+.container-fluid > .navbar-collapse {
+  margin-right: -15px;
+  margin-left: -15px;
+}
+@media (min-width: 768px) {
+  .container > .navbar-header,
+  .container-fluid > .navbar-header,
+  .container > .navbar-collapse,
+  .container-fluid > .navbar-collapse {
+    margin-right: 0;
+    margin-left: 0;
+  }
+}
+.navbar-static-top {
+  z-index: 1000;
+  border-width: 0 0 1px;
+}
+@media (min-width: 768px) {
+  .navbar-static-top {
+    border-radius: 0;
+  }
+}
+.navbar-fixed-top,
+.navbar-fixed-bottom {
+  position: fixed;
+  right: 0;
+  left: 0;
+  z-index: 1030;
+}
+@media (min-width: 768px) {
+  .navbar-fixed-top,
+  .navbar-fixed-bottom {
+    border-radius: 0;
+  }
+}
+.navbar-fixed-top {
+  top: 0;
+  border-width: 0 0 1px;
+}
+.navbar-fixed-bottom {
+  bottom: 0;
+  margin-bottom: 0;
+  border-width: 1px 0 0;
+}
+.navbar-brand {
+  float: left;
+  padding: 19.5px 15px;
+  font-size: 19px;
+  line-height: 21px;
+  height: 60px;
+}
+.navbar-brand:hover,
+.navbar-brand:focus {
+  text-decoration: none;
+}
+.navbar-brand > img {
+  display: block;
+}
+@media (min-width: 768px) {
+  .navbar > .container .navbar-brand,
+  .navbar > .container-fluid .navbar-brand {
+    margin-left: -15px;
+  }
+}
+.navbar-toggle {
+  position: relative;
+  float: right;
+  margin-right: 15px;
+  padding: 9px 10px;
+  margin-top: 13px;
+  margin-bottom: 13px;
+  background-color: transparent;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+.navbar-toggle:focus {
+  outline: 0;
+}
+.navbar-toggle .icon-bar {
+  display: block;
+  width: 22px;
+  height: 2px;
+  border-radius: 1px;
+}
+.navbar-toggle .icon-bar + .icon-bar {
+  margin-top: 4px;
+}
+@media (min-width: 768px) {
+  .navbar-toggle {
+    display: none;
+  }
+}
+.navbar-nav {
+  margin: 9.75px -15px;
+}
+.navbar-nav > li > a {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  line-height: 21px;
+}
+@media (max-width: 767px) {
+  .navbar-nav .open .dropdown-menu {
+    position: static;
+    float: none;
+    width: auto;
+    margin-top: 0;
+    background-color: transparent;
+    border: 0;
+    -webkit-box-shadow: none;
+            box-shadow: none;
+  }
+  .navbar-nav .open .dropdown-menu > li > a,
+  .navbar-nav .open .dropdown-menu .dropdown-header {
+    padding: 5px 15px 5px 25px;
+  }
+  .navbar-nav .open .dropdown-menu > li > a {
+    line-height: 21px;
+  }
+  .navbar-nav .open .dropdown-menu > li > a:hover,
+  .navbar-nav .open .dropdown-menu > li > a:focus {
+    background-image: none;
+  }
+}
+@media (min-width: 768px) {
+  .navbar-nav {
+    float: left;
+    margin: 0;
+  }
+  .navbar-nav > li {
+    float: left;
+  }
+  .navbar-nav > li > a {
+    padding-top: 19.5px;
+    padding-bottom: 19.5px;
+  }
+}
+.navbar-form {
+  margin-left: -15px;
+  margin-right: -15px;
+  padding: 10px 15px;
+  border-top: 1px solid transparent;
+  border-bottom: 1px solid transparent;
+  -webkit-box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 1px 0 rgba(255, 255, 255, 0.1);
+  margin-top: 7.5px;
+  margin-bottom: 7.5px;
+}
+@media (min-width: 768px) {
+  .navbar-form .form-group {
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .navbar-form .form-control {
+    display: inline-block;
+    width: auto;
+    vertical-align: middle;
+  }
+  .navbar-form .form-control-static {
+    display: inline-block;
+  }
+  .navbar-form .input-group {
+    display: inline-table;
+    vertical-align: middle;
+  }
+  .navbar-form .input-group .input-group-addon,
+  .navbar-form .input-group .input-group-btn,
+  .navbar-form .input-group .form-control {
+    width: auto;
+  }
+  .navbar-form .input-group > .form-control {
+    width: 100%;
+  }
+  .navbar-form .control-label {
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .navbar-form .radio,
+  .navbar-form .checkbox {
+    display: inline-block;
+    margin-top: 0;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+  .navbar-form .radio label,
+  .navbar-form .checkbox label {
+    padding-left: 0;
+  }
+  .navbar-form .radio input[type="radio"],
+  .navbar-form .checkbox input[type="checkbox"] {
+    position: relative;
+    margin-left: 0;
+  }
+  .navbar-form .has-feedback .form-control-feedback {
+    top: 0;
+  }
+}
+@media (max-width: 767px) {
+  .navbar-form .form-group {
+    margin-bottom: 5px;
+  }
+  .navbar-form .form-group:last-child {
+    margin-bottom: 0;
+  }
+}
+@media (min-width: 768px) {
+  .navbar-form {
+    width: auto;
+    border: 0;
+    margin-left: 0;
+    margin-right: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+    -webkit-box-shadow: none;
+    box-shadow: none;
+  }
+}
+.navbar-nav > li > .dropdown-menu {
+  margin-top: 0;
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}
+.navbar-fixed-bottom .navbar-nav > li > .dropdown-menu {
+  margin-bottom: 0;
+  border-top-right-radius: 4px;
+  border-top-left-radius: 4px;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+.navbar-btn {
+  margin-top: 7.5px;
+  margin-bottom: 7.5px;
+}
+.navbar-btn.btn-sm {
+  margin-top: 12.5px;
+  margin-bottom: 12.5px;
+}
+.navbar-btn.btn-xs {
+  margin-top: 19px;
+  margin-bottom: 19px;
+}
+.navbar-text {
+  margin-top: 19.5px;
+  margin-bottom: 19.5px;
+}
+@media (min-width: 768px) {
+  .navbar-text {
+    float: left;
+    margin-left: 15px;
+    margin-right: 15px;
+  }
+}
+@media (min-width: 768px) {
+  .navbar-left {
+    float: left !important;
+  }
+  .navbar-right {
+    float: right !important;
+    margin-right: -15px;
+  }
+  .navbar-right ~ .navbar-right {
+    margin-right: 0;
+  }
+}
+.navbar-default {
+  background-color: #2c3e50;
+  border-color: transparent;
+}
+.navbar-default .navbar-brand {
+  color: #ffffff;
+}
+.navbar-default .navbar-brand:hover,
+.navbar-default .navbar-brand:focus {
+  color: #18bc9c;
+  background-color: transparent;
+}
+.navbar-default .navbar-text {
+  color: #ffffff;
+}
+.navbar-default .navbar-nav > li > a {
+  color: #ffffff;
+}
+.navbar-default .navbar-nav > li > a:hover,
+.navbar-default .navbar-nav > li > a:focus {
+  color: #18bc9c;
+  background-color: transparent;
+}
+.navbar-default .navbar-nav > .active > a,
+.navbar-default .navbar-nav > .active > a:hover,
+.navbar-default .navbar-nav > .active > a:focus {
+  color: #ffffff;
+  background-color: #1a242f;
+}
+.navbar-default .navbar-nav > .disabled > a,
+.navbar-default .navbar-nav > .disabled > a:hover,
+.navbar-default .navbar-nav > .disabled > a:focus {
+  color: #cccccc;
+  background-color: transparent;
+}
+.navbar-default .navbar-toggle {
+  border-color: #1a242f;
+}
+.navbar-default .navbar-toggle:hover,
+.navbar-default .navbar-toggle:focus {
+  background-color: #1a242f;
+}
+.navbar-default .navbar-toggle .icon-bar {
+  background-color: #ffffff;
+}
+.navbar-default .navbar-collapse,
+.navbar-default .navbar-form {
+  border-color: transparent;
+}
+.navbar-default .navbar-nav > .open > a,
+.navbar-default .navbar-nav > .open > a:hover,
+.navbar-default .navbar-nav > .open > a:focus {
+  background-color: #1a242f;
+  color: #ffffff;
+}
+@media (max-width: 767px) {
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a {
+    color: #ffffff;
+  }
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > li > a:focus {
+    color: #18bc9c;
+    background-color: transparent;
+  }
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > a,
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > a:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > .active > a:focus {
+    color: #ffffff;
+    background-color: #1a242f;
+  }
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a,
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:hover,
+  .navbar-default .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+    color: #cccccc;
+    background-color: transparent;
+  }
+}
+.navbar-default .navbar-link {
+  color: #ffffff;
+}
+.navbar-default .navbar-link:hover {
+  color: #18bc9c;
+}
+.navbar-default .btn-link {
+  color: #ffffff;
+}
+.navbar-default .btn-link:hover,
+.navbar-default .btn-link:focus {
+  color: #18bc9c;
+}
+.navbar-default .btn-link[disabled]:hover,
+fieldset[disabled] .navbar-default .btn-link:hover,
+.navbar-default .btn-link[disabled]:focus,
+fieldset[disabled] .navbar-default .btn-link:focus {
+  color: #cccccc;
+}
+.navbar-inverse {
+  background-color: #18bc9c;
+  border-color: transparent;
+}
+.navbar-inverse .navbar-brand {
+  color: #ffffff;
+}
+.navbar-inverse .navbar-brand:hover,
+.navbar-inverse .navbar-brand:focus {
+  color: #2c3e50;
+  background-color: transparent;
+}
+.navbar-inverse .navbar-text {
+  color: #ffffff;
+}
+.navbar-inverse .navbar-nav > li > a {
+  color: #ffffff;
+}
+.navbar-inverse .navbar-nav > li > a:hover,
+.navbar-inverse .navbar-nav > li > a:focus {
+  color: #2c3e50;
+  background-color: transparent;
+}
+.navbar-inverse .navbar-nav > .active > a,
+.navbar-inverse .navbar-nav > .active > a:hover,
+.navbar-inverse .navbar-nav > .active > a:focus {
+  color: #ffffff;
+  background-color: #15a589;
+}
+.navbar-inverse .navbar-nav > .disabled > a,
+.navbar-inverse .navbar-nav > .disabled > a:hover,
+.navbar-inverse .navbar-nav > .disabled > a:focus {
+  color: #cccccc;
+  background-color: transparent;
+}
+.navbar-inverse .navbar-toggle {
+  border-color: #128f76;
+}
+.navbar-inverse .navbar-toggle:hover,
+.navbar-inverse .navbar-toggle:focus {
+  background-color: #128f76;
+}
+.navbar-inverse .navbar-toggle .icon-bar {
+  background-color: #ffffff;
+}
+.navbar-inverse .navbar-collapse,
+.navbar-inverse .navbar-form {
+  border-color: #149c82;
+}
+.navbar-inverse .navbar-nav > .open > a,
+.navbar-inverse .navbar-nav > .open > a:hover,
+.navbar-inverse .navbar-nav > .open > a:focus {
+  background-color: #15a589;
+  color: #ffffff;
+}
+@media (max-width: 767px) {
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .dropdown-header {
+    border-color: transparent;
+  }
+  .navbar-inverse .navbar-nav .open .dropdown-menu .divider {
+    background-color: transparent;
+  }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > li > a {
+    color: #ffffff;
+  }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:hover,
+  .navbar-inverse .navbar-nav .open .dropdown-menu > li > a:focus {
+    color: #2c3e50;
+    background-color: transparent;
+  }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a,
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:hover,
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .active > a:focus {
+    color: #ffffff;
+    background-color: #15a589;
+  }
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a,
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:hover,
+  .navbar-inverse .navbar-nav .open .dropdown-menu > .disabled > a:focus {
+    color: #cccccc;
+    background-color: transparent;
+  }
+}
+.navbar-inverse .navbar-link {
+  color: #ffffff;
+}
+.navbar-inverse .navbar-link:hover {
+  color: #2c3e50;
+}
+.navbar-inverse .btn-link {
+  color: #ffffff;
+}
+.navbar-inverse .btn-link:hover,
+.navbar-inverse .btn-link:focus {
+  color: #2c3e50;
+}
+.navbar-inverse .btn-link[disabled]:hover,
+fieldset[disabled] .navbar-inverse .btn-link:hover,
+.navbar-inverse .btn-link[disabled]:focus,
+fieldset[disabled] .navbar-inverse .btn-link:focus {
+  color: #cccccc;
+}
+.breadcrumb {
+  padding: 8px 15px;
+  margin-bottom: 21px;
+  list-style: none;
+  background-color: #ecf0f1;
+  border-radius: 4px;
+}
+.breadcrumb > li {
+  display: inline-block;
+}
+.breadcrumb > li + li:before {
+  content: "/\00a0";
+  padding: 0 5px;
+  color: #cccccc;
+}
+.breadcrumb > .active {
+  color: #95a5a6;
+}
+.pagination {
+  display: inline-block;
+  padding-left: 0;
+  margin: 21px 0;
+  border-radius: 4px;
+}
+.pagination > li {
+  display: inline;
+}
+.pagination > li > a,
+.pagination > li > span {
+  position: relative;
+  float: left;
+  padding: 10px 15px;
+  line-height: 1.42857143;
+  text-decoration: none;
+  color: #ffffff;
+  background-color: #18bc9c;
+  border: 1px solid transparent;
+  margin-left: -1px;
+}
+.pagination > li:first-child > a,
+.pagination > li:first-child > span {
+  margin-left: 0;
+  border-bottom-left-radius: 4px;
+  border-top-left-radius: 4px;
+}
+.pagination > li:last-child > a,
+.pagination > li:last-child > span {
+  border-bottom-right-radius: 4px;
+  border-top-right-radius: 4px;
+}
+.pagination > li > a:hover,
+.pagination > li > span:hover,
+.pagination > li > a:focus,
+.pagination > li > span:focus {
+  z-index: 2;
+  color: #ffffff;
+  background-color: #0f7864;
+  border-color: transparent;
+}
+.pagination > .active > a,
+.pagination > .active > span,
+.pagination > .active > a:hover,
+.pagination > .active > span:hover,
+.pagination > .active > a:focus,
+.pagination > .active > span:focus {
+  z-index: 3;
+  color: #ffffff;
+  background-color: #0f7864;
+  border-color: transparent;
+  cursor: default;
+}
+.pagination > .disabled > span,
+.pagination > .disabled > span:hover,
+.pagination > .disabled > span:focus,
+.pagination > .disabled > a,
+.pagination > .disabled > a:hover,
+.pagination > .disabled > a:focus {
+  color: #ecf0f1;
+  background-color: #3be6c4;
+  border-color: transparent;
+  cursor: not-allowed;
+}
+.pagination-lg > li > a,
+.pagination-lg > li > span {
+  padding: 18px 27px;
+  font-size: 19px;
+  line-height: 1.3333333;
+}
+.pagination-lg > li:first-child > a,
+.pagination-lg > li:first-child > span {
+  border-bottom-left-radius: 6px;
+  border-top-left-radius: 6px;
+}
+.pagination-lg > li:last-child > a,
+.pagination-lg > li:last-child > span {
+  border-bottom-right-radius: 6px;
+  border-top-right-radius: 6px;
+}
+.pagination-sm > li > a,
+.pagination-sm > li > span {
+  padding: 6px 9px;
+  font-size: 13px;
+  line-height: 1.5;
+}
+.pagination-sm > li:first-child > a,
+.pagination-sm > li:first-child > span {
+  border-bottom-left-radius: 3px;
+  border-top-left-radius: 3px;
+}
+.pagination-sm > li:last-child > a,
+.pagination-sm > li:last-child > span {
+  border-bottom-right-radius: 3px;
+  border-top-right-radius: 3px;
+}
+.pager {
+  padding-left: 0;
+  margin: 21px 0;
+  list-style: none;
+  text-align: center;
+}
+.pager li {
+  display: inline;
+}
+.pager li > a,
+.pager li > span {
+  display: inline-block;
+  padding: 5px 14px;
+  background-color: #18bc9c;
+  border: 1px solid transparent;
+  border-radius: 15px;
+}
+.pager li > a:hover,
+.pager li > a:focus {
+  text-decoration: none;
+  background-color: #0f7864;
+}
+.pager .next > a,
+.pager .next > span {
+  float: right;
+}
+.pager .previous > a,
+.pager .previous > span {
+  float: left;
+}
+.pager .disabled > a,
+.pager .disabled > a:hover,
+.pager .disabled > a:focus,
+.pager .disabled > span {
+  color: #ffffff;
+  background-color: #18bc9c;
+  cursor: not-allowed;
+}
+.label {
+  display: inline;
+  padding: .2em .6em .3em;
+  font-size: 75%;
+  font-weight: bold;
+  line-height: 1;
+  color: #ffffff;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border-radius: .25em;
+}
+a.label:hover,
+a.label:focus {
+  color: #ffffff;
+  text-decoration: none;
+  cursor: pointer;
+}
+.label:empty {
+  display: none;
+}
+.btn .label {
+  position: relative;
+  top: -1px;
+}
+.label-default {
+  background-color: #95a5a6;
+}
+.label-default[href]:hover,
+.label-default[href]:focus {
+  background-color: #798d8f;
+}
+.label-primary {
+  background-color: #2c3e50;
+}
+.label-primary[href]:hover,
+.label-primary[href]:focus {
+  background-color: #1a242f;
+}
+.label-success {
+  background-color: #18bc9c;
+}
+.label-success[href]:hover,
+.label-success[href]:focus {
+  background-color: #128f76;
+}
+.label-info {
+  background-color: #3498db;
+}
+.label-info[href]:hover,
+.label-info[href]:focus {
+  background-color: #217dbb;
+}
+.label-warning {
+  background-color: #f39c12;
+}
+.label-warning[href]:hover,
+.label-warning[href]:focus {
+  background-color: #c87f0a;
+}
+.label-danger {
+  background-color: #e74c3c;
+}
+.label-danger[href]:hover,
+.label-danger[href]:focus {
+  background-color: #d62c1a;
+}
+.badge {
+  display: inline-block;
+  min-width: 10px;
+  padding: 3px 7px;
+  font-size: 13px;
+  font-weight: bold;
+  color: #ffffff;
+  line-height: 1;
+  vertical-align: middle;
+  white-space: nowrap;
+  text-align: center;
+  background-color: #2c3e50;
+  border-radius: 10px;
+}
+.badge:empty {
+  display: none;
+}
+.btn .badge {
+  position: relative;
+  top: -1px;
+}
+.btn-xs .badge,
+.btn-group-xs > .btn .badge {
+  top: 0;
+  padding: 1px 5px;
+}
+a.badge:hover,
+a.badge:focus {
+  color: #ffffff;
+  text-decoration: none;
+  cursor: pointer;
+}
+.list-group-item.active > .badge,
+.nav-pills > .active > a > .badge {
+  color: #2c3e50;
+  background-color: #ffffff;
+}
+.list-group-item > .badge {
+  float: right;
+}
+.list-group-item > .badge + .badge {
+  margin-right: 5px;
+}
+.nav-pills > li > a > .badge {
+  margin-left: 3px;
+}
+.jumbotron {
+  padding-top: 30px;
+  padding-bottom: 30px;
+  margin-bottom: 30px;
+  color: inherit;
+  background-color: #ecf0f1;
+}
+.jumbotron h1,
+.jumbotron .h1 {
+  color: inherit;
+}
+.jumbotron p {
+  margin-bottom: 15px;
+  font-size: 23px;
+  font-weight: 200;
+}
+.jumbotron > hr {
+  border-top-color: #cfd9db;
+}
+.container .jumbotron,
+.container-fluid .jumbotron {
+  border-radius: 6px;
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.jumbotron .container {
+  max-width: 100%;
+}
+@media screen and (min-width: 768px) {
+  .jumbotron {
+    padding-top: 48px;
+    padding-bottom: 48px;
+  }
+  .container .jumbotron,
+  .container-fluid .jumbotron {
+    padding-left: 60px;
+    padding-right: 60px;
+  }
+  .jumbotron h1,
+  .jumbotron .h1 {
+    font-size: 68px;
+  }
+}
+.thumbnail {
+  display: block;
+  padding: 4px;
+  margin-bottom: 21px;
+  line-height: 1.42857143;
+  background-color: #ffffff;
+  border: 1px solid #ecf0f1;
+  border-radius: 4px;
+  -webkit-transition: border 0.2s ease-in-out;
+  -o-transition: border 0.2s ease-in-out;
+  transition: border 0.2s ease-in-out;
+}
+.thumbnail > img,
+.thumbnail a > img {
+  margin-left: auto;
+  margin-right: auto;
+}
+a.thumbnail:hover,
+a.thumbnail:focus,
+a.thumbnail.active {
+  border-color: #18bc9c;
+}
+.thumbnail .caption {
+  padding: 9px;
+  color: #2c3e50;
+}
+.alert {
+  padding: 15px;
+  margin-bottom: 21px;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+.alert h4 {
+  margin-top: 0;
+  color: inherit;
+}
+.alert .alert-link {
+  font-weight: bold;
+}
+.alert > p,
+.alert > ul {
+  margin-bottom: 0;
+}
+.alert > p + p {
+  margin-top: 5px;
+}
+.alert-dismissable,
+.alert-dismissible {
+  padding-right: 35px;
+}
+.alert-dismissable .close,
+.alert-dismissible .close {
+  position: relative;
+  top: -2px;
+  right: -21px;
+  color: inherit;
+}
+.alert-success {
+  background-color: #18bc9c;
+  border-color: #18bc9c;
+  color: #ffffff;
+}
+.alert-success hr {
+  border-top-color: #15a589;
+}
+.alert-success .alert-link {
+  color: #e6e6e6;
+}
+.alert-info {
+  background-color: #3498db;
+  border-color: #3498db;
+  color: #ffffff;
+}
+.alert-info hr {
+  border-top-color: #258cd1;
+}
+.alert-info .alert-link {
+  color: #e6e6e6;
+}
+.alert-warning {
+  background-color: #f39c12;
+  border-color: #f39c12;
+  color: #ffffff;
+}
+.alert-warning hr {
+  border-top-color: #e08e0b;
+}
+.alert-warning .alert-link {
+  color: #e6e6e6;
+}
+.alert-danger {
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+  color: #ffffff;
+}
+.alert-danger hr {
+  border-top-color: #e43725;
+}
+.alert-danger .alert-link {
+  color: #e6e6e6;
+}
+@-webkit-keyframes progress-bar-stripes {
+  from {
+    background-position: 40px 0;
+  }
+  to {
+    background-position: 0 0;
+  }
+}
+@-o-keyframes progress-bar-stripes {
+  from {
+    background-position: 40px 0;
+  }
+  to {
+    background-position: 0 0;
+  }
+}
+@keyframes progress-bar-stripes {
+  from {
+    background-position: 40px 0;
+  }
+  to {
+    background-position: 0 0;
+  }
+}
+.progress {
+  overflow: hidden;
+  height: 21px;
+  margin-bottom: 21px;
+  background-color: #ecf0f1;
+  border-radius: 4px;
+  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+.progress-bar {
+  float: left;
+  width: 0%;
+  height: 100%;
+  font-size: 13px;
+  line-height: 21px;
+  color: #ffffff;
+  text-align: center;
+  background-color: #2c3e50;
+  -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+  -webkit-transition: width 0.6s ease;
+  -o-transition: width 0.6s ease;
+  transition: width 0.6s ease;
+}
+.progress-striped .progress-bar,
+.progress-bar-striped {
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  -webkit-background-size: 40px 40px;
+          background-size: 40px 40px;
+}
+.progress.active .progress-bar,
+.progress-bar.active {
+  -webkit-animation: progress-bar-stripes 2s linear infinite;
+  -o-animation: progress-bar-stripes 2s linear infinite;
+  animation: progress-bar-stripes 2s linear infinite;
+}
+.progress-bar-success {
+  background-color: #18bc9c;
+}
+.progress-striped .progress-bar-success {
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+}
+.progress-bar-info {
+  background-color: #3498db;
+}
+.progress-striped .progress-bar-info {
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+}
+.progress-bar-warning {
+  background-color: #f39c12;
+}
+.progress-striped .progress-bar-warning {
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+}
+.progress-bar-danger {
+  background-color: #e74c3c;
+}
+.progress-striped .progress-bar-danger {
+  background-image: -webkit-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: -o-linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
+}
+.media {
+  margin-top: 15px;
+}
+.media:first-child {
+  margin-top: 0;
+}
+.media,
+.media-body {
+  zoom: 1;
+  overflow: hidden;
+}
+.media-body {
+  width: 10000px;
+}
+.media-object {
+  display: block;
+}
+.media-object.img-thumbnail {
+  max-width: none;
+}
+.media-right,
+.media > .pull-right {
+  padding-left: 10px;
+}
+.media-left,
+.media > .pull-left {
+  padding-right: 10px;
+}
+.media-left,
+.media-right,
+.media-body {
+  display: table-cell;
+  vertical-align: top;
+}
+.media-middle {
+  vertical-align: middle;
+}
+.media-bottom {
+  vertical-align: bottom;
+}
+.media-heading {
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+.media-list {
+  padding-left: 0;
+  list-style: none;
+}
+.list-group {
+  margin-bottom: 20px;
+  padding-left: 0;
+}
+.list-group-item {
+  position: relative;
+  display: block;
+  padding: 10px 15px;
+  margin-bottom: -1px;
+  background-color: #ffffff;
+  border: 1px solid #ecf0f1;
+}
+.list-group-item:first-child {
+  border-top-right-radius: 4px;
+  border-top-left-radius: 4px;
+}
+.list-group-item:last-child {
+  margin-bottom: 0;
+  border-bottom-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+a.list-group-item,
+button.list-group-item {
+  color: #555555;
+}
+a.list-group-item .list-group-item-heading,
+button.list-group-item .list-group-item-heading {
+  color: #333333;
+}
+a.list-group-item:hover,
+button.list-group-item:hover,
+a.list-group-item:focus,
+button.list-group-item:focus {
+  text-decoration: none;
+  color: #555555;
+  background-color: #ecf0f1;
+}
+button.list-group-item {
+  width: 100%;
+  text-align: left;
+}
+.list-group-item.disabled,
+.list-group-item.disabled:hover,
+.list-group-item.disabled:focus {
+  background-color: #ecf0f1;
+  color: #b4bcc2;
+  cursor: not-allowed;
+}
+.list-group-item.disabled .list-group-item-heading,
+.list-group-item.disabled:hover .list-group-item-heading,
+.list-group-item.disabled:focus .list-group-item-heading {
+  color: inherit;
+}
+.list-group-item.disabled .list-group-item-text,
+.list-group-item.disabled:hover .list-group-item-text,
+.list-group-item.disabled:focus .list-group-item-text {
+  color: #b4bcc2;
+}
+.list-group-item.active,
+.list-group-item.active:hover,
+.list-group-item.active:focus {
+  z-index: 2;
+  color: #ffffff;
+  background-color: #2c3e50;
+  border-color: #2c3e50;
+}
+.list-group-item.active .list-group-item-heading,
+.list-group-item.active:hover .list-group-item-heading,
+.list-group-item.active:focus .list-group-item-heading,
+.list-group-item.active .list-group-item-heading > small,
+.list-group-item.active:hover .list-group-item-heading > small,
+.list-group-item.active:focus .list-group-item-heading > small,
+.list-group-item.active .list-group-item-heading > .small,
+.list-group-item.active:hover .list-group-item-heading > .small,
+.list-group-item.active:focus .list-group-item-heading > .small {
+  color: inherit;
+}
+.list-group-item.active .list-group-item-text,
+.list-group-item.active:hover .list-group-item-text,
+.list-group-item.active:focus .list-group-item-text {
+  color: #8aa4be;
+}
+.list-group-item-success {
+  color: #ffffff;
+  background-color: #18bc9c;
+}
+a.list-group-item-success,
+button.list-group-item-success {
+  color: #ffffff;
+}
+a.list-group-item-success .list-group-item-heading,
+button.list-group-item-success .list-group-item-heading {
+  color: inherit;
+}
+a.list-group-item-success:hover,
+button.list-group-item-success:hover,
+a.list-group-item-success:focus,
+button.list-group-item-success:focus {
+  color: #ffffff;
+  background-color: #15a589;
+}
+a.list-group-item-success.active,
+button.list-group-item-success.active,
+a.list-group-item-success.active:hover,
+button.list-group-item-success.active:hover,
+a.list-group-item-success.active:focus,
+button.list-group-item-success.active:focus {
+  color: #fff;
+  background-color: #ffffff;
+  border-color: #ffffff;
+}
+.list-group-item-info {
+  color: #ffffff;
+  background-color: #3498db;
+}
+a.list-group-item-info,
+button.list-group-item-info {
+  color: #ffffff;
+}
+a.list-group-item-info .list-group-item-heading,
+button.list-group-item-info .list-group-item-heading {
+  color: inherit;
+}
+a.list-group-item-info:hover,
+button.list-group-item-info:hover,
+a.list-group-item-info:focus,
+button.list-group-item-info:focus {
+  color: #ffffff;
+  background-color: #258cd1;
+}
+a.list-group-item-info.active,
+button.list-group-item-info.active,
+a.list-group-item-info.active:hover,
+button.list-group-item-info.active:hover,
+a.list-group-item-info.active:focus,
+button.list-group-item-info.active:focus {
+  color: #fff;
+  background-color: #ffffff;
+  border-color: #ffffff;
+}
+.list-group-item-warning {
+  color: #ffffff;
+  background-color: #f39c12;
+}
+a.list-group-item-warning,
+button.list-group-item-warning {
+  color: #ffffff;
+}
+a.list-group-item-warning .list-group-item-heading,
+button.list-group-item-warning .list-group-item-heading {
+  color: inherit;
+}
+a.list-group-item-warning:hover,
+button.list-group-item-warning:hover,
+a.list-group-item-warning:focus,
+button.list-group-item-warning:focus {
+  color: #ffffff;
+  background-color: #e08e0b;
+}
+a.list-group-item-warning.active,
+button.list-group-item-warning.active,
+a.list-group-item-warning.active:hover,
+button.list-group-item-warning.active:hover,
+a.list-group-item-warning.active:focus,
+button.list-group-item-warning.active:focus {
+  color: #fff;
+  background-color: #ffffff;
+  border-color: #ffffff;
+}
+.list-group-item-danger {
+  color: #ffffff;
+  background-color: #e74c3c;
+}
+a.list-group-item-danger,
+button.list-group-item-danger {
+  color: #ffffff;
+}
+a.list-group-item-danger .list-group-item-heading,
+button.list-group-item-danger .list-group-item-heading {
+  color: inherit;
+}
+a.list-group-item-danger:hover,
+button.list-group-item-danger:hover,
+a.list-group-item-danger:focus,
+button.list-group-item-danger:focus {
+  color: #ffffff;
+  background-color: #e43725;
+}
+a.list-group-item-danger.active,
+button.list-group-item-danger.active,
+a.list-group-item-danger.active:hover,
+button.list-group-item-danger.active:hover,
+a.list-group-item-danger.active:focus,
+button.list-group-item-danger.active:focus {
+  color: #fff;
+  background-color: #ffffff;
+  border-color: #ffffff;
+}
+.list-group-item-heading {
+  margin-top: 0;
+  margin-bottom: 5px;
+}
+.list-group-item-text {
+  margin-bottom: 0;
+  line-height: 1.3;
+}
+.panel {
+  margin-bottom: 21px;
+  background-color: #ffffff;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+}
+.panel-body {
+  padding: 15px;
+}
+.panel-heading {
+  padding: 10px 15px;
+  border-bottom: 1px solid transparent;
+  border-top-right-radius: 3px;
+  border-top-left-radius: 3px;
+}
+.panel-heading > .dropdown .dropdown-toggle {
+  color: inherit;
+}
+.panel-title {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-size: 17px;
+  color: inherit;
+}
+.panel-title > a,
+.panel-title > small,
+.panel-title > .small,
+.panel-title > small > a,
+.panel-title > .small > a {
+  color: inherit;
+}
+.panel-footer {
+  padding: 10px 15px;
+  background-color: #ecf0f1;
+  border-top: 1px solid #ecf0f1;
+  border-bottom-right-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+.panel > .list-group,
+.panel > .panel-collapse > .list-group {
+  margin-bottom: 0;
+}
+.panel > .list-group .list-group-item,
+.panel > .panel-collapse > .list-group .list-group-item {
+  border-width: 1px 0;
+  border-radius: 0;
+}
+.panel > .list-group:first-child .list-group-item:first-child,
+.panel > .panel-collapse > .list-group:first-child .list-group-item:first-child {
+  border-top: 0;
+  border-top-right-radius: 3px;
+  border-top-left-radius: 3px;
+}
+.panel > .list-group:last-child .list-group-item:last-child,
+.panel > .panel-collapse > .list-group:last-child .list-group-item:last-child {
+  border-bottom: 0;
+  border-bottom-right-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+.panel > .panel-heading + .panel-collapse > .list-group .list-group-item:first-child {
+  border-top-right-radius: 0;
+  border-top-left-radius: 0;
+}
+.panel-heading + .list-group .list-group-item:first-child {
+  border-top-width: 0;
+}
+.list-group + .panel-footer {
+  border-top-width: 0;
+}
+.panel > .table,
+.panel > .table-responsive > .table,
+.panel > .panel-collapse > .table {
+  margin-bottom: 0;
+}
+.panel > .table caption,
+.panel > .table-responsive > .table caption,
+.panel > .panel-collapse > .table caption {
+  padding-left: 15px;
+  padding-right: 15px;
+}
+.panel > .table:first-child,
+.panel > .table-responsive:first-child > .table:first-child {
+  border-top-right-radius: 3px;
+  border-top-left-radius: 3px;
+}
+.panel > .table:first-child > thead:first-child > tr:first-child,
+.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child,
+.panel > .table:first-child > tbody:first-child > tr:first-child,
+.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child {
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+}
+.panel > .table:first-child > thead:first-child > tr:first-child td:first-child,
+.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:first-child,
+.panel > .table:first-child > tbody:first-child > tr:first-child td:first-child,
+.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:first-child,
+.panel > .table:first-child > thead:first-child > tr:first-child th:first-child,
+.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:first-child,
+.panel > .table:first-child > tbody:first-child > tr:first-child th:first-child,
+.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:first-child {
+  border-top-left-radius: 3px;
+}
+.panel > .table:first-child > thead:first-child > tr:first-child td:last-child,
+.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child td:last-child,
+.panel > .table:first-child > tbody:first-child > tr:first-child td:last-child,
+.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child td:last-child,
+.panel > .table:first-child > thead:first-child > tr:first-child th:last-child,
+.panel > .table-responsive:first-child > .table:first-child > thead:first-child > tr:first-child th:last-child,
+.panel > .table:first-child > tbody:first-child > tr:first-child th:last-child,
+.panel > .table-responsive:first-child > .table:first-child > tbody:first-child > tr:first-child th:last-child {
+  border-top-right-radius: 3px;
+}
+.panel > .table:last-child,
+.panel > .table-responsive:last-child > .table:last-child {
+  border-bottom-right-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+.panel > .table:last-child > tbody:last-child > tr:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child,
+.panel > .table:last-child > tfoot:last-child > tr:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child {
+  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 3px;
+}
+.panel > .table:last-child > tbody:last-child > tr:last-child td:first-child,
+.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:first-child,
+.panel > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
+.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:first-child,
+.panel > .table:last-child > tbody:last-child > tr:last-child th:first-child,
+.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:first-child,
+.panel > .table:last-child > tfoot:last-child > tr:last-child th:first-child,
+.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:first-child {
+  border-bottom-left-radius: 3px;
+}
+.panel > .table:last-child > tbody:last-child > tr:last-child td:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child td:last-child,
+.panel > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child td:last-child,
+.panel > .table:last-child > tbody:last-child > tr:last-child th:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tbody:last-child > tr:last-child th:last-child,
+.panel > .table:last-child > tfoot:last-child > tr:last-child th:last-child,
+.panel > .table-responsive:last-child > .table:last-child > tfoot:last-child > tr:last-child th:last-child {
+  border-bottom-right-radius: 3px;
+}
+.panel > .panel-body + .table,
+.panel > .panel-body + .table-responsive,
+.panel > .table + .panel-body,
+.panel > .table-responsive + .panel-body {
+  border-top: 1px solid #ecf0f1;
+}
+.panel > .table > tbody:first-child > tr:first-child th,
+.panel > .table > tbody:first-child > tr:first-child td {
+  border-top: 0;
+}
+.panel > .table-bordered,
+.panel > .table-responsive > .table-bordered {
+  border: 0;
+}
+.panel > .table-bordered > thead > tr > th:first-child,
+.panel > .table-responsive > .table-bordered > thead > tr > th:first-child,
+.panel > .table-bordered > tbody > tr > th:first-child,
+.panel > .table-responsive > .table-bordered > tbody > tr > th:first-child,
+.panel > .table-bordered > tfoot > tr > th:first-child,
+.panel > .table-responsive > .table-bordered > tfoot > tr > th:first-child,
+.panel > .table-bordered > thead > tr > td:first-child,
+.panel > .table-responsive > .table-bordered > thead > tr > td:first-child,
+.panel > .table-bordered > tbody > tr > td:first-child,
+.panel > .table-responsive > .table-bordered > tbody > tr > td:first-child,
+.panel > .table-bordered > tfoot > tr > td:first-child,
+.panel > .table-responsive > .table-bordered > tfoot > tr > td:first-child {
+  border-left: 0;
+}
+.panel > .table-bordered > thead > tr > th:last-child,
+.panel > .table-responsive > .table-bordered > thead > tr > th:last-child,
+.panel > .table-bordered > tbody > tr > th:last-child,
+.panel > .table-responsive > .table-bordered > tbody > tr > th:last-child,
+.panel > .table-bordered > tfoot > tr > th:last-child,
+.panel > .table-responsive > .table-bordered > tfoot > tr > th:last-child,
+.panel > .table-bordered > thead > tr > td:last-child,
+.panel > .table-responsive > .table-bordered > thead > tr > td:last-child,
+.panel > .table-bordered > tbody > tr > td:last-child,
+.panel > .table-responsive > .table-bordered > tbody > tr > td:last-child,
+.panel > .table-bordered > tfoot > tr > td:last-child,
+.panel > .table-responsive > .table-bordered > tfoot > tr > td:last-child {
+  border-right: 0;
+}
+.panel > .table-bordered > thead > tr:first-child > td,
+.panel > .table-responsive > .table-bordered > thead > tr:first-child > td,
+.panel > .table-bordered > tbody > tr:first-child > td,
+.panel > .table-responsive > .table-bordered > tbody > tr:first-child > td,
+.panel > .table-bordered > thead > tr:first-child > th,
+.panel > .table-responsive > .table-bordered > thead > tr:first-child > th,
+.panel > .table-bordered > tbody > tr:first-child > th,
+.panel > .table-responsive > .table-bordered > tbody > tr:first-child > th {
+  border-bottom: 0;
+}
+.panel > .table-bordered > tbody > tr:last-child > td,
+.panel > .table-responsive > .table-bordered > tbody > tr:last-child > td,
+.panel > .table-bordered > tfoot > tr:last-child > td,
+.panel > .table-responsive > .table-bordered > tfoot > tr:last-child > td,
+.panel > .table-bordered > tbody > tr:last-child > th,
+.panel > .table-responsive > .table-bordered > tbody > tr:last-child > th,
+.panel > .table-bordered > tfoot > tr:last-child > th,
+.panel > .table-responsive > .table-bordered > tfoot > tr:last-child > th {
+  border-bottom: 0;
+}
+.panel > .table-responsive {
+  border: 0;
+  margin-bottom: 0;
+}
+.panel-group {
+  margin-bottom: 21px;
+}
+.panel-group .panel {
+  margin-bottom: 0;
+  border-radius: 4px;
+}
+.panel-group .panel + .panel {
+  margin-top: 5px;
+}
+.panel-group .panel-heading {
+  border-bottom: 0;
+}
+.panel-group .panel-heading + .panel-collapse > .panel-body,
+.panel-group .panel-heading + .panel-collapse > .list-group {
+  border-top: 1px solid #ecf0f1;
+}
+.panel-group .panel-footer {
+  border-top: 0;
+}
+.panel-group .panel-footer + .panel-collapse .panel-body {
+  border-bottom: 1px solid #ecf0f1;
+}
+.panel-default {
+  border-color: #ecf0f1;
+}
+.panel-default > .panel-heading {
+  color: #2c3e50;
+  background-color: #ecf0f1;
+  border-color: #ecf0f1;
+}
+.panel-default > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #ecf0f1;
+}
+.panel-default > .panel-heading .badge {
+  color: #ecf0f1;
+  background-color: #2c3e50;
+}
+.panel-default > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #ecf0f1;
+}
+.panel-primary {
+  border-color: #2c3e50;
+}
+.panel-primary > .panel-heading {
+  color: #ffffff;
+  background-color: #2c3e50;
+  border-color: #2c3e50;
+}
+.panel-primary > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #2c3e50;
+}
+.panel-primary > .panel-heading .badge {
+  color: #2c3e50;
+  background-color: #ffffff;
+}
+.panel-primary > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #2c3e50;
+}
+.panel-success {
+  border-color: #18bc9c;
+}
+.panel-success > .panel-heading {
+  color: #ffffff;
+  background-color: #18bc9c;
+  border-color: #18bc9c;
+}
+.panel-success > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #18bc9c;
+}
+.panel-success > .panel-heading .badge {
+  color: #18bc9c;
+  background-color: #ffffff;
+}
+.panel-success > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #18bc9c;
+}
+.panel-info {
+  border-color: #3498db;
+}
+.panel-info > .panel-heading {
+  color: #ffffff;
+  background-color: #3498db;
+  border-color: #3498db;
+}
+.panel-info > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #3498db;
+}
+.panel-info > .panel-heading .badge {
+  color: #3498db;
+  background-color: #ffffff;
+}
+.panel-info > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #3498db;
+}
+.panel-warning {
+  border-color: #f39c12;
+}
+.panel-warning > .panel-heading {
+  color: #ffffff;
+  background-color: #f39c12;
+  border-color: #f39c12;
+}
+.panel-warning > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #f39c12;
+}
+.panel-warning > .panel-heading .badge {
+  color: #f39c12;
+  background-color: #ffffff;
+}
+.panel-warning > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #f39c12;
+}
+.panel-danger {
+  border-color: #e74c3c;
+}
+.panel-danger > .panel-heading {
+  color: #ffffff;
+  background-color: #e74c3c;
+  border-color: #e74c3c;
+}
+.panel-danger > .panel-heading + .panel-collapse > .panel-body {
+  border-top-color: #e74c3c;
+}
+.panel-danger > .panel-heading .badge {
+  color: #e74c3c;
+  background-color: #ffffff;
+}
+.panel-danger > .panel-footer + .panel-collapse > .panel-body {
+  border-bottom-color: #e74c3c;
+}
+.embed-responsive {
+  position: relative;
+  display: block;
+  height: 0;
+  padding: 0;
+  overflow: hidden;
+}
+.embed-responsive .embed-responsive-item,
+.embed-responsive iframe,
+.embed-responsive embed,
+.embed-responsive object,
+.embed-responsive video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  height: 100%;
+  width: 100%;
+  border: 0;
+}
+.embed-responsive-16by9 {
+  padding-bottom: 56.25%;
+}
+.embed-responsive-4by3 {
+  padding-bottom: 75%;
+}
+.well {
+  min-height: 20px;
+  padding: 19px;
+  margin-bottom: 20px;
+  background-color: #ecf0f1;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+}
+.well blockquote {
+  border-color: #ddd;
+  border-color: rgba(0, 0, 0, 0.15);
+}
+.well-lg {
+  padding: 24px;
+  border-radius: 6px;
+}
+.well-sm {
+  padding: 9px;
+  border-radius: 3px;
+}
+.close {
+  float: right;
+  font-size: 22.5px;
+  font-weight: bold;
+  line-height: 1;
+  color: #000000;
+  text-shadow: none;
+  opacity: 0.2;
+  filter: alpha(opacity=20);
+}
+.close:hover,
+.close:focus {
+  color: #000000;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 0.5;
+  filter: alpha(opacity=50);
+}
+button.close {
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  -webkit-appearance: none;
+}
+.modal-open {
+  overflow: hidden;
+}
+.modal {
+  display: none;
+  overflow: hidden;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1050;
+  -webkit-overflow-scrolling: touch;
+  outline: 0;
+}
+.modal.fade .modal-dialog {
+  -webkit-transform: translate(0, -25%);
+  -ms-transform: translate(0, -25%);
+  -o-transform: translate(0, -25%);
+  transform: translate(0, -25%);
+  -webkit-transition: -webkit-transform 0.3s ease-out;
+  -o-transition: -o-transform 0.3s ease-out;
+  transition: transform 0.3s ease-out;
+}
+.modal.in .modal-dialog {
+  -webkit-transform: translate(0, 0);
+  -ms-transform: translate(0, 0);
+  -o-transform: translate(0, 0);
+  transform: translate(0, 0);
+}
+.modal-open .modal {
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.modal-dialog {
+  position: relative;
+  width: auto;
+  margin: 10px;
+}
+.modal-content {
+  position: relative;
+  background-color: #ffffff;
+  border: 1px solid #999999;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  -webkit-box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 3px 9px rgba(0, 0, 0, 0.5);
+  -webkit-background-clip: padding-box;
+          background-clip: padding-box;
+  outline: 0;
+}
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1040;
+  background-color: #000000;
+}
+.modal-backdrop.fade {
+  opacity: 0;
+  filter: alpha(opacity=0);
+}
+.modal-backdrop.in {
+  opacity: 0.5;
+  filter: alpha(opacity=50);
+}
+.modal-header {
+  padding: 15px;
+  border-bottom: 1px solid #e5e5e5;
+}
+.modal-header .close {
+  margin-top: -2px;
+}
+.modal-title {
+  margin: 0;
+  line-height: 1.42857143;
+}
+.modal-body {
+  position: relative;
+  padding: 20px;
+}
+.modal-footer {
+  padding: 20px;
+  text-align: right;
+  border-top: 1px solid #e5e5e5;
+}
+.modal-footer .btn + .btn {
+  margin-left: 5px;
+  margin-bottom: 0;
+}
+.modal-footer .btn-group .btn + .btn {
+  margin-left: -1px;
+}
+.modal-footer .btn-block + .btn-block {
+  margin-left: 0;
+}
+.modal-scrollbar-measure {
+  position: absolute;
+  top: -9999px;
+  width: 50px;
+  height: 50px;
+  overflow: scroll;
+}
+@media (min-width: 768px) {
+  .modal-dialog {
+    width: 600px;
+    margin: 30px auto;
+  }
+  .modal-content {
+    -webkit-box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.5);
+  }
+  .modal-sm {
+    width: 300px;
+  }
+}
+@media (min-width: 992px) {
+  .modal-lg {
+    width: 900px;
+  }
+}
+.tooltip {
+  position: absolute;
+  z-index: 1070;
+  display: block;
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  letter-spacing: normal;
+  line-break: auto;
+  line-height: 1.42857143;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  white-space: normal;
+  word-break: normal;
+  word-spacing: normal;
+  word-wrap: normal;
+  font-size: 13px;
+  opacity: 0;
+  filter: alpha(opacity=0);
+}
+.tooltip.in {
+  opacity: 0.9;
+  filter: alpha(opacity=90);
+}
+.tooltip.top {
+  margin-top: -3px;
+  padding: 5px 0;
+}
+.tooltip.right {
+  margin-left: 3px;
+  padding: 0 5px;
+}
+.tooltip.bottom {
+  margin-top: 3px;
+  padding: 5px 0;
+}
+.tooltip.left {
+  margin-left: -3px;
+  padding: 0 5px;
+}
+.tooltip-inner {
+  max-width: 200px;
+  padding: 3px 8px;
+  color: #ffffff;
+  text-align: center;
+  background-color: #000000;
+  border-radius: 4px;
+}
+.tooltip-arrow {
+  position: absolute;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+}
+.tooltip.top .tooltip-arrow {
+  bottom: 0;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px 5px 0;
+  border-top-color: #000000;
+}
+.tooltip.top-left .tooltip-arrow {
+  bottom: 0;
+  right: 5px;
+  margin-bottom: -5px;
+  border-width: 5px 5px 0;
+  border-top-color: #000000;
+}
+.tooltip.top-right .tooltip-arrow {
+  bottom: 0;
+  left: 5px;
+  margin-bottom: -5px;
+  border-width: 5px 5px 0;
+  border-top-color: #000000;
+}
+.tooltip.right .tooltip-arrow {
+  top: 50%;
+  left: 0;
+  margin-top: -5px;
+  border-width: 5px 5px 5px 0;
+  border-right-color: #000000;
+}
+.tooltip.left .tooltip-arrow {
+  top: 50%;
+  right: 0;
+  margin-top: -5px;
+  border-width: 5px 0 5px 5px;
+  border-left-color: #000000;
+}
+.tooltip.bottom .tooltip-arrow {
+  top: 0;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 0 5px 5px;
+  border-bottom-color: #000000;
+}
+.tooltip.bottom-left .tooltip-arrow {
+  top: 0;
+  right: 5px;
+  margin-top: -5px;
+  border-width: 0 5px 5px;
+  border-bottom-color: #000000;
+}
+.tooltip.bottom-right .tooltip-arrow {
+  top: 0;
+  left: 5px;
+  margin-top: -5px;
+  border-width: 0 5px 5px;
+  border-bottom-color: #000000;
+}
+.popover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1060;
+  display: none;
+  max-width: 276px;
+  padding: 1px;
+  font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-style: normal;
+  font-weight: normal;
+  letter-spacing: normal;
+  line-break: auto;
+  line-height: 1.42857143;
+  text-align: left;
+  text-align: start;
+  text-decoration: none;
+  text-shadow: none;
+  text-transform: none;
+  white-space: normal;
+  word-break: normal;
+  word-spacing: normal;
+  word-wrap: normal;
+  font-size: 15px;
+  background-color: #ffffff;
+  -webkit-background-clip: padding-box;
+          background-clip: padding-box;
+  border: 1px solid #cccccc;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+}
+.popover.top {
+  margin-top: -10px;
+}
+.popover.right {
+  margin-left: 10px;
+}
+.popover.bottom {
+  margin-top: 10px;
+}
+.popover.left {
+  margin-left: -10px;
+}
+.popover-title {
+  margin: 0;
+  padding: 8px 14px;
+  font-size: 15px;
+  background-color: #f7f7f7;
+  border-bottom: 1px solid #ebebeb;
+  border-radius: 5px 5px 0 0;
+}
+.popover-content {
+  padding: 9px 14px;
+}
+.popover > .arrow,
+.popover > .arrow:after {
+  position: absolute;
+  display: block;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+}
+.popover > .arrow {
+  border-width: 11px;
+}
+.popover > .arrow:after {
+  border-width: 10px;
+  content: "";
+}
+.popover.top > .arrow {
+  left: 50%;
+  margin-left: -11px;
+  border-bottom-width: 0;
+  border-top-color: #999999;
+  border-top-color: rgba(0, 0, 0, 0.25);
+  bottom: -11px;
+}
+.popover.top > .arrow:after {
+  content: " ";
+  bottom: 1px;
+  margin-left: -10px;
+  border-bottom-width: 0;
+  border-top-color: #ffffff;
+}
+.popover.right > .arrow {
+  top: 50%;
+  left: -11px;
+  margin-top: -11px;
+  border-left-width: 0;
+  border-right-color: #999999;
+  border-right-color: rgba(0, 0, 0, 0.25);
+}
+.popover.right > .arrow:after {
+  content: " ";
+  left: 1px;
+  bottom: -10px;
+  border-left-width: 0;
+  border-right-color: #ffffff;
+}
+.popover.bottom > .arrow {
+  left: 50%;
+  margin-left: -11px;
+  border-top-width: 0;
+  border-bottom-color: #999999;
+  border-bottom-color: rgba(0, 0, 0, 0.25);
+  top: -11px;
+}
+.popover.bottom > .arrow:after {
+  content: " ";
+  top: 1px;
+  margin-left: -10px;
+  border-top-width: 0;
+  border-bottom-color: #ffffff;
+}
+.popover.left > .arrow {
+  top: 50%;
+  right: -11px;
+  margin-top: -11px;
+  border-right-width: 0;
+  border-left-color: #999999;
+  border-left-color: rgba(0, 0, 0, 0.25);
+}
+.popover.left > .arrow:after {
+  content: " ";
+  right: 1px;
+  border-right-width: 0;
+  border-left-color: #ffffff;
+  bottom: -10px;
+}
+.carousel {
+  position: relative;
+}
+.carousel-inner {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+}
+.carousel-inner > .item {
+  display: none;
+  position: relative;
+  -webkit-transition: 0.6s ease-in-out left;
+  -o-transition: 0.6s ease-in-out left;
+  transition: 0.6s ease-in-out left;
+}
+.carousel-inner > .item > img,
+.carousel-inner > .item > a > img {
+  line-height: 1;
+}
+@media all and (transform-3d), (-webkit-transform-3d) {
+  .carousel-inner > .item {
+    -webkit-transition: -webkit-transform 0.6s ease-in-out;
+    -o-transition: -o-transform 0.6s ease-in-out;
+    transition: transform 0.6s ease-in-out;
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+    -webkit-perspective: 1000px;
+    perspective: 1000px;
+  }
+  .carousel-inner > .item.next,
+  .carousel-inner > .item.active.right {
+    -webkit-transform: translate3d(100%, 0, 0);
+    transform: translate3d(100%, 0, 0);
+    left: 0;
+  }
+  .carousel-inner > .item.prev,
+  .carousel-inner > .item.active.left {
+    -webkit-transform: translate3d(-100%, 0, 0);
+    transform: translate3d(-100%, 0, 0);
+    left: 0;
+  }
+  .carousel-inner > .item.next.left,
+  .carousel-inner > .item.prev.right,
+  .carousel-inner > .item.active {
+    -webkit-transform: translate3d(0, 0, 0);
+    transform: translate3d(0, 0, 0);
+    left: 0;
+  }
+}
+.carousel-inner > .active,
+.carousel-inner > .next,
+.carousel-inner > .prev {
+  display: block;
+}
+.carousel-inner > .active {
+  left: 0;
+}
+.carousel-inner > .next,
+.carousel-inner > .prev {
+  position: absolute;
+  top: 0;
+  width: 100%;
+}
+.carousel-inner > .next {
+  left: 100%;
+}
+.carousel-inner > .prev {
+  left: -100%;
+}
+.carousel-inner > .next.left,
+.carousel-inner > .prev.right {
+  left: 0;
+}
+.carousel-inner > .active.left {
+  left: -100%;
+}
+.carousel-inner > .active.right {
+  left: 100%;
+}
+.carousel-control {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 15%;
+  opacity: 0.5;
+  filter: alpha(opacity=50);
+  font-size: 20px;
+  color: #ffffff;
+  text-align: center;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  background-color: rgba(0, 0, 0, 0);
+}
+.carousel-control.left {
+  background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
+  background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
+  background-image: -webkit-gradient(linear, left top, right top, from(rgba(0, 0, 0, 0.5)), to(rgba(0, 0, 0, 0.0001)));
+  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.5) 0%, rgba(0, 0, 0, 0.0001) 100%);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#80000000', endColorstr='#00000000', GradientType=1);
+}
+.carousel-control.right {
+  left: auto;
+  right: 0;
+  background-image: -webkit-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
+  background-image: -o-linear-gradient(left, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
+  background-image: -webkit-gradient(linear, left top, right top, from(rgba(0, 0, 0, 0.0001)), to(rgba(0, 0, 0, 0.5)));
+  background-image: linear-gradient(to right, rgba(0, 0, 0, 0.0001) 0%, rgba(0, 0, 0, 0.5) 100%);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#00000000', endColorstr='#80000000', GradientType=1);
+}
+.carousel-control:hover,
+.carousel-control:focus {
+  outline: 0;
+  color: #ffffff;
+  text-decoration: none;
+  opacity: 0.9;
+  filter: alpha(opacity=90);
+}
+.carousel-control .icon-prev,
+.carousel-control .icon-next,
+.carousel-control .glyphicon-chevron-left,
+.carousel-control .glyphicon-chevron-right {
+  position: absolute;
+  top: 50%;
+  margin-top: -10px;
+  z-index: 5;
+  display: inline-block;
+}
+.carousel-control .icon-prev,
+.carousel-control .glyphicon-chevron-left {
+  left: 50%;
+  margin-left: -10px;
+}
+.carousel-control .icon-next,
+.carousel-control .glyphicon-chevron-right {
+  right: 50%;
+  margin-right: -10px;
+}
+.carousel-control .icon-prev,
+.carousel-control .icon-next {
+  width: 20px;
+  height: 20px;
+  line-height: 1;
+  font-family: serif;
+}
+.carousel-control .icon-prev:before {
+  content: '\2039';
+}
+.carousel-control .icon-next:before {
+  content: '\203a';
+}
+.carousel-indicators {
+  position: absolute;
+  bottom: 10px;
+  left: 50%;
+  z-index: 15;
+  width: 60%;
+  margin-left: -30%;
+  padding-left: 0;
+  list-style: none;
+  text-align: center;
+}
+.carousel-indicators li {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin: 1px;
+  text-indent: -999px;
+  border: 1px solid #ffffff;
+  border-radius: 10px;
+  cursor: pointer;
+  background-color: #000 \9;
+  background-color: rgba(0, 0, 0, 0);
+}
+.carousel-indicators .active {
+  margin: 0;
+  width: 12px;
+  height: 12px;
+  background-color: #ffffff;
+}
+.carousel-caption {
+  position: absolute;
+  left: 15%;
+  right: 15%;
+  bottom: 20px;
+  z-index: 10;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  color: #ffffff;
+  text-align: center;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+}
+.carousel-caption .btn {
+  text-shadow: none;
+}
+@media screen and (min-width: 768px) {
+  .carousel-control .glyphicon-chevron-left,
+  .carousel-control .glyphicon-chevron-right,
+  .carousel-control .icon-prev,
+  .carousel-control .icon-next {
+    width: 30px;
+    height: 30px;
+    margin-top: -10px;
+    font-size: 30px;
+  }
+  .carousel-control .glyphicon-chevron-left,
+  .carousel-control .icon-prev {
+    margin-left: -10px;
+  }
+  .carousel-control .glyphicon-chevron-right,
+  .carousel-control .icon-next {
+    margin-right: -10px;
+  }
+  .carousel-caption {
+    left: 20%;
+    right: 20%;
+    padding-bottom: 30px;
+  }
+  .carousel-indicators {
+    bottom: 20px;
+  }
+}
+.clearfix:before,
+.clearfix:after,
+.dl-horizontal dd:before,
+.dl-horizontal dd:after,
+.container:before,
+.container:after,
+.container-fluid:before,
+.container-fluid:after,
+.row:before,
+.row:after,
+.form-horizontal .form-group:before,
+.form-horizontal .form-group:after,
+.btn-toolbar:before,
+.btn-toolbar:after,
+.btn-group-vertical > .btn-group:before,
+.btn-group-vertical > .btn-group:after,
+.nav:before,
+.nav:after,
+.navbar:before,
+.navbar:after,
+.navbar-header:before,
+.navbar-header:after,
+.navbar-collapse:before,
+.navbar-collapse:after,
+.pager:before,
+.pager:after,
+.panel-body:before,
+.panel-body:after,
+.modal-header:before,
+.modal-header:after,
+.modal-footer:before,
+.modal-footer:after {
+  content: " ";
+  display: table;
+}
+.clearfix:after,
+.dl-horizontal dd:after,
+.container:after,
+.container-fluid:after,
+.row:after,
+.form-horizontal .form-group:after,
+.btn-toolbar:after,
+.btn-group-vertical > .btn-group:after,
+.nav:after,
+.navbar:after,
+.navbar-header:after,
+.navbar-collapse:after,
+.pager:after,
+.panel-body:after,
+.modal-header:after,
+.modal-footer:after {
+  clear: both;
+}
+.center-block {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+.pull-right {
+  float: right !important;
+}
+.pull-left {
+  float: left !important;
+}
+.hide {
+  display: none !important;
+}
+.show {
+  display: block !important;
+}
+.invisible {
+  visibility: hidden;
+}
+.text-hide {
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
+}
+.hidden {
+  display: none !important;
+}
+.affix {
+  position: fixed;
+}
+@-ms-viewport {
+  width: device-width;
+}
+.visible-xs,
+.visible-sm,
+.visible-md,
+.visible-lg {
+  display: none !important;
+}
+.visible-xs-block,
+.visible-xs-inline,
+.visible-xs-inline-block,
+.visible-sm-block,
+.visible-sm-inline,
+.visible-sm-inline-block,
+.visible-md-block,
+.visible-md-inline,
+.visible-md-inline-block,
+.visible-lg-block,
+.visible-lg-inline,
+.visible-lg-inline-block {
+  display: none !important;
+}
+@media (max-width: 767px) {
+  .visible-xs {
+    display: block !important;
+  }
+  table.visible-xs {
+    display: table !important;
+  }
+  tr.visible-xs {
+    display: table-row !important;
+  }
+  th.visible-xs,
+  td.visible-xs {
+    display: table-cell !important;
+  }
+}
+@media (max-width: 767px) {
+  .visible-xs-block {
+    display: block !important;
+  }
+}
+@media (max-width: 767px) {
+  .visible-xs-inline {
+    display: inline !important;
+  }
+}
+@media (max-width: 767px) {
+  .visible-xs-inline-block {
+    display: inline-block !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .visible-sm {
+    display: block !important;
+  }
+  table.visible-sm {
+    display: table !important;
+  }
+  tr.visible-sm {
+    display: table-row !important;
+  }
+  th.visible-sm,
+  td.visible-sm {
+    display: table-cell !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .visible-sm-block {
+    display: block !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .visible-sm-inline {
+    display: inline !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .visible-sm-inline-block {
+    display: inline-block !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .visible-md {
+    display: block !important;
+  }
+  table.visible-md {
+    display: table !important;
+  }
+  tr.visible-md {
+    display: table-row !important;
+  }
+  th.visible-md,
+  td.visible-md {
+    display: table-cell !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .visible-md-block {
+    display: block !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .visible-md-inline {
+    display: inline !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .visible-md-inline-block {
+    display: inline-block !important;
+  }
+}
+@media (min-width: 1200px) {
+  .visible-lg {
+    display: block !important;
+  }
+  table.visible-lg {
+    display: table !important;
+  }
+  tr.visible-lg {
+    display: table-row !important;
+  }
+  th.visible-lg,
+  td.visible-lg {
+    display: table-cell !important;
+  }
+}
+@media (min-width: 1200px) {
+  .visible-lg-block {
+    display: block !important;
+  }
+}
+@media (min-width: 1200px) {
+  .visible-lg-inline {
+    display: inline !important;
+  }
+}
+@media (min-width: 1200px) {
+  .visible-lg-inline-block {
+    display: inline-block !important;
+  }
+}
+@media (max-width: 767px) {
+  .hidden-xs {
+    display: none !important;
+  }
+}
+@media (min-width: 768px) and (max-width: 991px) {
+  .hidden-sm {
+    display: none !important;
+  }
+}
+@media (min-width: 992px) and (max-width: 1199px) {
+  .hidden-md {
+    display: none !important;
+  }
+}
+@media (min-width: 1200px) {
+  .hidden-lg {
+    display: none !important;
+  }
+}
+.visible-print {
+  display: none !important;
+}
+@media print {
+  .visible-print {
+    display: block !important;
+  }
+  table.visible-print {
+    display: table !important;
+  }
+  tr.visible-print {
+    display: table-row !important;
+  }
+  th.visible-print,
+  td.visible-print {
+    display: table-cell !important;
+  }
+}
+.visible-print-block {
+  display: none !important;
+}
+@media print {
+  .visible-print-block {
+    display: block !important;
+  }
+}
+.visible-print-inline {
+  display: none !important;
+}
+@media print {
+  .visible-print-inline {
+    display: inline !important;
+  }
+}
+.visible-print-inline-block {
+  display: none !important;
+}
+@media print {
+  .visible-print-inline-block {
+    display: inline-block !important;
+  }
+}
+@media print {
+  .hidden-print {
+    display: none !important;
+  }
+}
+.navbar {
+  border-width: 0;
+}
+.navbar-default .badge {
+  background-color: #fff;
+  color: #2c3e50;
+}
+.navbar-inverse .badge {
+  background-color: #fff;
+  color: #18bc9c;
+}
+.navbar-brand {
+  line-height: 1;
+}
+.btn {
+  border-width: 2px;
+}
+.btn:active {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.btn-group.open .dropdown-toggle {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.text-primary,
+.text-primary:hover {
+  color: #2c3e50;
+}
+.text-success,
+.text-success:hover {
+  color: #18bc9c;
+}
+.text-danger,
+.text-danger:hover {
+  color: #e74c3c;
+}
+.text-warning,
+.text-warning:hover {
+  color: #f39c12;
+}
+.text-info,
+.text-info:hover {
+  color: #3498db;
+}
+table a:not(.btn),
+.table a:not(.btn) {
+  text-decoration: underline;
+}
+table .dropdown-menu a,
+.table .dropdown-menu a {
+  text-decoration: none;
+}
+table .success,
+.table .success,
+table .warning,
+.table .warning,
+table .danger,
+.table .danger,
+table .info,
+.table .info {
+  color: #fff;
+}
+table .success > th > a,
+.table .success > th > a,
+table .warning > th > a,
+.table .warning > th > a,
+table .danger > th > a,
+.table .danger > th > a,
+table .info > th > a,
+.table .info > th > a,
+table .success > td > a,
+.table .success > td > a,
+table .warning > td > a,
+.table .warning > td > a,
+table .danger > td > a,
+.table .danger > td > a,
+table .info > td > a,
+.table .info > td > a,
+table .success > a,
+.table .success > a,
+table .warning > a,
+.table .warning > a,
+table .danger > a,
+.table .danger > a,
+table .info > a,
+.table .info > a {
+  color: #fff;
+}
+table > thead > tr > th,
+.table > thead > tr > th,
+table > tbody > tr > th,
+.table > tbody > tr > th,
+table > tfoot > tr > th,
+.table > tfoot > tr > th,
+table > thead > tr > td,
+.table > thead > tr > td,
+table > tbody > tr > td,
+.table > tbody > tr > td,
+table > tfoot > tr > td,
+.table > tfoot > tr > td {
+  border: none;
+}
+table-bordered > thead > tr > th,
+.table-bordered > thead > tr > th,
+table-bordered > tbody > tr > th,
+.table-bordered > tbody > tr > th,
+table-bordered > tfoot > tr > th,
+.table-bordered > tfoot > tr > th,
+table-bordered > thead > tr > td,
+.table-bordered > thead > tr > td,
+table-bordered > tbody > tr > td,
+.table-bordered > tbody > tr > td,
+table-bordered > tfoot > tr > td,
+.table-bordered > tfoot > tr > td {
+  border: 1px solid #ecf0f1;
+}
+.form-control,
+input {
+  border-width: 2px;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.form-control:focus,
+input:focus {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.has-warning .help-block,
+.has-warning .control-label,
+.has-warning .radio,
+.has-warning .checkbox,
+.has-warning .radio-inline,
+.has-warning .checkbox-inline,
+.has-warning.radio label,
+.has-warning.checkbox label,
+.has-warning.radio-inline label,
+.has-warning.checkbox-inline label,
+.has-warning .form-control-feedback {
+  color: #f39c12;
+}
+.has-warning .form-control,
+.has-warning .form-control:focus {
+  border: 2px solid #f39c12;
+}
+.has-warning .input-group-addon {
+  border-color: #f39c12;
+}
+.has-error .help-block,
+.has-error .control-label,
+.has-error .radio,
+.has-error .checkbox,
+.has-error .radio-inline,
+.has-error .checkbox-inline,
+.has-error.radio label,
+.has-error.checkbox label,
+.has-error.radio-inline label,
+.has-error.checkbox-inline label,
+.has-error .form-control-feedback {
+  color: #e74c3c;
+}
+.has-error .form-control,
+.has-error .form-control:focus {
+  border: 2px solid #e74c3c;
+}
+.has-error .input-group-addon {
+  border-color: #e74c3c;
+}
+.has-success .help-block,
+.has-success .control-label,
+.has-success .radio,
+.has-success .checkbox,
+.has-success .radio-inline,
+.has-success .checkbox-inline,
+.has-success.radio label,
+.has-success.checkbox label,
+.has-success.radio-inline label,
+.has-success.checkbox-inline label,
+.has-success .form-control-feedback {
+  color: #18bc9c;
+}
+.has-success .form-control,
+.has-success .form-control:focus {
+  border: 2px solid #18bc9c;
+}
+.has-success .input-group-addon {
+  border-color: #18bc9c;
+}
+.nav .open > a,
+.nav .open > a:hover,
+.nav .open > a:focus {
+  border-color: transparent;
+}
+.pager a,
+.pager a:hover {
+  color: #fff;
+}
+.pager .disabled > a,
+.pager .disabled > a:hover,
+.pager .disabled > a:focus,
+.pager .disabled > span {
+  background-color: #3be6c4;
+}
+.close {
+  color: #fff;
+  text-decoration: none;
+  opacity: 0.4;
+}
+.close:hover,
+.close:focus {
+  color: #fff;
+  opacity: 1;
+}
+.alert .alert-link {
+  color: #fff;
+  text-decoration: underline;
+}
+.progress {
+  height: 10px;
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+.progress .progress-bar {
+  font-size: 10px;
+  line-height: 10px;
+}
+.well {
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+a.list-group-item.active,
+a.list-group-item.active:hover,
+a.list-group-item.active:focus {
+  border-color: #ecf0f1;
+}
+a.list-group-item-success.active {
+  background-color: #18bc9c;
+}
+a.list-group-item-success.active:hover,
+a.list-group-item-success.active:focus {
+  background-color: #15a589;
+}
+a.list-group-item-warning.active {
+  background-color: #f39c12;
+}
+a.list-group-item-warning.active:hover,
+a.list-group-item-warning.active:focus {
+  background-color: #e08e0b;
+}
+a.list-group-item-danger.active {
+  background-color: #e74c3c;
+}
+a.list-group-item-danger.active:hover,
+a.list-group-item-danger.active:focus {
+  background-color: #e43725;
+}
+.panel-default .close {
+  color: #2c3e50;
+}
+.modal .close {
+  color: #2c3e50;
+}
+.popover {
+  color: #2c3e50;
+}
+
+{-# START_FILE BASE64 static/fonts/glyphicons-halflings-regular.eot #-}
+b08AABFOAAACAAIABAAAAAAABQAAAAAAAAABAJABAAAEAExQAAAAAAAAAAAAAAAAAAAAAAEAAAAA
+AAAAjPL/pQAAAAAAAAAAAAAAAAAAAAAAACgARwBMAFkAUABIAEkAQwBPAE4AUwAgAEgAYQBsAGYA
+bABpAG4AZwBzAAAADgBSAGUAZwB1AGwAYQByAAAAeABWAGUAcgBzAGkAbwBuACAAMQAuADAAMAAx
+ADsAUABTACAAMAAwADEALgAwADAAMQA7AGgAbwB0AGMAbwBuAHYAIAAxAC4AMAAuADcAMAA7AG0A
+YQBrAGUAbwB0AGYALgBsAGkAYgAyAC4ANQAuADUAOAAzADIAOQAAADgARwBMAFkAUABIAEkAQwBP
+AE4AUwAgAEgAYQBsAGYAbABpAG4AZwBzACAAUgBlAGcAdQBsAGEAcgAAAAAAQlNHUAAAAAAAAAAA
+AAAAAAAAAAADAHa4ADV2ADV8AC1cEs3pishg2FfJaEtxSn94IlU6ciwvljRcm9wVDgxsadLb0/GI
+ypoPBp1Fx0xGTbQdxoAU51YoZ9RXGB0bXNPyK3JLMApRwa/IMy1PPoJDx39kimekZX1c+DSW41tE
+ZBuFiwdwx1dRoPVA2vWPSlsSDqhNkqYfhrqlVUGD0J3HEAgZavmtLnDC5WBriSpD8Uk02KsUkJ9v
+CFz2CZXAd5viwGZ2xcVYRPa1bEIai51nMYlbL2ERuB2TCzLAbPWWRZ3/sZ/KBjLk8/gAZzK1OaxN
+w4oGBbsNhx6Reg5HRFVCrwa15kGmJEy5kX1YypVm/Ho7TjKP3l+/nuCTOyiOa6S8QEJbuiGYNlCn
+M7tHChCHRRQHXQh7yPXASlcvc5KrNKol6orb35kbo+iEwl8d230cfWPwTy00bFDRYURYGchbwsoD
+caR2AJsFGCrbWCzBdQ0qCobWwLfueqAzSkzaHX3yCjDlGYPV0VZqVXlqbr4poRaG5NNPMDv5MCHk
+LSFyABMRBhMiGSZiDgABYmwsLWDjUZCUnHwvXt0VAUy4/qjwVgjfUqp1evzUqutJB7DW99Cq5aEh
+GePsa4omKUp7LnSQUz+Zq51pU72ApMxkaVZE9jF3IGKVnF0GlK1E6iqLJXFzy1BEv6Kr0ngCzIgV
+ANRwCkVHYJj86Sv2dzqgVrjYKlg8W94FbPGQghEbTakZ4AoS9h0u39DOoRJTA2iirs9xa5m9Ir0K
+wkogoqFNVDbTIGO0/WuJYfp61Kq0bhgbcbnvbTDj4HBESsXMdvrvpp7Owf/S2EbndoEoglO/jigG
+AuLUTUmG07ZGlRCZ4QZLu81tPEgTtAvF99BxfnxNslgVYH5Jc4AfHwsiktDBO4wjgjizFMsIeBTG
+mIYrhtrK3tvtBu5tYB0PDMXILUkFYPM+5yLLGOU9DtoDLYWLQig+8wNRZbJZZWeK5JyKNwumLgP7
+X6pqgiZMFUvfCTl6Urx1gUOjzhcICumUUsiNESZCmTANkgHoh+KU0t1fgQYOBkNfp4MRiJysezS1
+Vz+ahE7ohM0iJBn4I+T9RJN/uQk6SjQGwC+om/SD7Zq2RxvcSjtdxHfo7NtktA46mEg5gBkTtMKu
+7oFb1KgqwqBLzQqZI/s4QSRhYF3ani1URTcMD38kDDqlc3DChmYJTCR9WpaWrYFiXeNi7jYa1Oe+
+SP30gxVyeC10DYOakGpWaU1qkQ9OXlujEbM4A6A+Q243TA2QnI8mKzNXNo1HPN1CFawST6uC9dky
+QTqq5bOKkkuGjz0nkj35Sr+Q/kLGg2iQMrTKImSGshnX7/0Jyh0JziDbTzxp3IrbosXgpchLcBJp
+LLUBrFbt/U6qXqAaNFJoeBItBoqgQlPZkpTq31s5VZsgIkFupAno5G9oKwCGRqv5294xFqOrEpew
+cjx+e06mxDkN85c0ckmWmMzbkFX9YHAf83p0EsnBywjZbcPxZw91kqg7voxasp3VfDhEDAufUx0M
+TddLO5kCyKkUBwOm/MurQH4bJQgK+p14dkBBhgxpBUkTlSbTE8DDu9qKiDSCtvmPY7FRMn0wuS6X
+R7J+npjjeaDNwiOgIKUWCP9aLb+Xpc4toQCryp6gjCVq1Cl1Di+tEx4WnBp2hmGZpEksZwTSggXu
+qAWD4B7WAMcir2wmA+I43ECxUSeTDT+xgR3O4XFPOGxHh09lxpScampLahUbICao0db7//+4CBMc
+CokQ7aOQ02MOzh0NEaJGGOvPR1t4sY1I55lNfQ3IkF04onnAomXxiNg2EbBbPTMBBlv+ggPSmkb4
+GNFW6Ehd6nDzJlnIXFfzr1bVWQlfylDodFBbhCDf/VB13j441dc2rx3h4hfAWIJuZqbH/wbuafg/
+nTQJ9bnMfR3U6TwYgDQJIOPOtmZW4ZHsR2VifZGaC6Pzv4ZzC2nSAaqSe09F9MxuI4UmUVA2RAUq
+BUIETEIAhB+tBhsxhVMXUmv3RPe1grhYWLM+PHwwO5W069qIgDXtETXZQ3741DSk+vO6y8k/7Mg6
+GFC5fSK02yXZ1XV0NZe8iknoIbSFnDm+bMP+BCQhoLKOeU3FVNQ+gPEntwkHT950cQYEYQc/XuL4
+nxwcRW2bIN+yskPaD5Rz6lN8LW5IDLYfuvhxlLcjWXSADeTshWsJk/HCuRbwjqLcx66fc6UlF33H
+ipliQ1cvfKlgRpVcsmIsiYnJjzJIovUyqi/2OTQcIwt+3WW44BAQh/2GymOIscSpIt0YUePiwOCJ
+N+Q60lqkSRbWi10lotzgWZsqzEI7OGFGeIoFyqli41/Nn7LfLQ0qtxkaAwbsKZQ0D9s/whBqoxhA
+lxCVNVF/J6rsUBQ49MLtR3ICtKPLKZ/QPEeIRgWUNLbNR3v3tTaL8uiXO+Oj3tSJc56KJHol9nGP
+uclbrQpCn4keT05ETSOQ/DwwKjCRLgIzBi7x+U7ByTZGUWcGLPY0VtXWC7kQ38C5thIGJx/xLM3K
+soGyRwC5AFUNWPzU0QBCaVXo6z1NCclLuPVA8/wWuNhiAG9CPPSSlIOCuh2AQM1d6MyIEIQArIa9
+YenQ5ug37h9gPNDHVLImcjE91ewI7pz7HgOEVqTD/jREYRtEoDIfgxzDePkVvHWJAtcpCJ+g2o4a
+kZpphRUQ0U92lJcKZGJI9mnpl8UVzpMi8SBGXUAPpgcS2cDAusSE6q0hNibhCgZHLReLsA+Sv8wF
+6LiDL3TogB1DsO/HeMg0ETucRO2hIOvbp1NVkFMclluNmBQbTy+osr2bJ7oWdUtSHi1s+2vWxq8n
+jY1eW4BCVr2EqSyIUuFKS9iwVF5FBGeg0hRcHwCKMtqYLBfvVSYXHdGZK3Ug95C2d+3t9ZWEYqq6
+F4TocgcDS4tI8cvEEXK1+yB9RofdKpHoA3eP9/B/EBG+IgvmwZ4Iir1SOYFEtUG/oVkECQqoPTdH
+oNpQKpA9K9k7TisAUBsKPtWgBriyeOxs1o+4KCIFumN744dH3Yf7X8F426LGtEhFLULhlKFgXF8W
+q2D6kFSBkViLad9D9U/P6A/r8SE7jsr9s+sb5ODWI5uS6BkZJI5RQ5QDVZ5/KOG6Dzc1RLQKAdGk
+gwLiZLQdEYQ9yhQLtD5kWr4wGHTv4GqloWePyHYyuy3Ek3iQVQkdkAz0MxcsHzccdMLO8KFh7ywo
+4jXywraIhIicAI4dWdD5wEXBhsMklzbWc8zi8opC3IlPsLXHCWOqOgq4iPU6xyDS2tdSLnlhSFjs
+CCWvMRt5TAI30EHR4f16NYyzoG/oKgCUsW4182Wvj5gpb0bGGLe8YRIYRGVgF2hwIlEfm7eUwwLZ
+WW+mmBZPggPnIKI0b6G+lHCncx0wkaVPRQpZKWIIrzh4yC4Ar2vTKzhVKSutNi1dSzmM73AGUXSB
+JrQH5J4Dfb+RU25tYrIVdLr4ogiwTE2i2hl39ffJWHNTSWq3PvVJplNqDTJgJcvCHYoQAuHeOew0
+gZGfmX3p4D0aSr1BhXbXRA1qipfS6LiggtiT1eDg4FTCWwCdAFC9FCOZ52EdrFetMBxUdC0dfnqp
+r0mELJE2m5FVMvwplyf0XIKclHa6/Qrw/FOVkVKK71Ab5iAVWm4GA3HnkCJhYkW06XJ3TDGB9YhV
+W9RuC39AFUcFWwU5eTNzuck7IQty7ZC9IjAGNHuZhQ8yDWZhGUoNyhDcKYQiUDqAC782makzJ1o3
+XJFIEDXgObv+TlS/dAr5rn2C/CDmkI0WO3cSTJwSLrS5dBdkyfpxAu4XghB3jgGShG8UCorOibUp
+7NciZgEDLmT6eOxDegpLRk7HomganEaTmRZAAMrhobApDjFWtOxht+NQngtKVgGL2yy6Qnsmju6D
+Ag4d/RvxHa5mBaEMcBekCMtwaPPGeKFPMsgAJTidusMLUbTAUBJMOmXRwhONkoLPqBhpTuLSYN+f
+8aeX1NKSxF2OUST9ezObkHETTsr04iWClpoFDE8OdIiDPQJqkHhnUPTcE43OsKBGS/zk6F57sqVm
+hZKjPxle2S+iIE+MXOiTOoRKF0Q7mbNRYGPZDp5eIdPOZHboa4CTvwnlZb0zCOW6kZJh6klDDvYg
+hmQ2FCDKB5DD+0nImiNcfSzaGT8aSPzEZjMQ2GPpA1Ws4Xeysyv0zSSMVVsiOoiowo2SfYFdapUB
+sWIoRXMAKYdguyVcwqX+zVWYLiNddi8p+xMV4dQIoUs6SQ4C1/BjtBw0ocOzLmMkEv5D8N4/Zu4g
+YA4ryDb5Y3gkIxdb37qMCWYmDGgsyEE00y3BZ4FgyT/dJLHxMQwx0gViQjWL0QyBfcufCgRYYGiC
+Hrxez874MrcqldLCEQLkCCK6pWCnULCh+VK6FW+1nm+N668e16QTKWprvRw3mkwitjPefHt5QKrV
+umkXsvsVrHdAJrodfWckxhhzknXZ8cMVIvKphJVfhvWbhoZbbgo3fygOr8PlKcVEYLTmUbjp8rTF
+lPRtPrdA8tljZ0REfnhwApCZ65Igtn1gBROJdPCCb9ZIqlQUq3W89ZjSgSnUz8nEBW03JCcQ/Sxo
+uQtYBE7ichYHbASPB5J1/zVfPINn38CqTMws1KKo/yvNXpDgBvCI08SBLSwX5Szp6WlpzoPEio8D
+sNzZQqgUMoq0+NMALrygrOlErJohXvIJ/0IqziZok6OuApG2eoGAEFsTc6yWf9eRcklYZRO3PkA+
+W8aN5ME8aLNC3Kdwtm64WyqytOEW1WQIg6bOFHAs1ovo3OfCvvZASxBcxg2SRCRTTJDBKajFH0LL
+1kSBroe6L9xvVxMCIFS7Zo6y4ZOEIkAI9QtGVIKKBlCvUUEq2S8FiR7VkJGbvBFaS6UzQV+ayV6N
+Kw62tbJbEjkJ7AMC17DK399DZr/tE5sUtaAPwaHNj9VCoVB4VAG0iNI9IjDo0mr97FWjYeDRSr3p
+stZTVZ6nj5Vp3IbssG3g0r9E2eSmHY97LYobIHPnEGkKDJP15WPWtwMgS8HeLd6NEnP4mIFlRJB4
+zLeDeoBElpUNRIQMzLbRQsGLj3DZhQytDQPLAUE9JWHiLKAJxVTOJNZsObEiutLqwox+M51t7vJQ
+hBeQm2i5bTa4D8qIUjqI1sL9G6Vha6U6IPUabeCUMIufG//6USyxymXNlfnVinkNvKZGUjz0EWKI
+gZEC4WkUEr+gP+FpkIPUVM+QEJPxFxKDlpBEeiUSaTgCm4sEfRnBxu0eF/LgLp0IFHMEt8aZrsQz
+TF3wRw8TdpzHNGMZrHHa6nU8KCQppWBVpJ8b2Xjq278mtoTfrgfAMSAm3cYEcDw+zcSsXTaUyd2P
+H6DCU0DdBiauxpsyoKlAh9IUAzS32X/0d3x7h4gL36Q5sC4YzkbttmSwhenP5pxxrBEEcoAohUGB
+1jHGtB2+I0FEcCM2y8EY1e2NPXJS7wp7APp46lC7gSit7FEFQCIDnNX/196lJs+gXTyJrXAze/Q+
+9GEFC7p5W7W5FEooh5QlO01B1OcYDH4VTmRSO8fHPjRo4FkT9GrnUZw9pXnDplu0YFyOaAsLOkxd
+su2gfYJ+DzBNihSUutbDbDy7VKS3KwwUTChYQkWCmldyS/y05EvDGbLbpkDfbbHNGEhTSiaAEDmo
+KTERX3pEuKYJT/lNS4IawkdDACC5Jk4hgNa2EGV8yblsXoSHDrqHDJs4JDXLLA67oCyia7LABDzB
+MInY5gnZCpFuyyuaWXjKHRgy409j2wNaI1bGlosUnhaB5iqHHZf2+bDPpsIwoahsWRL69BhhyPHQ
+BUNCyBR+UJzMOBRMxTVhNsS0+1n5kboqmNZcC+t6HYVscRaBeox/vv3/xwdoUoRvs6CamykRGihd
+8HTNaL+xRuoo3QVZvFT7xS9opWLiNbQRti9PXbNg0J5WDsxaNesdmkYOcwpiqsURuor+S8hhgWni
+GGll+tD55enFSsyATy9MonNXUJV5Q7eAouzR/P4HlA5YWBYYjm6NDAEk+x9On0MGm65/Em1GKndn
+Rp4cv/jFAdM7hnXsaXnGKAeK4aE/6BhOq1/AWmgCMQ4zC8G0wBzhuMSeeVhgAl0jpwicoR64K+BY
+lYbWz0gTGAGtI3puhx3F5/5QKXradYFuhJPYWq3ITCUUNLpugdVBegedngCO/DN5mJBWzGEL932j
+L1YntvCgzzLeR0WczKl0J4g8Gcbo6p5LOslpYBw4kE3ZDMiHPjBGyAUjkrWXqYTrl7gRUwex0zKV
+ekIhoI0dsFRDtQxsLctjOlRs5Y2gYpQeBORQFR4C3hXh8EnZUzuloqFLFATXzpzv6k5XoHB3fZLN
+UiPV5DvAfroLwH8tYhkcOxWnHqePfQulM0DCPTadXa/TpoHYkh9BeeAwpmi9Kbo/m88ob17pFzKP
+2lJpfWxbyD3PccS041A0MQWUqNDHOPOFt57Q6TiHQEKJQsI4v1JqcD7Q3orOdsLvExRQwS0nlUtV
+/pQbx0wSlrRSneWAQ/JhPaT6rMvIcid93ahrnKe34YxGA3D30BI2lEiLGh5iAUkBLBoXRshvpjGJ
+GLzGcvonIqzVubgEJv4mbEl7JggQUWb6AYaQMmGUXEwIjylByVLbgcEbUQL5RFiRkX/bOhzb9Xav
+zmFpR0cOdx3etgoaCPbiL5gR8o0wJNdPMCYcmyP0SDmmsW8o0O/y5HNRxqz3IhmaxvIT/xpN8Pj+
+x4i/GawfTOod+pvHN9BMNQUKG555l7yAKsma4r8JwVm6gxqBECXHA3e+dCsONR41WrcokynYzYqB
+0xlCdg9Nu/VL4rgwOiTVy8K70TghEjAOHeFBYvGwmkrDIzlwQsyBsr3K/EBFKO8UQ6J1hU/YGFA8
+fGgTnBoNnAmZc+9S+XnpbpJ4QKgdip6TZnI6woSQaYgxGpdaxxSuQkxu0avCBOSwchx0SS0x5HgR
+6iz9AkbeoDFTnGInFfbnMUP+8p3uSQu2CVkHxeVeEMICXKlVDsj89UY7AfyMvxTyws7ilT3y4zYS
+LVToLb1IwDJHJ804mZKVSKgSOa0mHCQrjWQLaz9LrCiISicIHspx5moJ/3Ng4rjU8aMqTDl5gjJA
+FgAMupkEoWEalYEtHh8CvvMqUP0Ra4v6BRr+dgNXFRLo+jKWRhaP4x63qqfsnw+/lDAo2doOxQP7
+GwahE+iZ2OX2l5DodFT8bGiL0YglcRmgDoYIEaRBLqdbj7HFD8xfZz45H2Tg6upN9XjuGCxtdxuV
+uRjssowtewrBo9gBM3T7d77hNjF9rd8QTMjwGLx3oWax6aa17t0I2gcG6kcQgw/phwfsB4gsCGgM
+GZU8P+ORAg4iQDmTP9XqByg+jtRqWtpaHjiHSL8CNah084UP6Rfjx8GU2eaRw4mH+A9Ad42Dummq
+hAj0/eMNS3V8lEHUSc1ntW779KspgJUBtJQEpS59ODiBRghAyioIrf/KoPh0eAJWqxh+SurG/5xV
+dzZBLgKEiYy4izBuKhCRIhfoADEt/B+irTWSOZVkcfzWBbA/AO817phMFhWQnvTwzjirEna6Jgrj
+gHyk+8nWk0k06KkkSOOryl2OrOta3U1Vai9SLWxcE3cY161P64wA5VUgBExRGc8qtWCkEHIJfWty
+bVbTm+hrXnbVSsP4ucJTC9onJ8N4r9lRaV/c4a2SZKmPNCgEUW7LDBXhvFxUvZYtnIuGD61WQtIr
+DXUc13hksUbImFeHrIBgvnG4ogmKBk5CClzY5DWqCCMzdrHBGSSOTyO+E8inLMGSApQqKJB3XKm/
+/MFoO17KuwfwqcaqjAyaJ5JOWW1Myr/s7ZQiw/PqVAMH+lK6DYqjGUMcAXnVxy6z6CDl6j5mDa5E
+G4j8C6pr0hKyRNnoiR1vl9DWOfC2+M4v44bO3onXro+Nlz00ZlGV2ICJ5CcCazVCJHIETBqVFhGT
+7KSBdNDv5ILpSacSTL0S6fX/P1CEIT5NZgcwpI0rkV7LqiHRoLUAPjXEqCZ5mLntX5JkkUEelCsU
+2tXCMZ6cZivQI6hYQNbXl4nc1sSNtBUTkQ8Y442KxRe7Uy5yOzB+UlA3MhvFmXweJJj/+G+qwJFW
+FLNYp0JhzD+4sl4JYn6a/vShCCo8hchMfrswjZgUqiToKfoOGaHdIAnKE+iEedBkyLwMSoNVX83T
+JERFy8PLMpBjsXtBITuS9lpPCTVl/vs2Aqzlzwnj7lpl6VX/Q74tWqUSzaKziwue1phr9BpcZjNc
+/GXuJUq15TMDnCsJS0X2wAtW5JQA5MaTyUH4cDRif3MDxZx3Se89P4WSIvEEeLjToJbXf/rRhBMt
+RevJxuf/s8EK4woZOFli3yTq3xqjBjrlierqgmUpFA15HFkeUOuLDjuhzLDjAGKK6WThTynzd/tC
+QWU3Nzd8/a0q/xwZYn/UPEHU6lsdG/n8gN+YACURCU+W/ldrXpdUK7WxhgWmNd+LDoQFCU0sFyHn
+3KqFz+Ig9e2C5oe9EOi7KdTBxPE1k4k5tkX/oZzSih8DJDFd+rITKNSsAAGtscSW9VDasqkEamMz
+eUOhRqRRAj9lc+7An2YOdL46GdcOLAsgYaFsR9hs0ToUzZ9rFRLG1/7eYLz1l5ijumbe1druwaHN
+FzZjtwt+n7paZaMZu2EIx+lxX/2SBrWJQQM0wmE19eWrGPIVMeAzVWWRp76m1skeqzaBBZ6So4eD
+8Gpv31bn+nO4WG/Og/B7xQu9kpA3eZL3w9cwzrZfMmbUSk5OiF3Qx7bQYhL0VoUQQP3Hmps1bBJD
+QU0qAJpWwnb4iFOMBthzwP81ilVnh1bIuk0C9Xe+1kSK/K/MYOh7vIa7ghqGEKzCiHrehs3cA1pz
+gec5NpLDtCqMPp1GVECA4QZKiZX0hQ/GqjOhhObmpH0vwx0WHctTrmGC84Ub6BOQVdXIqoxqMVNh
+Qjd+0CYMRk1zp6/PnIOsW7k+hQEruSB7+DEGv1lziYEEwur9gsigQBG8EJ3zeigdA74WvD0h2Ibd
+NzPw3okAFsdmi3qKH41lxijDPDtvZcEzXwUnRNn4WpCP3vPNHhO8czUiYjRn6GRIQ4SymW9MhjUu
+/jbWOhOqNeh9OSRNh1EaFZcalxYnJMLCpTlEDttzYxhNCcZ86PUpbEkFmkU5HRiAF9AahZ8jQ769
+NUzJGkq9YLj9HWZLEK+IryXyPLZHAAHsBSe5moWq2RRQT655EACRYKQ1AR2mNQU6hNdrqLyfpSeJ
+5PrccWf3dXVxmIidWyyIkCm1v1oFYgyGcXwrCRPXPMLYHRFvGVuYyAUhzgYntJmDhE4VCNKoSxWl
+SFiFuMGumZHJnCJyAdT+HcgUhIEJZgWOjmy/ZWisKRYo4JjuPntQGSxlJg3XJ5DBsFM3kGGQjqEC
+yjqYFW6ccOkCDy3EhUt6taBIaHclyblt3Xxs353KjciddJC7gI4cZaPj4zBxOVNfei9MW9cLUHsp
+ngSFFni3AL7sLsbqo3totPWMf0yD2bdWKWuK2a4eF5jKcYCZyvORgcHeETtqeqhAYtIyiFGAYJQM
+OX4VJzPjyDKiavWJRtjWCnaTUdPR6FRkTfFAARc+3Ln3oFDETvxxiaDT3roIpaWwEEjRlhjvs9ZK
+iU2o1HJOMuVRFAA5fWzMgAqSKDaSLNQcQZbaFzsgKxXWIvjaOqsoiS0kA1bx2TN4NrJBVMJcmRWN
+IqrjepyobiDa9yXYKmJvgQWZhEBvF8wEx0pMQqCzcf9JemmcVMROHpvzARvqDrI5WOXmah0Zkh+6
+PIozOYm78ieRAJObTPxSCLuwQiRlWaLSxJ5hgIIrjsEUKPWMqRFuMgh1FsNDFw5jPGKPTWzyiSEI
+S6IPweoS55G9SZZ6wcpW+HYMSkoSETssJ3QQM9bQRo1JdCQdS1np6F5WR9wujL48y6xB4M6Y7FMn
+X7f22J6F5gyYVK0QlgEQxVXFUuC964aXqqhT5cX8XaZv5hVzeTU7bSoy40QuTOUjLVShZVi5iWJM
+AbFhku4I5QyO1x0Pm+cTesk5XsjnzwoAIsmXCFbWyIZQuawuVuXuR8DK92lWJDrNrbFtNbCj5sTT
+Cx7e2Wb0UydtbZ/0CSIT7OnVIY0fRntwN3jNOdh7nGpmmq9CbBm1uLafMptryjPHHp7tKZEuAL7O
+jXHySRjUkXydXE+SrNxA2Um5Al8Dh3EZC5V4SFynxsMTKCAIMqEqNKzuJCQM3tvVBjRfT7xHSuCO
+72a6pSo2wn8/aXBmKI9sW2BccnPF8aML8+ohhb7ciWy/xch7McUey2CPGCyVKaKDX8+SBNgqZqML
+bCgZ4NPkIF6NfeH7gtElIrOqbudNqU8yyyewVZneKXuzObCUxU5b2tecTa7Jn7SE6UlSYMTkMfCs
+3Q7fVCaqK5k6pf/2wW//osIJEgW3skUNgQHyb+sAi4ECMNcyjicIITuXGyXkkRIXyN50Jg3r1FpM
+maQSUl9pGxnNMp8jf24vS5eX/yJYlMUISy9e6JooaPn7fiuG4QEscaDgCZpra85ygZUcJInLV6C3
+14YPJdG2UL6qljb1QV1ZhrNcFecs0j2qb5gvkKHOFxHphwdBgEJc3y8qihwdZCQpJ62h1voTUccf
+fiDJEzkU8jbXRvLFdPbcmVBUhArEuTKQFe570IglefLJ30dWmVAtx23vIGmF7N6auVNpZUQVHNmA
+lGgjNet51laJgLQSpfZyxBEqLwoCEGlF6ISp0NUmhUHT5a12/ZElPE5UGO9AVnKpae3D5llVvXAH
+K0FIH3uE8AXFPF/Swx3OdCN6aViMIxEVcqv1UsLJo03R0grVOHRogBCiYVrK/qFBPmGrDyXLgr6D
+xBMSKnf1uSBgiRjCiwL1QoM981XHZnusKIVJ405xXwx6aBUuM2YXS0jaCPwaC2Zdp07J8gxM1Knp
+WMqNkRCfPaYTelLbBmd97YeNAOFaFOlV29YQn0qIInmIeMFxikX4U1pEusNYtOX6tKZKkgVONLhI
+F9ZPpxNWGA5fslgv82Lx49LF6FltT3Qp7q4Rcu4hKczn2m1GTA4unFBAkDCqY+D5s2dyVIfDeGeB
+gwDnPbGYXQqwM0E/BCl69QtVYbUwkQZAtSB618VkAzCPAs93Ip9qWnBMX+RUX0PFxCACZQwpfvNv
+AMGrD69RE6JSyNNOvRD8v3gzw46n8oB8mFQiYiwgidAyJgrfY1SaNrL5QDEjIIgYLECALRSK49wP
+mSO8jZLnesJ8oFZjWJyTrfBrNRCeOMoaVxOojhX6WVAhhJ6dvBPZ4AbMXC37YPHBFKUgA7t8mCk8
+U07mFgWg3wbOZDgsEZBOC/ApoLJL8CzpXhZuoEh0ntzsvrUPhE40+UUkCAm26DxGMecbxuJ+pPJc
+t9BZL6lVcWLmHps6SSRwqmRJeypwrd3vNnIawZkqBn+umMrwB/c/+IAx3X3Ehjr/zJIVUK8Luxlv
+5IeNoBQPnIhvJDZfGo8KIpLh8O4iRusiuQOtytJ61yCvQUGFmCxEEliRlQmkN5wrVLkx3CUrlDG3
+ABe14lLsoysj9hXY/TJpUb3tCvpw8Ez7Wb20lfIScq/6wGFIrBkgzjtNLBoYqAgJoKvDHcdkTRNb
+mMKP7Fha6v0z1qPmfqQzKW+i9g0kSWn1vQuqaJyaTAX7hrJwJgfaPjJvb6wXroHZRAD5NH2E2KaW
+tBw9TGd9mIea9+PrxlBpyjnQhg6rLogT7414uB8V19PPcBZUhnNx/hr1+tX/1jKG4nnHv2EtR3VO
+jo9oWEibOHX8508Tra1pFg4lnAwoQ2u2JcsDi7diOc/uhvd8qexCvYgoI6m9VYAg7Vl0PRXiuCdg
+HdKDIIHG0j73u07ULaOJJ60Y178Lsgtd7zYdOUGlMCYhR2Uhyglt3KUjPCpM8MKjVS6OgTHgqD1S
+SQ+qhzInvSk8VzFP1cI8vLxtdDvH35uPzMi4mQtJCrVUqhBWbQRke9Sjt9laOS7Y9YqUkXldpaAo
+ofKmUNsx0D7eYLc+spsKbO71qdmmaGglAJjo4kj6XlnIWS1hQZORC/h4i/CdcbaFFuxb0AYMJ7Ed
+QExeIHEdPRtCxVECvtxHzbEyldDvie9cGKwImUuI0xEL9W+7FhefRJ05ePV427NJDYmhOCwBDNBP
+5LrIiblD6aw7pSeWFA/lDoWYMm+ZEcF16VDdA3ALq7hDBlLUzNTL9AoVyczpCwb7xHucfK6T64W0
+AnDzYLg0HYWadOMPdoP/lliqiAlAWP4rio6stY02elA/LOPBnEr6rsAqtMRsS2g6HJtNANGwpxTd
+ZEP5Xt5mE2gPs7dE0gyQv+Fdd8QTBEqmAeMHtNnjBtKvg7KmIZCj9303GT9mWQXZxolBupTHIhJT
++0WN7uu1FbRp6NnSRDIj1aXRJD25s/AD5/Ic2OQ0iDp7/3Dbv3Oa8McFBhXrPpAKzhrFANFpcnLm
+EVTXjq0MO5sJAPVxFbMh93VfD/DppG4mBzXSgVfXJeWNNxoKF8QTwcQFXwQPB7QLE2PENdF/4vDL
+9zn0ZgQ1i6Nyr35KAwetsESlUtEENQbCFOeUFb9lg4Q/W5lUNo2fsscGbWY4T6pynpP0Krl+JFEf
+Y+GGHI3aj8aBO0K/ndAEPa5FX51Niq7CEOhoB2hSpGAgBT5+uzxAMzSuVEeQmZIbYew4tM4UsHYd
+ZtT/9ibeR1u6rlX6lBQlSBT6LQ9YUEAgmAxLkAKQL9PSm/3NQF4w7ZvdqRqMJ5DYZh3j3I1rDmyX
+yti0llyZjkLnoPtHHwZd+fwWVz9ztMTMCFjpKBVWAdcYhRV6wY0kRv47nqddzEhQvXsqNstE6GNi
+LTd8iliAfI5vfm2KjfTQwbxz2uFzaUL0A9VKWzB7VrWS0QvlqVw9VCXOB6RDSgbNtW05PB7pEz/H
+Zkv+XQTUD8mSQ3mJk/EUe3/2ixiuDVAOBfyIscXixo/rh7BHtl5KSBigokAOClzsk5pj5X5S9GLK
+gu5AbQNotZBWU5zoIzScHQKjeFNr0MiX0Mp+lHmHKuaDcfU2H//hJmeXl1nPE8E/k8ULZ/CLYtwJ
+WG4CHI8h5ySfOAFbkRVFJyi0KYkQ/fhDAjciw08ETminGEMzG/wOERVW0AEslZEl4sfr5AYRKGVS
+MzkDSQ/nhkipQ8y8EF9ZRGKCOxRzfpNMubhc+s9lZBHqNegMaRLozjP+g8CUsaVzp5Wd0ZI5SaeS
+dNAD1HIc0vTPw7SLi4Jpa1gGgtEY865KzsFCn6I1RvKT3r6BVdYGsBPWdVzeLfbxKi8BVQVzd9f8
+3goEpezGYiAXT8S/pW37TxnZ6f+og248Vvj9otMMAmzAfvCpPYmXIx6ZAKAwBH737j2KJpWyuPMn
+FIBfqRrEBYiTiWVjvdx5T7k0dwFjgjLrLVm28m/XLNfjkSOzkoh3hangxcOjvxzVDIGSxYBxI9ak
++DsrVTPAlMWZD7OThbuxdkWjCtGwtH4QzQdpmaBsHV8Yrg1iAK64TC2WMbQJAFFciwJFPSRQ86Ot
+UrnPSODgRE/hD4qWAHDlWBDy1KPUCEbpodyyU4TnaIFzU+tJJAes10UhzVTNE6fGDGUN33wCgAZY
+oIz44wHk6fDO7wGbAEwmcVQg1HGGByFjYGdwJD1joA5AM8olCJ1LlTUGB/khlrmbJbCbD4Uj0GZT
+y06zCTjOeVkJKZzqk0nE4+3RmlgDHpJwCwwZKOl8SEEH+8TQK7R6TiIPAy/5M08zWqjpXg4KWF/M
+NQpvipZJ4KZfGsivxCXyinAY16NjMD+kgtfc8pGpAgSyN27l+uW3OjjOCnldBAJLpzjAYdBoh3b0
+yuYkLj7c6iwxR9NHW9WBeGVYjvaTEHVq2t96HA16vtKz3ZgtNuJgpjnNZRGEjbmQuiQEBJ2BdgHx
+FDqf0F1dQJcS4sIvDHlCASh65anDjgr07Qa98i8Jb1rAbSdOOz0cM9wlKXm7ugzOMTmi8EbeTBIo
+HrudZ9RSwEtADDsgyFwnxyfzXecDzLGFMmkRrGWCdnWVnSMMcc4cl7NaF+t+gTHgy9s1SV05LLaw
+7YYgNxNKt2kpiEgpahsRp/0tarSWdfS3AdWYIAnrT68WTwX1vtPgL7EMcIzmOpOxL7oZh+coizve
+UkJVmjedZZlkwkno1E7+jVJIoz8APlgweTgHUL/GciPnYgtfrq4TtxE4adiNQ2ZgyJHWYWmrMlW6
+ebFkPaAUwzKsAhoGXxXGRGKFObHKQOqFOnGgkyLajFNwhUa4fqva2yI2DlREZ6p0CNOGwR4XCrS4
+K3SH8pDQGvZIaDcMPtJUoLRM0owJ0iT9QcdRK5IRIIpAOzsUotf3TbAVvbQH8n5voA6kUzw6LqVn
+wPkmnYxgJLYiQ7hQYlEsYL4k5GCZvd58ypvZfwO5t1fXMTj11hE8GuAZhX78JMPsK/J0yQqDPk4Z
++JbbXS1tia0EBwCjgWUJsUI18clQ/L/H39pOY3jRcZFFfW7bC5v98f/wQjY4osg1CYvJfYmKVWbi
+PLEpDvlTEGLjUbCmh74cUqKtsVVr9hspTEdTKrKSRjqUHkhwgyUQeNizUsUp3cLmGnOoxPIuzYDG
+HFJxwclXasrQR5Pp4/X9adXL0zyaNRcp5govE/KIiLMyYKgb3rKpuxbm7t8U7GiR8qcIvzarYOuI
+r0z8D1QgHRWmwQj1jMXJlqpuDBiVUQD80Fnr7quJElyEAs47dXRoms8yEtA2VxNaYbJmUQ+lsKhy
+YLlk2q0QMXQSsMctgTGOka0GYae3AxbsfNKwpf8YnyAYZzDx20P8xvD5aQ4OkVtbj/xeO9gPGmBG
+T3BiXsWroQWXXm7Mw8XnUAttSlNyNEsqWLOLy5MJLmMa9m7Abm0SuOJF9RWA8VDp5xMP/I6LaAKU
+mkqt6/xs1XyWrgcDo5hjmvshCSHhWpwCludJPk5i4bpUhqFw+RmK4VAI0O11JGtbQ64l+y0LUdW7
+GarSUUwP47kW2CYDEdvsA/TXw0I4OPf2SvJ0FKjn7aZxxwVp2xjhpWMTDxaZMkiOxaFFLydXq16f
+efH2qVJybgXVpioGcKFhS4AjNTEa5T37zLo22Qv1apFD5qUjB9w8yA0vSc2RMiA7xIsRIGBTWOjH
+H9SZlK6QJGru7w+q2GoC22fzSVxkr+WlT9rAABqi3RiLzDxns68PSEUIxqrqFw8oMUhIeL+SdTHA
+vw8M5C0b29DIIfScMQS0TKwvPEq3kAQvxMTC0D+7tnB7QNRliGiWl0NuVnIUY7QMwRkP/gVT2WDB
+X08+WLDc+iW0mz2CZ3IAvWqesMkIe3lWqMvUDL5Q33McSklm9U0P9SHgPGGVlX40diyUBp+pfWi/
+h9sKTOvCRCj+eFIWvUXobOyAxrHlhKFGhOiw1vyKUiNMgN3k9No1jfVEpQEU35laY1OWX0u+F/3A
+cQq9opTw0RwEyxVosGLDgIkSdn7hs+IHrv2jR+JUh2kADlTtyX8HxtYxLUhMLj3/FpJAhfxzoRsp
+qTIQicEOQtI1iv4n0xi9GiED3BLS+riXyEyU1v6KfcGAWCaq/gQ5kImR6wna1UoP6KtpT9XLI4Ee
+bxCRQriHsHkCOgDlZM8hJEHcCfGIERpbdeZFFHtE3lBjH2cIQ5p7TNVfRTwBkflxGhmddY2YfZbM
+F0bFv76YdpbH3dxSKmVVsblZW2xdvOxqSIQqbw536IFhJKhELagVlMG3LQqHU43e+RZjx4BJExsL
+cLX1oShyJFvhFevBTFOUF3Exw2yNBWwMCW5QA+7UmPhwM7AMOXRddPg6OxuaNAmiDYRKlcHo4FwU
+eta/LSOUyYddHQi3OFkb4z35KYG+xJAOZ8LTMyJ/CgARNXgZ/C+fKy8W7VwKPzhRpDnIMS0ClN6s
+PMpa421GfuLwApsG0C4FpdCsaLM0NtsctgKVSkeql94+XUmITqdGBajY4m4NmDFEk2HiFjYtNLmZ
+SxNY1QM4KakEvIQIFts+OJ0QCRKvhCmQcfRAjN4VmYgb58CBUMiSUpcyuEfRFZS0SThDQPO4aFcJ
+iNJUvlFdO0s8RaeSdpOSHscV+JAIchHCniOYTsEqhdLZtWVSiAw6hEDO7LI4or+kXTE6zB0CA9o4
+NUeZIpS0Fn7Q8lU4X9sZNCO0uPfjoWqOaqDVcbxBJSAs8RV9IcKmOPY/LDUnXDLSYfFT1xyNTWRL
+KRW0kFxctTIuvuU6R//9ApGo0EHrqGH7dEmsI+gA0UXpfNwWFxUHz9CYK9toXP6IlTFRhuGh7z3b
+hwL5qzzoRAF8dkwboKslbtuftJDrshFMoBNaIvpSXyAFRCCKFOKEkzCkB3NDQB2qtV/ANwHNea+A
+UDr6WWScJazRx4glReLp8vQ8sFtz+hqehlJO6MM5NMIc8/kWnwbE768NqCDKBi+pY288WynJ1CT2
+Kq9+o6rhlUpRatsVIsacJhA+q8M9X/UQMRZhshDAvsXwlZfxDn+WCfyJyLFA2s54on9a54PSC3Wg
+chQWZLZgEl8xGrFUqCofhkvqYtXjA9XyewEKlnAtD26XlSvqtdhXOT+i5BrX6S6hHVcqbZ8qbh+E
+zffUpCfTG5HULg9DQQaQ6ENkkq3DvUSAQwcxh24qkmtdRoIMDxOVDdy0T2w3afIBABsQGxnqJaAO
+Y1gWawTUuhslaSivzrXaPcRyGhUkH0R541UbNvLKiY070WOGYY4R/g1rfKhHcjoV4p45o21tldJX
+mpG0XsOekNlYucZlkAWkVUHtjkSeUbdfBMKrGATodKL9arS5JFVovaKRlOWbNJIS6GHxuLt8CX+B
+YQUYDfxlQrQQhL7z6vChINNDAVVN0rXxaKjegwIPOJf7rXfHBBHGpBNpaeLGFXCBrWAdpIwF6mcE
+7pE2z4HdIxcWkU0QA3TKjZQ/PNc4VwWA3OqmXuoleHBmMRLsU3ENaVgIpVnIWvBLVDYNLzVRdIef
+ms6mo9VoRQZ6cCkQSOdK6KDkWEMZkQyIEM6QUltTfQ1xFpxUL/lFho06RSy0MhFQCIEh5FrTToDE
+gpZU4QcT/bYWc9XTPTTM6ZiDUk6d8MHSyFOgi3cE0Oh5I2Tv/ThHNjxg7A0zwweFEVnLpE0Ai8Q9
+OWYcdB1zNKwLEBtxjc45oHjshf4AMMWhwwRhRdBnjEU3iL3TIBscW+vDMwGJnW4omSkqIJxsnzyW
+wZBg9lQCsSZ2CK25fZnAEtrlT3WZ1xUoqsQBEiEMEmCZAjQU8EhBFQSUEVhPwf6Ekh/QtYOKDqg+
+IfAJ8CuQ0oaANSG8CrQwYJAhV0I0D4CXAOIBYAcYMUAO4A0AuQNYAwAWgJAFzA9A0AgoIOA4ARIJ
+oBoDTBVATUAVA/fmHjl6j+5Pa79V8K/h/QfNvjz3P7ler/HHh7/Pw68DnObsHvPy3cPPA5wScuOB
+7qBzX7b8SuTXQrw88fvOjUnszbV9wOhztB3/rTR53FdNbVFq3a82jxmuwOcluBDDjLjOjALxD3/Q
+iP39Y7a5Rt0oNm7G8V06nAGXPxV3oiByNCcCfXAkpuOrai62YwdiJaYXnQsst7b8q9lbH1AhQ4fO
+tIhMRO4kqFfJyARyYkd8VFgh1WJGVCPlA1ZMLjSDAUNwDDwkxBcqWcEmILYipcSYqtCIqlSAqaSA
+qUCAqkjRU7GCpiLFSkWKlAgVIxAqRiBUbDiowGFRIMKhYMKgwKK/YQV6wYrughXTBCtmAFaz8Vpv
+xWa/FYZ4KujsVY/Yqr+xVOdCp85FSnwKkjcVGeoqJdRUiaio4xFRNgKhy0VBtoqArRXysFeyurkV
+1bquqMqqonq+h2r6EqfoBp++NH3jn+5M325m+zqX6/4/rnjqtKKqtoqqPhqmWGqVIapJgqjWCqxY
+Kqxeqp52qenapVdqkp2qOnaopdqh52qD3Krsbqs1uquGqqZaqmdqqVmapLZqjdgLkVYtPvgiXswW
+obLWxLWyK0qjACE6uL48VDS74vVFa9UPr1QitVAa1XzWq9S1XKUq4ilUQUqiClULTqhKdUDSqgSN
+X2hV9IVfB9XkdViTasMbVeTarwZVcjKrSZVYS6q6XVVS6qiXVCBdUEF1fgqrzlVcsqrdlVbQqrWk
+/Z8n7Vkfagj7JEfYwf7Cj/Xof68j/W8f62DVWIarWDVaUarJi1YsWrEC1XsWq9C1XQWq1iVWMSqM
+BKoqEqhgSqBxKvuJV7g6ucHVwg6tqHVrg6vuFV6QquaFVwQatsDVrwatGDVnAascDVhwaoyAqiv9
+UO/qhL9UBfq+n6vB/7kf+2/x+tVskpnZEuCUxHC+/YuIK6NNKiB/EzIk5DuCcPq3Ew4GQBYmlqw4
+gUEVMiRKFQwiMCQcTgAAAAEDAWAAF5ItM+6bFophhd3N1nA4zIKh4NARWfqCooqII1UQ4kBYJ2AQ
+sGyO2lAp+6Xiqm/Ckfz5urtugisAuGzxeNHQh1A73Vh4dG0/NDkMQKtSO/BTm3DojsrbF3jq6kKd
+axNxwpKvTKteAnM7mCQ85oHLN5AxXtO3FxElkoEAFo/Y7SdVN5daSO3q5Y+GBpQAYrusw+EY9/XM
+mtYT6y1gbXXfGgzHr8ic6AN9hcvHwEYELAoOjr69A1yaVwaL10euR3YUZUZvQl5xZXoT8YeJLqVK
+FrjMLT83+N7REmekLvRn0TLh+ZMzVhvjjOcuh7/DGoSIzhcgAEyu2q+gmErl0SoAyvHf0gOOHkuR
+FZQSSkFEDSG4HCQ838BiFt5mdNnEIYrPlCai6RoN3/EdkyVeA7o+HQvKrwD5CYAAo2RJZIeP1xRy
++lJaWuskPYYJ6GKPdNLzxcio1M6LXHJDQbx0X1i8B9YnLsQYerRiZjBe+2alDqaPIASEoxCeRAUM
+VuivCDeCNo43Zi+mFz4viBZJrJMbwxhXGCv8CUG+GpgMJzaVH06hQdq5woKyZyKYDByVHQl05OpU
+qPrSuURMAxrqnfhkQENbMcnlzk3MLnnmnljBLSdHj488rWP0ithH7Mq2sETRkNmgYc3AZSu6gL+C
+k4IDhPtHR057XmxZs5enMzU7IR5rdjAD5bhqPdP0mGax4/BC5rzvd/NmFSTuivxBTftCPQY+TO9C
+X4l81r5FFfrkZ1yrTcaX/E35vu8hUNdTlgS2iD0q93mIVdiG+zz6ZoWvKaG4axR1VGYKVxYs/hBQ
+R7uUeb1mU/3VlT93WVa55WteFObdmuaGauUaHua6G9Lh9q5rpXj/wgi3iPylvEGKzMA9lXBUjbXH
+UnsEBSjM4dcmrgF7f0G9lwAQt4RLmuXHbpvBr9TrIO6tAdGiB79MRHozMKD8uVjof8zfR8GjzHzh
+s033A2Py+ejgTAGqXxpL/w2WVk1lFTJqz+0kBeRuJCR5GRySPRQSmUbztwmWP9kLIWUhlXSVdCic
+r0AP0QVDW1JhE6NsgqFunp2ST1zYgQv6Qnhu0JlL3GiFmbc6pMG8mzBJsoRi1z3Z5NTM0f1ndDFj
+ciaUQqsNg6uq3fi8dFUAWOQGs1VX8XhLFmvpemPhnFsJ4EJp5fMYZskQQsqfYfD9NJDx6cnQ0sTS
+uR2L40hG49L+mrs3RoC4ghACgxYOijJAtdpXHsZI0rFXEhZYgy3algwWFOreuLxQmZTNtXroCxgY
+hVHmAFChJHArQSkYK5FLPlzPCQ38AzsClDlC4ke6RHiVatgqkBMcH5a6mGXLmcLkgxPCTi3IYssN
+hBMcXoBJkK7iAw/q1cJO27YZZ1dgwK6TjpcOKZhOClzaJK94ByvnLhalwYwwHNGbpKKrMoiCUVvM
+U4ZDGftbGmdYDSWM4M18njvCm2QeRAFzCJCDrWq4fFsh0jgTZAy3lAyEhSb5p3l+7zqhPPDOxcQ5
+kAj9XEi83gCXQDB330FUKUN8JTMzokg+MHLm0D3oGAQxNjGVUC4qv3mNqY80W8Wma/G/RJg0Pokw
+2Jil+UKRbOEH5QZhYg2DwSICOBEYPtpPgwWBiCfyJ0YCZEGKrTfFYsGyw21JEW52PoQdw+SszylG
+kFpTMhd5kWLnyTIQai8z1ij55qLRN75GxKwkR9E1MhMUCbxmmw63GyiBjM6OORqQNMpJtSUqMssF
+siIRB3bOWC1CBqx4cDrtymvUnfKZrNpclIQX0iC+0SWyKIyxEbrSIkB4ly9nnkYJu6fFFI5Ukewz
+CvGzpCmkfDtvWO/vOQBSKG+w4WeOGpxQqahRKjqs7pmglalwleZKZnV2WNi1CBepIZxSes8CtZlR
+I0GWmUOVcYlpvK0hUKRhWaEyXRViM53DzUU8eSDYlUJQqDMmUYc2RuqTtfeLBUIWJzpxmeJiOCoA
+XmCaSqYM441iWisAz0U0EQHSkfuH3o9uyZk0g2C+1Huy1lYiCySpvTSdjMKwTiKdQVCax08qRNA1
+Vs2wiL2IyamfCpg+lZwXvOo2sB1QB9xIdX6Bj6VzRgd4UoHI9PenyASnBA8k3EjsE1S2ipMclWB3
+LPJeWzSHOikaNhJsFX5zoP45XxaGhDK/pP/DIYztiS6vqMPACWcgP2kpZWjOfJBHYRQNI4tp3WUQ
+GWpE8ZqoZEFvYJaFCTkUJPdTqeYpTEWodgDyHYOTQomy+oKxLC8BtejPZfK3UMphCswZ56qASoLK
+60kVHNgZzT8/UWcqkls5xsQ57uoPAv+CrnsSCROispXTpjPKe4ND10sCf/ElOsPgR+1K2fX5hXhJ
+fNGzBWCpiE4EjGUBgUzovLqcdL1yqDbTutsHLe0YqwBcpKRqcP65/vot41Eg4cbCrFOObHzAyIO3
+Np2zmgIymMqrmdZ5wgWiOKMA+V8kKigbnyOAnZzQK1uMozbw7SBWI+tpCLJTN4yFsnUOPsR6JqbO
+mnG2mYUYJV0I/FDRgDb2YBKeBAzYRv4d82IRIjKNJ6kthxBIf4f6tg5Rewqogb+BL89Xa+8Y7mPw
+JBnr+qyHL3Me2KqwE3nnFG4NiIrI+vziW0DG1jcQIHeE7iAwtWHXwFYTmEfOmdkgt4Pr1n2vJwnS
+QymN0R0NLRTgAHjDVSIfITmkvlvfz7MU64jgUChw5hCXsYgG5gXyQ1osKsxCRhvPgsghFG5zI1CX
+CBIAwKkjyKLeqBc+fEUFiCvfGOta3gR/U26my2RNT0gywIO1yxoMTM8Mlfo35lpDQ4jfU18jrE6Q
+iUumMhcIndvm8iDoRH8amzyNFXNUKcSoCnh5AQYr61lElsUE1avUS/nDanpv/ZFa3VH2JIq5OrC2
+wDxYOhlkZf5BIr5I2JAQY6MewSa45Ob/z+EjpgzBQTlG3AdVyHpu2GkjfOxGCSQ/4KBsYV+4WC4t
+HrRIEC3vi8DWBGimk2R3cQNWDhpiR/9KQZE618tdreVPJR485XjWwoxbnLTn6IZ4EjKrhRraDtVP
+s4zmDldmpWjWM5L49vWKkkh21cJ0GELX5Hje5CUKJRNkIrvqKWk7bw8b7gYD5fEhk7VgXTHJI0Us
+IqSimKH3B62CsLrQWXjB+oWwKWamDL6RlAYnwhMdNFIyfJuJIyo2hI+RLmmREVRHaJdaBYDQo4bD
+l91nK3Zy7hcqlXpT//g9jl5m4DVYTnaJOAoq7zjeA2QzPBWRnDjFKG0AJybS5gxwd7oVkVIAgAqW
+CrwA2TuCFHn+lQSxm2EjeZemixAGSIByWTtmzQII9iyI6QxlnEfiedIUpRSDRKzAojtJx830mEfq
+cSqHRLRGSUmpIkhYAfBXhL3h5wRAsiPnzp5CmVoG70nYHSlNBsQEOYNSYjVHmDMCMyyhMYHx+hks
+Boo78rYc0vB6ClzXpCsSQL0xuJj0lRG0q3NgS/gqHn0/dBeijOqfmwAAwNmamjdRSr62goEAhLCK
+0y0mqVtUz8B3F3pE3rUMN9wQoCtpvRAK3sFTK3tcPZnt6Z27rdUEcCb1qxd8b7ARVibBsC+RyonU
+CCcPwOsBKtzEuPpnx3V+Qo3FTRLkQsTzT/t5GIpAhUffp2BuiRh/hQEK3waIhUoJczWFQtyb9PP5
+ODdKmoRpQHa5EoivjH117VzUEyb9h3I8XFhYGY2GgobkujLXrm+bJ7HN7wo3WOTojHaQLy5ZQH60
+wuIar4h1s2FLyTWktIBtEtP6PSDSPebTewSizvHczvHVzmh8LyM8TZbIzBlYhsTDRW2MtA4tMbKo
+UyaOwZNB0EcTEoAHayrWzlDMhazQx8GCH8+XZI4EskKhE1hnN1De89ZjtBMDWCxLN+4bn5AnyOhx
+pTflbO1kA/0EGhUliSyMtWT0UMb+qEPinhEFYyHEbAUyp8tYuqYDRipLscjyGJA3zbmKdMTMI8V7
+2v2ZQ8R1C6WY4qjndJBCREkDNEWaBovAOsU5JvqCCECn5/q30Wfs27Q1NX3PB1CxWQYK4rW6gl2D
+EhCJLvzF+BEKd6LLjbQMVuJRpueMSQJN40n5WAdyXvuYQeXUQsoQDysgsemARNTywlJKFiZeuo5A
+iRfoTmTq6hkwijNVgqADIQ0SrFqBN9hK5RC2ZzmikwVm0CCZzso1HPlzzN0IP+QCIQZ/zA/J0cIi
+WLfbbDGvgdRmzRiOWxhWyl0iXpQfpiIVEQuNo2d7rj0OZeiVOeay6x5oKlhwZCcg8KUij44xrtH4
+IX6UM37YQMPXh6QvlpkcPG94IVYA3iwMJ0L8LuuaogTlCTJsenAjL0PQ7L1Pi8hmGJdOqOJeVo7E
+CLPOdRHN4hjBEITrTPlmX622a1Nkllc+XvRIMYsWFbQasKlkKf0TuoImAklJXaN12zLmMOiREi6f
+UAhVGrkOVhqjWR2eenOmgUY7GLcmbnAqWpftrThQTmBEC5zJQBDcPyN4AoXnInBM2UJew3uo3Osd
+/VotG4JFRB1dhhN21R2ig74o0Jw8ZN7VnA0lWB0lDFZ5PDtyXLlhvcGuF0S6Wr3U2CqpnkDjwB2m
+BQdPGRuL5x1IFo03LEOsHEh4MKRvE9edrMh0Snaf0cShzOIJdiyBYWbPeMzTRGYsBHAfX1laNIl1
+ZVxzggRI5m51PG59wVXQ7HQGRYRRnGy89qI5okgmTpsdUtZgAxPvJ+WcqIbSWx6tf5yN+uJkKOjR
+OUqEcP4y6WDOTFIXxQkr7hHBS7hmbyT8AljD77OJLW4CQGYAb2Pei8bNTgMttEECV0uBXZksyIJd
+39JlDyojumSt0T2TM5i3S2cviYGBEzQtmTKzAFB8QEcXkZq4YmJ/TDWdYLS0Kazft+a+C7HwNZAJ
+aVEY3kfqPHY2SBxchsqiGqJLn5a/mjEa8QgmABHka5AWJ+G18I9w3WjonkFGEwKhtgp0j8YPUeYE
+ncSOLNhhwVJnEiplRLfp6lN7z5sAMYVx+A71pVUbhIzIaaNzUbAarADBLMSSoXqKXumbEiOijClh
+zIbSA5gGB2qtutd0MjQyWBaAzJmfqki7MMaEQAOCXbwaXixbEGNFnHCqmWg8qjxIZ0oeAxEPKD1A
+7yRyuS4AIRwOrQJ6DxVHVPpAc7aCkBHpHC9GMxBqe9Qt62zjQGJy9sjB5efNIj3/yv2r6z+SM/zu
+FE0Za9wOJ37u2rcQy7P6SvWZqCuEJKtvjAUTarXAcyMQRrVOlrD0HTsN2KDiUivtwmgj5U9inAK5
++C4IqL6iNHhU7OH98NmQILOWxNwJiPwwlnf1QAEMLagJuGLoYUdlqBRDn8QcRAg9AuLhe4myJn/E
+oxUfepXHhZ8Dk0BKaH6znSNmNJJ2IRdEvxoTfFkKRNn0cEvSio6ek7OG7AZljFvqNgRejEgmOwp7
+toPkAA5CIjKCsWmYPIlxUdVDDj/6UQEQZwMPCocey9jKiCj3ryLWjtGlYDdewTAsT/ytgOZKoG6j
+Df/UzE+DBwpk/Px891KJ7wcBDtmnc4Zr8PjCwfnWIE7Tz5Wh4XZOloMKHqBYibF9JCb589kpcmC6
+MqgAH60Nwcj+nBhrvYWI7IfIiYD0IThyXLu+BjtuDKdFNmVqTy8ELHUIcco0LUngtn+upQtGnWSs
+HRGOZxzUOEULCoCKWugvY7ZqEN0MDmNHqeKtmwQSOPoR/Z0KGKGB2wdDYj1CrZsodEQx2TukU2/M
+DvJyPuRgDSC80jH6IO5DbRYrS0rIXfANDM017avY1V29khrSTX8G/Wm5HQ3j02j1MGoCeHm+25tI
+ebrUOsJUhfKhD0EIEeXj3++Q43UQYWPGKRd5tI6RgOxzkuNv3Ji8YcsIU0cpJNn1rQt1eBb5t/e6
+vSIMsxyrbVRxAHaSs8/ijk5AW1W3ajQf6DP51FkKbjEEaQp7ThQOL8pUajXNZgjP+AGWp2PntYtY
+taMRzL3lOTlAMAU2jKG8l3wMD+bxPb8RDFLiiPnwnwm42DzJDXbmbGIZ0jLkON0Ub4bgHg3f5pBR
+/oVAu0YDFztE+zps+P3bAAWSgSxlY2S3LazAF0KZAmzACvKJ/Mz0beXxl+eIEFgZCLRMTD0eI7mF
+nojAK95ZgCTCfQOybhXCo6576fGouBIpcPFCU9ALkeU0pQaG70p3LmSrRNvUUN3vI9R8lCXjgQBK
+D9twFivCVAT47aBVWQPv7zSwNj8Un/SFG3FqLOS5c+WZHKZKVGCPSmIgHEwoN5C6HgtxiaB5+UvB
+rgQmTbO5rMJ+CuldZzfzxgdXp9XgD508hFWCeR8zw0tDDW2xoicZACrgqgnQ48NRFvjGjGQLa0bZ
+/YIPRHYC9plKdMERvlMGhAQeqDBMhf6LZGmyElMCwEIYOo1BZ6PH7+WHUp1YWZa7wqK1XoOCvECZ
+SwoJH1Mkaogtg1cnvzmDI1q5S6K8zNTnhUkglWVoNqdHdJkfg0Fxp37eM/nNEjkRlbYvQhIWSCHT
+/qEBqUlbxYgGY+MSFSRxt4bg1PVnRhKNZIXooJOn0HVNY/cfiwOh4kjntxHmybS7MJkM71QCMhZG
+bYSMrJ68qAj1YN82a3v5utE6PJoWbuOva8RkRMPNZOJG3h4NcQ9LTUNP7WRG34U+6pZFDjhFpbJy
+Eq7ddJp5LrxHhOcWeKH5m0I1Q2anhxKm+O1yIfm7BGh7B/jqYiPKEBJ6cFrT2ZB6TmSyLIpnTVkU
+/YqVla2WfZcp7SSoTzv6vLYtG8AgtXlxfWZxN6Gzmta1EwxIU6yE9s0x/ZlSkSYE8X5a7/VPKA/l
+ig684F00nmacRk4WooPYSFBnHTa1ebr6zgD+McOV4BeWlJJLrL0qnYZSAVtBA5UxpOASkxyTpYRB
+UMiUqxjxU+ce5iSPwywJQRsno2JDcLSzoQnpUALmNJE+WSFPdsteXHMocr/C0IqI26humQ1wKQoH
+cGmUNYBVwIFZqI1azUTzdFmIOugxHeiO7FGrlsIVmnE3L1JrCuYeQCJCpQc/0JCGgQIe79NvrOoY
+eDQJ2REZcyhK7ihxb2NeHkVj0aI0LIicFJjQk21YaBO4G64TBu2IKBTzYheH2CASyWnlbZNFDbFl
+JqA1Q4kIljGpwnmhmXbOSQEgWsMmsHkBZYKRUWBv9HZZ1N1JSN64WPlCBOt7zqAJMKpczyNBpzQk
+5o//xDjQg86ozQyN4waltVoDaLJOfWjYqewlULt9QO8N4AqlP/o1ZIqJMaZ/ORyILlDFoGoeY2/s
+wI7MBMVXSMJXCUeRsJjHIU6kNEsAqZoBDoHo8Y8pZtM+GL8OLfcPdBbsbvRZuDQcyyrZ42OoTsMJ
+2GH21od/RCfgHrkeCyZfMOkWTSYgXtqYxGIGLcI5gKg/ZR2xnb1upteR3rcNGITv8oKHpUWdLK9k
+IZlFfEtPUNAgnOY66o0dWYJq2a0UT3usCxxDZm0UIViE7Q13vLoyXH6VgLZoJt476o2dZ1DSsnih
+ertfmTnTdREBRHm5ASIGxMbMSITKCmV5fMqgFiewxFtxqh5yfCPkmlKNcrJfmvyKlbaqps0Oa/BS
+PXk4FJjtWF2wOHfpFY63qA49US3T180HXmbqEjYsSpRFkkOVMCBH1C9JAJTRgjCWNAjl2MSA+vZj
+ADldAJGTIoWBOcOEUI4qwvBSI4hMj8m7WHoFosA0M4Q4yS8XtN+5emVGJDGqX8D5SVbE/0bWETJR
+yRFYKQ8umFTkY2ZnV9Lz+VW9hgHq+HYhsrghzcANy+02yEIiJuDFngZnEHSFnTnqDAicaKOgtLZk
+RXBqGS3bgcqBK6B+mV5G4+xzA1IlYTTtL30wAPCkFZuhlgsViFEnA5Rg4UXmBbXBAW7JuNvZlXTV
+sYDMV305DdUPX6QyUFMwndSexwLkpBDsIQ4lUnD9QoEF8QmpcQk8FJckIIkVwvETqBSrIvHRim18
+B7iqFwNCcFoUKmSj9cSfX37WL+CT4mAKH+S76AYlpBE3eYErTSL68qrzEKiOZo1mbN1ujQapDrmT
+Wb1s3iBTeQMCYcYfVeS5ks0rTlCPWr9AjV/bgZ8To6s7qOr3+kRUCKT5GAAUzFlHOkmV3fJEImmh
+CZ4S5ivYOcC3SUx70Is+gfKTQfQBsES9NEX4x0WTcQkWV5JKEJNl0UV8pDmBNnC/4qRYIkjLTUkn
+CCTbfLBLJzy4rnSGTntJHjdpYIWlqzxK+G+RBy22IJ8gMQIibkjgh8Y9Q2H5aenHLwEJg2iDmhQy
+bR8G3gfKxBAZwppQkDi9rFMfLSe8Fgalu2z9mKNwe+F24HWYNjNI3zoQfXsIck6YiAwCMhAsEDMv
+xfp9PxAAxF94h42eFp8V8BZxS3g/oQhPG05yIyOc5GxA27VgPq/N9uxGcdZCP9PAWYlmmiIlMHE/
+Rj3IzE8YKgGEh8OmOkN4KuO6GYyNnRhoWNSgmY9+VfMfhBm7xIwZPp7ggg==
+
+{-# START_FILE static/fonts/glyphicons-halflings-regular.svg #-}
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<svg xmlns="http://www.w3.org/2000/svg">
+<metadata></metadata>
+<defs>
+<font id="glyphicons_halflingsregular" horiz-adv-x="1200" >
+<font-face units-per-em="1200" ascent="960" descent="-240" />
+<missing-glyph horiz-adv-x="500" />
+<glyph />
+<glyph />
+<glyph unicode="&#xd;" />
+<glyph unicode=" " />
+<glyph unicode="*" d="M100 500v200h259l-183 183l141 141l183 -183v259h200v-259l183 183l141 -141l-183 -183h259v-200h-259l183 -183l-141 -141l-183 183v-259h-200v259l-183 -183l-141 141l183 183h-259z" />
+<glyph unicode="+" d="M0 400v300h400v400h300v-400h400v-300h-400v-400h-300v400h-400z" />
+<glyph unicode="&#xa0;" />
+<glyph unicode="&#x2000;" horiz-adv-x="652" />
+<glyph unicode="&#x2001;" horiz-adv-x="1304" />
+<glyph unicode="&#x2002;" horiz-adv-x="652" />
+<glyph unicode="&#x2003;" horiz-adv-x="1304" />
+<glyph unicode="&#x2004;" horiz-adv-x="434" />
+<glyph unicode="&#x2005;" horiz-adv-x="326" />
+<glyph unicode="&#x2006;" horiz-adv-x="217" />
+<glyph unicode="&#x2007;" horiz-adv-x="217" />
+<glyph unicode="&#x2008;" horiz-adv-x="163" />
+<glyph unicode="&#x2009;" horiz-adv-x="260" />
+<glyph unicode="&#x200a;" horiz-adv-x="72" />
+<glyph unicode="&#x202f;" horiz-adv-x="260" />
+<glyph unicode="&#x205f;" horiz-adv-x="326" />
+<glyph unicode="&#x20ac;" d="M100 500l100 100h113q0 47 5 100h-218l100 100h135q37 167 112 257q117 141 297 141q242 0 354 -189q60 -103 66 -209h-181q0 55 -25.5 99t-63.5 68t-75 36.5t-67 12.5q-24 0 -52.5 -10t-62.5 -32t-65.5 -67t-50.5 -107h379l-100 -100h-300q-6 -46 -6 -100h406l-100 -100 h-300q9 -74 33 -132t52.5 -91t62 -54.5t59 -29t46.5 -7.5q29 0 66 13t75 37t63.5 67.5t25.5 96.5h174q-31 -172 -128 -278q-107 -117 -274 -117q-205 0 -324 158q-36 46 -69 131.5t-45 205.5h-217z" />
+<glyph unicode="&#x2212;" d="M200 400h900v300h-900v-300z" />
+<glyph unicode="&#x25fc;" horiz-adv-x="500" d="M0 0z" />
+<glyph unicode="&#x2601;" d="M-14 494q0 -80 56.5 -137t135.5 -57h750q120 0 205 86.5t85 207.5t-85 207t-205 86q-46 0 -90 -14q-44 97 -134.5 156.5t-200.5 59.5q-152 0 -260 -107.5t-108 -260.5q0 -25 2 -37q-66 -14 -108.5 -67.5t-42.5 -122.5z" />
+<glyph unicode="&#x2709;" d="M0 100l400 400l200 -200l200 200l400 -400h-1200zM0 300v600l300 -300zM0 1100l600 -603l600 603h-1200zM900 600l300 300v-600z" />
+<glyph unicode="&#x270f;" d="M-13 -13l333 112l-223 223zM187 403l214 -214l614 614l-214 214zM887 1103l214 -214l99 92q13 13 13 32.5t-13 33.5l-153 153q-15 13 -33 13t-33 -13z" />
+<glyph unicode="&#xe001;" d="M0 1200h1200l-500 -550v-550h300v-100h-800v100h300v550z" />
+<glyph unicode="&#xe002;" d="M14 84q18 -55 86 -75.5t147 5.5q65 21 109 69t44 90v606l600 155v-521q-64 16 -138 -7q-79 -26 -122.5 -83t-25.5 -111q18 -55 86 -75.5t147 4.5q70 23 111.5 63.5t41.5 95.5v881q0 10 -7 15.5t-17 2.5l-752 -193q-10 -3 -17 -12.5t-7 -19.5v-689q-64 17 -138 -7 q-79 -25 -122.5 -82t-25.5 -112z" />
+<glyph unicode="&#xe003;" d="M23 693q0 200 142 342t342 142t342 -142t142 -342q0 -142 -78 -261l300 -300q7 -8 7 -18t-7 -18l-109 -109q-8 -7 -18 -7t-18 7l-300 300q-119 -78 -261 -78q-200 0 -342 142t-142 342zM176 693q0 -136 97 -233t234 -97t233.5 96.5t96.5 233.5t-96.5 233.5t-233.5 96.5 t-234 -97t-97 -233z" />
+<glyph unicode="&#xe005;" d="M100 784q0 64 28 123t73 100.5t104.5 64t119 20.5t120 -38.5t104.5 -104.5q48 69 109.5 105t121.5 38t118.5 -20.5t102.5 -64t71 -100.5t27 -123q0 -57 -33.5 -117.5t-94 -124.5t-126.5 -127.5t-150 -152.5t-146 -174q-62 85 -145.5 174t-149.5 152.5t-126.5 127.5 t-94 124.5t-33.5 117.5z" />
+<glyph unicode="&#xe006;" d="M-72 800h479l146 400h2l146 -400h472l-382 -278l145 -449l-384 275l-382 -275l146 447zM168 71l2 1z" />
+<glyph unicode="&#xe007;" d="M-72 800h479l146 400h2l146 -400h472l-382 -278l145 -449l-384 275l-382 -275l146 447zM168 71l2 1zM237 700l196 -142l-73 -226l192 140l195 -141l-74 229l193 140h-235l-77 211l-78 -211h-239z" />
+<glyph unicode="&#xe008;" d="M0 0v143l400 257v100q-37 0 -68.5 74.5t-31.5 125.5v200q0 124 88 212t212 88t212 -88t88 -212v-200q0 -51 -31.5 -125.5t-68.5 -74.5v-100l400 -257v-143h-1200z" />
+<glyph unicode="&#xe009;" d="M0 0v1100h1200v-1100h-1200zM100 100h100v100h-100v-100zM100 300h100v100h-100v-100zM100 500h100v100h-100v-100zM100 700h100v100h-100v-100zM100 900h100v100h-100v-100zM300 100h600v400h-600v-400zM300 600h600v400h-600v-400zM1000 100h100v100h-100v-100z M1000 300h100v100h-100v-100zM1000 500h100v100h-100v-100zM1000 700h100v100h-100v-100zM1000 900h100v100h-100v-100z" />
+<glyph unicode="&#xe010;" d="M0 50v400q0 21 14.5 35.5t35.5 14.5h400q21 0 35.5 -14.5t14.5 -35.5v-400q0 -21 -14.5 -35.5t-35.5 -14.5h-400q-21 0 -35.5 14.5t-14.5 35.5zM0 650v400q0 21 14.5 35.5t35.5 14.5h400q21 0 35.5 -14.5t14.5 -35.5v-400q0 -21 -14.5 -35.5t-35.5 -14.5h-400 q-21 0 -35.5 14.5t-14.5 35.5zM600 50v400q0 21 14.5 35.5t35.5 14.5h400q21 0 35.5 -14.5t14.5 -35.5v-400q0 -21 -14.5 -35.5t-35.5 -14.5h-400q-21 0 -35.5 14.5t-14.5 35.5zM600 650v400q0 21 14.5 35.5t35.5 14.5h400q21 0 35.5 -14.5t14.5 -35.5v-400 q0 -21 -14.5 -35.5t-35.5 -14.5h-400q-21 0 -35.5 14.5t-14.5 35.5z" />
+<glyph unicode="&#xe011;" d="M0 50v200q0 21 14.5 35.5t35.5 14.5h200q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5zM0 450v200q0 21 14.5 35.5t35.5 14.5h200q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-200 q-21 0 -35.5 14.5t-14.5 35.5zM0 850v200q0 21 14.5 35.5t35.5 14.5h200q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5zM400 50v200q0 21 14.5 35.5t35.5 14.5h200q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5 t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5zM400 450v200q0 21 14.5 35.5t35.5 14.5h200q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5zM400 850v200q0 21 14.5 35.5t35.5 14.5h200q21 0 35.5 -14.5t14.5 -35.5 v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5zM800 50v200q0 21 14.5 35.5t35.5 14.5h200q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5zM800 450v200q0 21 14.5 35.5t35.5 14.5h200 q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5zM800 850v200q0 21 14.5 35.5t35.5 14.5h200q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5z" />
+<glyph unicode="&#xe012;" d="M0 50v200q0 21 14.5 35.5t35.5 14.5h200q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5zM0 450q0 -21 14.5 -35.5t35.5 -14.5h200q21 0 35.5 14.5t14.5 35.5v200q0 21 -14.5 35.5t-35.5 14.5h-200q-21 0 -35.5 -14.5 t-14.5 -35.5v-200zM0 850v200q0 21 14.5 35.5t35.5 14.5h200q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5zM400 50v200q0 21 14.5 35.5t35.5 14.5h700q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5 t-35.5 -14.5h-700q-21 0 -35.5 14.5t-14.5 35.5zM400 450v200q0 21 14.5 35.5t35.5 14.5h700q21 0 35.5 -14.5t14.5 -35.5v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-700q-21 0 -35.5 14.5t-14.5 35.5zM400 850v200q0 21 14.5 35.5t35.5 14.5h700q21 0 35.5 -14.5t14.5 -35.5 v-200q0 -21 -14.5 -35.5t-35.5 -14.5h-700q-21 0 -35.5 14.5t-14.5 35.5z" />
+<glyph unicode="&#xe013;" d="M29 454l419 -420l818 820l-212 212l-607 -607l-206 207z" />
+<glyph unicode="&#xe014;" d="M106 318l282 282l-282 282l212 212l282 -282l282 282l212 -212l-282 -282l282 -282l-212 -212l-282 282l-282 -282z" />
+<glyph unicode="&#xe015;" d="M23 693q0 200 142 342t342 142t342 -142t142 -342q0 -142 -78 -261l300 -300q7 -8 7 -18t-7 -18l-109 -109q-8 -7 -18 -7t-18 7l-300 300q-119 -78 -261 -78q-200 0 -342 142t-142 342zM176 693q0 -136 97 -233t234 -97t233.5 96.5t96.5 233.5t-96.5 233.5t-233.5 96.5 t-234 -97t-97 -233zM300 600v200h100v100h200v-100h100v-200h-100v-100h-200v100h-100z" />
+<glyph unicode="&#xe016;" d="M23 694q0 200 142 342t342 142t342 -142t142 -342q0 -141 -78 -262l300 -299q7 -7 7 -18t-7 -18l-109 -109q-8 -8 -18 -8t-18 8l-300 300q-119 -78 -261 -78q-200 0 -342 142t-142 342zM176 694q0 -136 97 -233t234 -97t233.5 97t96.5 233t-96.5 233t-233.5 97t-234 -97 t-97 -233zM300 601h400v200h-400v-200z" />
+<glyph unicode="&#xe017;" d="M23 600q0 183 105 331t272 210v-166q-103 -55 -165 -155t-62 -220q0 -177 125 -302t302 -125t302 125t125 302q0 120 -62 220t-165 155v166q167 -62 272 -210t105 -331q0 -118 -45.5 -224.5t-123 -184t-184 -123t-224.5 -45.5t-224.5 45.5t-184 123t-123 184t-45.5 224.5 zM500 750q0 -21 14.5 -35.5t35.5 -14.5h100q21 0 35.5 14.5t14.5 35.5v400q0 21 -14.5 35.5t-35.5 14.5h-100q-21 0 -35.5 -14.5t-14.5 -35.5v-400z" />
+<glyph unicode="&#xe018;" d="M100 1h200v300h-200v-300zM400 1v500h200v-500h-200zM700 1v800h200v-800h-200zM1000 1v1200h200v-1200h-200z" />
+<glyph unicode="&#xe019;" d="M26 601q0 -33 6 -74l151 -38l2 -6q14 -49 38 -93l3 -5l-80 -134q45 -59 105 -105l133 81l5 -3q45 -26 94 -39l5 -2l38 -151q40 -5 74 -5q27 0 74 5l38 151l6 2q46 13 93 39l5 3l134 -81q56 44 104 105l-80 134l3 5q24 44 39 93l1 6l152 38q5 40 5 74q0 28 -5 73l-152 38 l-1 6q-16 51 -39 93l-3 5l80 134q-44 58 -104 105l-134 -81l-5 3q-45 25 -93 39l-6 1l-38 152q-40 5 -74 5q-27 0 -74 -5l-38 -152l-5 -1q-50 -14 -94 -39l-5 -3l-133 81q-59 -47 -105 -105l80 -134l-3 -5q-25 -47 -38 -93l-2 -6l-151 -38q-6 -48 -6 -73zM385 601 q0 88 63 151t152 63t152 -63t63 -151q0 -89 -63 -152t-152 -63t-152 63t-63 152z" />
+<glyph unicode="&#xe020;" d="M100 1025v50q0 10 7.5 17.5t17.5 7.5h275v100q0 41 29.5 70.5t70.5 29.5h300q41 0 70.5 -29.5t29.5 -70.5v-100h275q10 0 17.5 -7.5t7.5 -17.5v-50q0 -11 -7 -18t-18 -7h-1050q-11 0 -18 7t-7 18zM200 100v800h900v-800q0 -41 -29.5 -71t-70.5 -30h-700q-41 0 -70.5 30 t-29.5 71zM300 100h100v700h-100v-700zM500 100h100v700h-100v-700zM500 1100h300v100h-300v-100zM700 100h100v700h-100v-700zM900 100h100v700h-100v-700z" />
+<glyph unicode="&#xe021;" d="M1 601l656 644l644 -644h-200v-600h-300v400h-300v-400h-300v600h-200z" />
+<glyph unicode="&#xe022;" d="M100 25v1150q0 11 7 18t18 7h475v-500h400v-675q0 -11 -7 -18t-18 -7h-850q-11 0 -18 7t-7 18zM700 800v300l300 -300h-300z" />
+<glyph unicode="&#xe023;" d="M4 600q0 162 80 299t217 217t299 80t299 -80t217 -217t80 -299t-80 -299t-217 -217t-299 -80t-299 80t-217 217t-80 299zM186 600q0 -171 121.5 -292.5t292.5 -121.5t292.5 121.5t121.5 292.5t-121.5 292.5t-292.5 121.5t-292.5 -121.5t-121.5 -292.5zM500 500v400h100 v-300h200v-100h-300z" />
+<glyph unicode="&#xe024;" d="M-100 0l431 1200h209l-21 -300h162l-20 300h208l431 -1200h-538l-41 400h-242l-40 -400h-539zM488 500h224l-27 300h-170z" />
+<glyph unicode="&#xe025;" d="M0 0v400h490l-290 300h200v500h300v-500h200l-290 -300h490v-400h-1100zM813 200h175v100h-175v-100z" />
+<glyph unicode="&#xe026;" d="M1 600q0 122 47.5 233t127.5 191t191 127.5t233 47.5t233 -47.5t191 -127.5t127.5 -191t47.5 -233t-47.5 -233t-127.5 -191t-191 -127.5t-233 -47.5t-233 47.5t-191 127.5t-127.5 191t-47.5 233zM188 600q0 -170 121 -291t291 -121t291 121t121 291t-121 291t-291 121 t-291 -121t-121 -291zM350 600h150v300h200v-300h150l-250 -300z" />
+<glyph unicode="&#xe027;" d="M4 600q0 162 80 299t217 217t299 80t299 -80t217 -217t80 -299t-80 -299t-217 -217t-299 -80t-299 80t-217 217t-80 299zM186 600q0 -171 121.5 -292.5t292.5 -121.5t292.5 121.5t121.5 292.5t-121.5 292.5t-292.5 121.5t-292.5 -121.5t-121.5 -292.5zM350 600l250 300 l250 -300h-150v-300h-200v300h-150z" />
+<glyph unicode="&#xe028;" d="M0 25v475l200 700h800l199 -700l1 -475q0 -11 -7 -18t-18 -7h-1150q-11 0 -18 7t-7 18zM200 500h200l50 -200h300l50 200h200l-97 500h-606z" />
+<glyph unicode="&#xe029;" d="M4 600q0 162 80 299t217 217t299 80t299 -80t217 -217t80 -299t-80 -299t-217 -217t-299 -80t-299 80t-217 217t-80 299zM186 600q0 -172 121.5 -293t292.5 -121t292.5 121t121.5 293q0 171 -121.5 292.5t-292.5 121.5t-292.5 -121.5t-121.5 -292.5zM500 397v401 l297 -200z" />
+<glyph unicode="&#xe030;" d="M23 600q0 -118 45.5 -224.5t123 -184t184 -123t224.5 -45.5t224.5 45.5t184 123t123 184t45.5 224.5h-150q0 -177 -125 -302t-302 -125t-302 125t-125 302t125 302t302 125q136 0 246 -81l-146 -146h400v400l-145 -145q-157 122 -355 122q-118 0 -224.5 -45.5t-184 -123 t-123 -184t-45.5 -224.5z" />
+<glyph unicode="&#xe031;" d="M23 600q0 118 45.5 224.5t123 184t184 123t224.5 45.5q198 0 355 -122l145 145v-400h-400l147 147q-112 80 -247 80q-177 0 -302 -125t-125 -302h-150zM100 0v400h400l-147 -147q112 -80 247 -80q177 0 302 125t125 302h150q0 -118 -45.5 -224.5t-123 -184t-184 -123 t-224.5 -45.5q-198 0 -355 122z" />
+<glyph unicode="&#xe032;" d="M100 0h1100v1200h-1100v-1200zM200 100v900h900v-900h-900zM300 200v100h100v-100h-100zM300 400v100h100v-100h-100zM300 600v100h100v-100h-100zM300 800v100h100v-100h-100zM500 200h500v100h-500v-100zM500 400v100h500v-100h-500zM500 600v100h500v-100h-500z M500 800v100h500v-100h-500z" />
+<glyph unicode="&#xe033;" d="M0 100v600q0 41 29.5 70.5t70.5 29.5h100v200q0 82 59 141t141 59h300q82 0 141 -59t59 -141v-200h100q41 0 70.5 -29.5t29.5 -70.5v-600q0 -41 -29.5 -70.5t-70.5 -29.5h-900q-41 0 -70.5 29.5t-29.5 70.5zM400 800h300v150q0 21 -14.5 35.5t-35.5 14.5h-200 q-21 0 -35.5 -14.5t-14.5 -35.5v-150z" />
+<glyph unicode="&#xe034;" d="M100 0v1100h100v-1100h-100zM300 400q60 60 127.5 84t127.5 17.5t122 -23t119 -30t110 -11t103 42t91 120.5v500q-40 -81 -101.5 -115.5t-127.5 -29.5t-138 25t-139.5 40t-125.5 25t-103 -29.5t-65 -115.5v-500z" />
+<glyph unicode="&#xe035;" d="M0 275q0 -11 7 -18t18 -7h50q11 0 18 7t7 18v300q0 127 70.5 231.5t184.5 161.5t245 57t245 -57t184.5 -161.5t70.5 -231.5v-300q0 -11 7 -18t18 -7h50q11 0 18 7t7 18v300q0 116 -49.5 227t-131 192.5t-192.5 131t-227 49.5t-227 -49.5t-192.5 -131t-131 -192.5 t-49.5 -227v-300zM200 20v460q0 8 6 14t14 6h160q8 0 14 -6t6 -14v-460q0 -8 -6 -14t-14 -6h-160q-8 0 -14 6t-6 14zM800 20v460q0 8 6 14t14 6h160q8 0 14 -6t6 -14v-460q0 -8 -6 -14t-14 -6h-160q-8 0 -14 6t-6 14z" />
+<glyph unicode="&#xe036;" d="M0 400h300l300 -200v800l-300 -200h-300v-400zM688 459l141 141l-141 141l71 71l141 -141l141 141l71 -71l-141 -141l141 -141l-71 -71l-141 141l-141 -141z" />
+<glyph unicode="&#xe037;" d="M0 400h300l300 -200v800l-300 -200h-300v-400zM700 857l69 53q111 -135 111 -310q0 -169 -106 -302l-67 54q86 110 86 248q0 146 -93 257z" />
+<glyph unicode="&#xe038;" d="M0 401v400h300l300 200v-800l-300 200h-300zM702 858l69 53q111 -135 111 -310q0 -170 -106 -303l-67 55q86 110 86 248q0 145 -93 257zM889 951l7 -8q123 -151 123 -344q0 -189 -119 -339l-7 -8l81 -66l6 8q142 178 142 405q0 230 -144 408l-6 8z" />
+<glyph unicode="&#xe039;" d="M0 0h500v500h-200v100h-100v-100h-200v-500zM0 600h100v100h400v100h100v100h-100v300h-500v-600zM100 100v300h300v-300h-300zM100 800v300h300v-300h-300zM200 200v100h100v-100h-100zM200 900h100v100h-100v-100zM500 500v100h300v-300h200v-100h-100v-100h-200v100 h-100v100h100v200h-200zM600 0v100h100v-100h-100zM600 1000h100v-300h200v-300h300v200h-200v100h200v500h-600v-200zM800 800v300h300v-300h-300zM900 0v100h300v-100h-300zM900 900v100h100v-100h-100zM1100 200v100h100v-100h-100z" />
+<glyph unicode="&#xe040;" d="M0 200h100v1000h-100v-1000zM100 0v100h300v-100h-300zM200 200v1000h100v-1000h-100zM500 0v91h100v-91h-100zM500 200v1000h200v-1000h-200zM700 0v91h100v-91h-100zM800 200v1000h100v-1000h-100zM900 0v91h200v-91h-200zM1000 200v1000h200v-1000h-200z" />
+<glyph unicode="&#xe041;" d="M0 700l1 475q0 10 7.5 17.5t17.5 7.5h474l700 -700l-500 -500zM148 953q0 -42 29 -71q30 -30 71.5 -30t71.5 30q29 29 29 71t-29 71q-30 30 -71.5 30t-71.5 -30q-29 -29 -29 -71z" />
+<glyph unicode="&#xe042;" d="M1 700l1 475q0 11 7 18t18 7h474l700 -700l-500 -500zM148 953q0 -42 30 -71q29 -30 71 -30t71 30q30 29 30 71t-30 71q-29 30 -71 30t-71 -30q-30 -29 -30 -71zM701 1200h100l700 -700l-500 -500l-50 50l450 450z" />
+<glyph unicode="&#xe043;" d="M100 0v1025l175 175h925v-1000l-100 -100v1000h-750l-100 -100h750v-1000h-900z" />
+<glyph unicode="&#xe044;" d="M200 0l450 444l450 -443v1150q0 20 -14.5 35t-35.5 15h-800q-21 0 -35.5 -15t-14.5 -35v-1151z" />
+<glyph unicode="&#xe045;" d="M0 100v700h200l100 -200h600l100 200h200v-700h-200v200h-800v-200h-200zM253 829l40 -124h592l62 124l-94 346q-2 11 -10 18t-18 7h-450q-10 0 -18 -7t-10 -18zM281 24l38 152q2 10 11.5 17t19.5 7h500q10 0 19.5 -7t11.5 -17l38 -152q2 -10 -3.5 -17t-15.5 -7h-600 q-10 0 -15.5 7t-3.5 17z" />
+<glyph unicode="&#xe046;" d="M0 200q0 -41 29.5 -70.5t70.5 -29.5h1000q41 0 70.5 29.5t29.5 70.5v600q0 41 -29.5 70.5t-70.5 29.5h-150q-4 8 -11.5 21.5t-33 48t-53 61t-69 48t-83.5 21.5h-200q-41 0 -82 -20.5t-70 -50t-52 -59t-34 -50.5l-12 -20h-150q-41 0 -70.5 -29.5t-29.5 -70.5v-600z M356 500q0 100 72 172t172 72t172 -72t72 -172t-72 -172t-172 -72t-172 72t-72 172zM494 500q0 -44 31 -75t75 -31t75 31t31 75t-31 75t-75 31t-75 -31t-31 -75zM900 700v100h100v-100h-100z" />
+<glyph unicode="&#xe047;" d="M53 0h365v66q-41 0 -72 11t-49 38t1 71l92 234h391l82 -222q16 -45 -5.5 -88.5t-74.5 -43.5v-66h417v66q-34 1 -74 43q-18 19 -33 42t-21 37l-6 13l-385 998h-93l-399 -1006q-24 -48 -52 -75q-12 -12 -33 -25t-36 -20l-15 -7v-66zM416 521l178 457l46 -140l116 -317h-340 z" />
+<glyph unicode="&#xe048;" d="M100 0v89q41 7 70.5 32.5t29.5 65.5v827q0 28 -1 39.5t-5.5 26t-15.5 21t-29 14t-49 14.5v71l471 -1q120 0 213 -88t93 -228q0 -55 -11.5 -101.5t-28 -74t-33.5 -47.5t-28 -28l-12 -7q8 -3 21.5 -9t48 -31.5t60.5 -58t47.5 -91.5t21.5 -129q0 -84 -59 -156.5t-142 -111 t-162 -38.5h-500zM400 200h161q89 0 153 48.5t64 132.5q0 90 -62.5 154.5t-156.5 64.5h-159v-400zM400 700h139q76 0 130 61.5t54 138.5q0 82 -84 130.5t-239 48.5v-379z" />
+<glyph unicode="&#xe049;" d="M200 0v57q77 7 134.5 40.5t65.5 80.5l173 849q10 56 -10 74t-91 37q-6 1 -10.5 2.5t-9.5 2.5v57h425l2 -57q-33 -8 -62 -25.5t-46 -37t-29.5 -38t-17.5 -30.5l-5 -12l-128 -825q-10 -52 14 -82t95 -36v-57h-500z" />
+<glyph unicode="&#xe050;" d="M-75 200h75v800h-75l125 167l125 -167h-75v-800h75l-125 -167zM300 900v300h150h700h150v-300h-50q0 29 -8 48.5t-18.5 30t-33.5 15t-39.5 5.5t-50.5 1h-200v-850l100 -50v-100h-400v100l100 50v850h-200q-34 0 -50.5 -1t-40 -5.5t-33.5 -15t-18.5 -30t-8.5 -48.5h-49z " />
+<glyph unicode="&#xe051;" d="M33 51l167 125v-75h800v75l167 -125l-167 -125v75h-800v-75zM100 901v300h150h700h150v-300h-50q0 29 -8 48.5t-18 30t-33.5 15t-40 5.5t-50.5 1h-200v-650l100 -50v-100h-400v100l100 50v650h-200q-34 0 -50.5 -1t-39.5 -5.5t-33.5 -15t-18.5 -30t-8 -48.5h-50z" />
+<glyph unicode="&#xe052;" d="M0 50q0 -20 14.5 -35t35.5 -15h1100q21 0 35.5 15t14.5 35v100q0 21 -14.5 35.5t-35.5 14.5h-1100q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM0 350q0 -20 14.5 -35t35.5 -15h800q21 0 35.5 15t14.5 35v100q0 21 -14.5 35.5t-35.5 14.5h-800q-21 0 -35.5 -14.5t-14.5 -35.5 v-100zM0 650q0 -20 14.5 -35t35.5 -15h1000q21 0 35.5 15t14.5 35v100q0 21 -14.5 35.5t-35.5 14.5h-1000q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM0 950q0 -20 14.5 -35t35.5 -15h600q21 0 35.5 15t14.5 35v100q0 21 -14.5 35.5t-35.5 14.5h-600q-21 0 -35.5 -14.5 t-14.5 -35.5v-100z" />
+<glyph unicode="&#xe053;" d="M0 50q0 -20 14.5 -35t35.5 -15h1100q21 0 35.5 15t14.5 35v100q0 21 -14.5 35.5t-35.5 14.5h-1100q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM0 650q0 -20 14.5 -35t35.5 -15h1100q21 0 35.5 15t14.5 35v100q0 21 -14.5 35.5t-35.5 14.5h-1100q-21 0 -35.5 -14.5t-14.5 -35.5 v-100zM200 350q0 -20 14.5 -35t35.5 -15h700q21 0 35.5 15t14.5 35v100q0 21 -14.5 35.5t-35.5 14.5h-700q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM200 950q0 -20 14.5 -35t35.5 -15h700q21 0 35.5 15t14.5 35v100q0 21 -14.5 35.5t-35.5 14.5h-700q-21 0 -35.5 -14.5 t-14.5 -35.5v-100z" />
+<glyph unicode="&#xe054;" d="M0 50v100q0 21 14.5 35.5t35.5 14.5h1100q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-1100q-21 0 -35.5 15t-14.5 35zM100 650v100q0 21 14.5 35.5t35.5 14.5h1000q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-1000q-21 0 -35.5 15 t-14.5 35zM300 350v100q0 21 14.5 35.5t35.5 14.5h800q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-800q-21 0 -35.5 15t-14.5 35zM500 950v100q0 21 14.5 35.5t35.5 14.5h600q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-600 q-21 0 -35.5 15t-14.5 35z" />
+<glyph unicode="&#xe055;" d="M0 50v100q0 21 14.5 35.5t35.5 14.5h1100q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-1100q-21 0 -35.5 15t-14.5 35zM0 350v100q0 21 14.5 35.5t35.5 14.5h1100q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-1100q-21 0 -35.5 15 t-14.5 35zM0 650v100q0 21 14.5 35.5t35.5 14.5h1100q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-1100q-21 0 -35.5 15t-14.5 35zM0 950v100q0 21 14.5 35.5t35.5 14.5h1100q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-1100 q-21 0 -35.5 15t-14.5 35z" />
+<glyph unicode="&#xe056;" d="M0 50v100q0 21 14.5 35.5t35.5 14.5h100q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-100q-21 0 -35.5 15t-14.5 35zM0 350v100q0 21 14.5 35.5t35.5 14.5h100q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-100q-21 0 -35.5 15 t-14.5 35zM0 650v100q0 21 14.5 35.5t35.5 14.5h100q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-100q-21 0 -35.5 15t-14.5 35zM0 950v100q0 21 14.5 35.5t35.5 14.5h100q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-100q-21 0 -35.5 15 t-14.5 35zM300 50v100q0 21 14.5 35.5t35.5 14.5h800q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-800q-21 0 -35.5 15t-14.5 35zM300 350v100q0 21 14.5 35.5t35.5 14.5h800q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-800 q-21 0 -35.5 15t-14.5 35zM300 650v100q0 21 14.5 35.5t35.5 14.5h800q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15h-800q-21 0 -35.5 15t-14.5 35zM300 950v100q0 21 14.5 35.5t35.5 14.5h800q21 0 35.5 -14.5t14.5 -35.5v-100q0 -20 -14.5 -35t-35.5 -15 h-800q-21 0 -35.5 15t-14.5 35z" />
+<glyph unicode="&#xe057;" d="M-101 500v100h201v75l166 -125l-166 -125v75h-201zM300 0h100v1100h-100v-1100zM500 50q0 -20 14.5 -35t35.5 -15h600q20 0 35 15t15 35v100q0 21 -15 35.5t-35 14.5h-600q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM500 350q0 -20 14.5 -35t35.5 -15h300q20 0 35 15t15 35 v100q0 21 -15 35.5t-35 14.5h-300q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM500 650q0 -20 14.5 -35t35.5 -15h500q20 0 35 15t15 35v100q0 21 -15 35.5t-35 14.5h-500q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM500 950q0 -20 14.5 -35t35.5 -15h100q20 0 35 15t15 35v100 q0 21 -15 35.5t-35 14.5h-100q-21 0 -35.5 -14.5t-14.5 -35.5v-100z" />
+<glyph unicode="&#xe058;" d="M1 50q0 -20 14.5 -35t35.5 -15h600q20 0 35 15t15 35v100q0 21 -15 35.5t-35 14.5h-600q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM1 350q0 -20 14.5 -35t35.5 -15h300q20 0 35 15t15 35v100q0 21 -15 35.5t-35 14.5h-300q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM1 650 q0 -20 14.5 -35t35.5 -15h500q20 0 35 15t15 35v100q0 21 -15 35.5t-35 14.5h-500q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM1 950q0 -20 14.5 -35t35.5 -15h100q20 0 35 15t15 35v100q0 21 -15 35.5t-35 14.5h-100q-21 0 -35.5 -14.5t-14.5 -35.5v-100zM801 0v1100h100v-1100 h-100zM934 550l167 -125v75h200v100h-200v75z" />
+<glyph unicode="&#xe059;" d="M0 275v650q0 31 22 53t53 22h750q31 0 53 -22t22 -53v-650q0 -31 -22 -53t-53 -22h-750q-31 0 -53 22t-22 53zM900 600l300 300v-600z" />
+<glyph unicode="&#xe060;" d="M0 44v1012q0 18 13 31t31 13h1112q19 0 31.5 -13t12.5 -31v-1012q0 -18 -12.5 -31t-31.5 -13h-1112q-18 0 -31 13t-13 31zM100 263l247 182l298 -131l-74 156l293 318l236 -288v500h-1000v-737zM208 750q0 56 39 95t95 39t95 -39t39 -95t-39 -95t-95 -39t-95 39t-39 95z " />
+<glyph unicode="&#xe062;" d="M148 745q0 124 60.5 231.5t165 172t226.5 64.5q123 0 227 -63t164.5 -169.5t60.5 -229.5t-73 -272q-73 -114 -166.5 -237t-150.5 -189l-57 -66q-10 9 -27 26t-66.5 70.5t-96 109t-104 135.5t-100.5 155q-63 139 -63 262zM342 772q0 -107 75.5 -182.5t181.5 -75.5 q107 0 182.5 75.5t75.5 182.5t-75.5 182t-182.5 75t-182 -75.5t-75 -181.5z" />
+<glyph unicode="&#xe063;" d="M1 600q0 122 47.5 233t127.5 191t191 127.5t233 47.5t233 -47.5t191 -127.5t127.5 -191t47.5 -233t-47.5 -233t-127.5 -191t-191 -127.5t-233 -47.5t-233 47.5t-191 127.5t-127.5 191t-47.5 233zM173 600q0 -177 125.5 -302t301.5 -125v854q-176 0 -301.5 -125 t-125.5 -302z" />
+<glyph unicode="&#xe064;" d="M117 406q0 94 34 186t88.5 172.5t112 159t115 177t87.5 194.5q21 -71 57.5 -142.5t76 -130.5t83 -118.5t82 -117t70 -116t50 -125.5t18.5 -136q0 -89 -39 -165.5t-102 -126.5t-140 -79.5t-156 -33.5q-114 6 -211.5 53t-161.5 139t-64 210zM243 414q14 -82 59.5 -136 t136.5 -80l16 98q-7 6 -18 17t-34 48t-33 77q-15 73 -14 143.5t10 122.5l9 51q-92 -110 -119.5 -185t-12.5 -156z" />
+<glyph unicode="&#xe065;" d="M0 400v300q0 165 117.5 282.5t282.5 117.5q366 -6 397 -14l-186 -186h-311q-41 0 -70.5 -29.5t-29.5 -70.5v-500q0 -41 29.5 -70.5t70.5 -29.5h500q41 0 70.5 29.5t29.5 70.5v125l200 200v-225q0 -165 -117.5 -282.5t-282.5 -117.5h-300q-165 0 -282.5 117.5 t-117.5 282.5zM436 341l161 50l412 412l-114 113l-405 -405zM995 1015l113 -113l113 113l-21 85l-92 28z" />
+<glyph unicode="&#xe066;" d="M0 400v300q0 165 117.5 282.5t282.5 117.5h261l2 -80q-133 -32 -218 -120h-145q-41 0 -70.5 -29.5t-29.5 -70.5v-500q0 -41 29.5 -70.5t70.5 -29.5h500q41 0 70.5 29.5t29.5 70.5l200 153v-53q0 -165 -117.5 -282.5t-282.5 -117.5h-300q-165 0 -282.5 117.5t-117.5 282.5 zM423 524q30 38 81.5 64t103 35.5t99 14t77.5 3.5l29 -1v-209l360 324l-359 318v-216q-7 0 -19 -1t-48 -8t-69.5 -18.5t-76.5 -37t-76.5 -59t-62 -88t-39.5 -121.5z" />
+<glyph unicode="&#xe067;" d="M0 400v300q0 165 117.5 282.5t282.5 117.5h300q61 0 127 -23l-178 -177h-349q-41 0 -70.5 -29.5t-29.5 -70.5v-500q0 -41 29.5 -70.5t70.5 -29.5h500q41 0 70.5 29.5t29.5 70.5v69l200 200v-169q0 -165 -117.5 -282.5t-282.5 -117.5h-300q-165 0 -282.5 117.5 t-117.5 282.5zM342 632l283 -284l567 567l-137 137l-430 -431l-146 147z" />
+<glyph unicode="&#xe068;" d="M0 603l300 296v-198h200v200h-200l300 300l295 -300h-195v-200h200v198l300 -296l-300 -300v198h-200v-200h195l-295 -300l-300 300h200v200h-200v-198z" />
+<glyph unicode="&#xe069;" d="M200 50v1000q0 21 14.5 35.5t35.5 14.5h100q21 0 35.5 -14.5t14.5 -35.5v-437l500 487v-1100l-500 488v-438q0 -21 -14.5 -35.5t-35.5 -14.5h-100q-21 0 -35.5 14.5t-14.5 35.5z" />
+<glyph unicode="&#xe070;" d="M0 50v1000q0 21 14.5 35.5t35.5 14.5h100q21 0 35.5 -14.5t14.5 -35.5v-437l500 487v-487l500 487v-1100l-500 488v-488l-500 488v-438q0 -21 -14.5 -35.5t-35.5 -14.5h-100q-21 0 -35.5 14.5t-14.5 35.5z" />
+<glyph unicode="&#xe071;" d="M136 550l564 550v-487l500 487v-1100l-500 488v-488z" />
+<glyph unicode="&#xe072;" d="M200 0l900 550l-900 550v-1100z" />
+<glyph unicode="&#xe073;" d="M200 150q0 -21 14.5 -35.5t35.5 -14.5h200q21 0 35.5 14.5t14.5 35.5v800q0 21 -14.5 35.5t-35.5 14.5h-200q-21 0 -35.5 -14.5t-14.5 -35.5v-800zM600 150q0 -21 14.5 -35.5t35.5 -14.5h200q21 0 35.5 14.5t14.5 35.5v800q0 21 -14.5 35.5t-35.5 14.5h-200 q-21 0 -35.5 -14.5t-14.5 -35.5v-800z" />
+<glyph unicode="&#xe074;" d="M200 150q0 -20 14.5 -35t35.5 -15h800q21 0 35.5 15t14.5 35v800q0 21 -14.5 35.5t-35.5 14.5h-800q-21 0 -35.5 -14.5t-14.5 -35.5v-800z" />
+<glyph unicode="&#xe075;" d="M0 0v1100l500 -487v487l564 -550l-564 -550v488z" />
+<glyph unicode="&#xe076;" d="M0 0v1100l500 -487v487l500 -487v437q0 21 14.5 35.5t35.5 14.5h100q21 0 35.5 -14.5t14.5 -35.5v-1000q0 -21 -14.5 -35.5t-35.5 -14.5h-100q-21 0 -35.5 14.5t-14.5 35.5v438l-500 -488v488z" />
+<glyph unicode="&#xe077;" d="M300 0v1100l500 -487v437q0 21 14.5 35.5t35.5 14.5h100q21 0 35.5 -14.5t14.5 -35.5v-1000q0 -21 -14.5 -35.5t-35.5 -14.5h-100q-21 0 -35.5 14.5t-14.5 35.5v438z" />
+<glyph unicode="&#xe078;" d="M100 250v100q0 21 14.5 35.5t35.5 14.5h1000q21 0 35.5 -14.5t14.5 -35.5v-100q0 -21 -14.5 -35.5t-35.5 -14.5h-1000q-21 0 -35.5 14.5t-14.5 35.5zM100 500h1100l-550 564z" />
+<glyph unicode="&#xe079;" d="M185 599l592 -592l240 240l-353 353l353 353l-240 240z" />
+<glyph unicode="&#xe080;" d="M272 194l353 353l-353 353l241 240l572 -571l21 -22l-1 -1v-1l-592 -591z" />
+<glyph unicode="&#xe081;" d="M3 600q0 162 80 299.5t217.5 217.5t299.5 80t299.5 -80t217.5 -217.5t80 -299.5t-80 -299.5t-217.5 -217.5t-299.5 -80t-299.5 80t-217.5 217.5t-80 299.5zM300 500h200v-200h200v200h200v200h-200v200h-200v-200h-200v-200z" />
+<glyph unicode="&#xe082;" d="M3 600q0 162 80 299.5t217.5 217.5t299.5 80t299.5 -80t217.5 -217.5t80 -299.5t-80 -299.5t-217.5 -217.5t-299.5 -80t-299.5 80t-217.5 217.5t-80 299.5zM300 500h600v200h-600v-200z" />
+<glyph unicode="&#xe083;" d="M3 600q0 162 80 299.5t217.5 217.5t299.5 80t299.5 -80t217.5 -217.5t80 -299.5t-80 -299.5t-217.5 -217.5t-299.5 -80t-299.5 80t-217.5 217.5t-80 299.5zM246 459l213 -213l141 142l141 -142l213 213l-142 141l142 141l-213 212l-141 -141l-141 142l-212 -213l141 -141 z" />
+<glyph unicode="&#xe084;" d="M3 600q0 162 80 299.5t217.5 217.5t299.5 80t299.5 -80t217.5 -217.5t80 -299.5t-80 -299.5t-217.5 -217.5t-299.5 -80t-299.5 80t-217.5 217.5t-80 299.5zM270 551l276 -277l411 411l-175 174l-236 -236l-102 102z" />
+<glyph unicode="&#xe085;" d="M3 600q0 162 80 299.5t217.5 217.5t299.5 80t299.5 -80t217.5 -217.5t80 -299.5t-80 -299.5t-217.5 -217.5t-299.5 -80t-299.5 80t-217.5 217.5t-80 299.5zM364 700h143q4 0 11.5 -1t11 -1t6.5 3t3 9t1 11t3.5 8.5t3.5 6t5.5 4t6.5 2.5t9 1.5t9 0.5h11.5h12.5 q19 0 30 -10t11 -26q0 -22 -4 -28t-27 -22q-5 -1 -12.5 -3t-27 -13.5t-34 -27t-26.5 -46t-11 -68.5h200q5 3 14 8t31.5 25.5t39.5 45.5t31 69t14 94q0 51 -17.5 89t-42 58t-58.5 32t-58.5 15t-51.5 3q-50 0 -90.5 -12t-75 -38.5t-53.5 -74.5t-19 -114zM500 300h200v100h-200 v-100z" />
+<glyph unicode="&#xe086;" d="M3 600q0 162 80 299.5t217.5 217.5t299.5 80t299.5 -80t217.5 -217.5t80 -299.5t-80 -299.5t-217.5 -217.5t-299.5 -80t-299.5 80t-217.5 217.5t-80 299.5zM400 300h400v100h-100v300h-300v-100h100v-200h-100v-100zM500 800h200v100h-200v-100z" />
+<glyph unicode="&#xe087;" d="M0 500v200h195q31 125 98.5 199.5t206.5 100.5v200h200v-200q54 -20 113 -60t112.5 -105.5t71.5 -134.5h203v-200h-203q-25 -102 -116.5 -186t-180.5 -117v-197h-200v197q-140 27 -208 102.5t-98 200.5h-194zM290 500q24 -73 79.5 -127.5t130.5 -78.5v206h200v-206 q149 48 201 206h-201v200h200q-25 74 -75.5 127t-124.5 77v-204h-200v203q-75 -23 -130 -77t-79 -126h209v-200h-210z" />
+<glyph unicode="&#xe088;" d="M4 600q0 162 80 299t217 217t299 80t299 -80t217 -217t80 -299t-80 -299t-217 -217t-299 -80t-299 80t-217 217t-80 299zM186 600q0 -171 121.5 -292.5t292.5 -121.5t292.5 121.5t121.5 292.5t-121.5 292.5t-292.5 121.5t-292.5 -121.5t-121.5 -292.5zM356 465l135 135 l-135 135l109 109l135 -135l135 135l109 -109l-135 -135l135 -135l-109 -109l-135 135l-135 -135z" />
+<glyph unicode="&#xe089;" d="M4 600q0 162 80 299t217 217t299 80t299 -80t217 -217t80 -299t-80 -299t-217 -217t-299 -80t-299 80t-217 217t-80 299zM186 600q0 -171 121.5 -292.5t292.5 -121.5t292.5 121.5t121.5 292.5t-121.5 292.5t-292.5 121.5t-292.5 -121.5t-121.5 -292.5zM322 537l141 141 l87 -87l204 205l142 -142l-346 -345z" />
+<glyph unicode="&#xe090;" d="M4 600q0 162 80 299t217 217t299 80t299 -80t217 -217t80 -299t-80 -299t-217 -217t-299 -80t-299 80t-217 217t-80 299zM186 600q0 -115 62 -215l568 567q-100 62 -216 62q-171 0 -292.5 -121.5t-121.5 -292.5zM391 245q97 -59 209 -59q171 0 292.5 121.5t121.5 292.5 q0 112 -59 209z" />
+<glyph unicode="&#xe091;" d="M0 547l600 453v-300h600v-300h-600v-301z" />
+<glyph unicode="&#xe092;" d="M0 400v300h600v300l600 -453l-600 -448v301h-600z" />
+<glyph unicode="&#xe093;" d="M204 600l450 600l444 -600h-298v-600h-300v600h-296z" />
+<glyph unicode="&#xe094;" d="M104 600h296v600h300v-600h298l-449 -600z" />
+<glyph unicode="&#xe095;" d="M0 200q6 132 41 238.5t103.5 193t184 138t271.5 59.5v271l600 -453l-600 -448v301q-95 -2 -183 -20t-170 -52t-147 -92.5t-100 -135.5z" />
+<glyph unicode="&#xe096;" d="M0 0v400l129 -129l294 294l142 -142l-294 -294l129 -129h-400zM635 777l142 -142l294 294l129 -129v400h-400l129 -129z" />
+<glyph unicode="&#xe097;" d="M34 176l295 295l-129 129h400v-400l-129 130l-295 -295zM600 600v400l129 -129l295 295l142 -141l-295 -295l129 -130h-400z" />
+<glyph unicode="&#xe101;" d="M23 600q0 118 45.5 224.5t123 184t184 123t224.5 45.5t224.5 -45.5t184 -123t123 -184t45.5 -224.5t-45.5 -224.5t-123 -184t-184 -123t-224.5 -45.5t-224.5 45.5t-184 123t-123 184t-45.5 224.5zM456 851l58 -302q4 -20 21.5 -34.5t37.5 -14.5h54q20 0 37.5 14.5 t21.5 34.5l58 302q4 20 -8 34.5t-32 14.5h-207q-21 0 -33 -14.5t-8 -34.5zM500 300h200v100h-200v-100z" />
+<glyph unicode="&#xe102;" d="M0 800h100v-200h400v300h200v-300h400v200h100v100h-111q1 1 1 6.5t-1.5 15t-3.5 17.5l-34 172q-11 39 -41.5 63t-69.5 24q-32 0 -61 -17l-239 -144q-22 -13 -40 -35q-19 24 -40 36l-238 144q-33 18 -62 18q-39 0 -69.5 -23t-40.5 -61l-35 -177q-2 -8 -3 -18t-1 -15v-6 h-111v-100zM100 0h400v400h-400v-400zM200 900q-3 0 14 48t36 96l18 47l213 -191h-281zM700 0v400h400v-400h-400zM731 900l202 197q5 -12 12 -32.5t23 -64t25 -72t7 -28.5h-269z" />
+<glyph unicode="&#xe103;" d="M0 -22v143l216 193q-9 53 -13 83t-5.5 94t9 113t38.5 114t74 124q47 60 99.5 102.5t103 68t127.5 48t145.5 37.5t184.5 43.5t220 58.5q0 -189 -22 -343t-59 -258t-89 -181.5t-108.5 -120t-122 -68t-125.5 -30t-121.5 -1.5t-107.5 12.5t-87.5 17t-56.5 7.5l-99 -55z M238.5 300.5q19.5 -6.5 86.5 76.5q55 66 367 234q70 38 118.5 69.5t102 79t99 111.5t86.5 148q22 50 24 60t-6 19q-7 5 -17 5t-26.5 -14.5t-33.5 -39.5q-35 -51 -113.5 -108.5t-139.5 -89.5l-61 -32q-369 -197 -458 -401q-48 -111 -28.5 -117.5z" />
+<glyph unicode="&#xe104;" d="M111 408q0 -33 5 -63q9 -56 44 -119.5t105 -108.5q31 -21 64 -16t62 23.5t57 49.5t48 61.5t35 60.5q32 66 39 184.5t-13 157.5q79 -80 122 -164t26 -184q-5 -33 -20.5 -69.5t-37.5 -80.5q-10 -19 -14.5 -29t-12 -26t-9 -23.5t-3 -19t2.5 -15.5t11 -9.5t19.5 -5t30.5 2.5 t42 8q57 20 91 34t87.5 44.5t87 64t65.5 88.5t47 122q38 172 -44.5 341.5t-246.5 278.5q22 -44 43 -129q39 -159 -32 -154q-15 2 -33 9q-79 33 -120.5 100t-44 175.5t48.5 257.5q-13 -8 -34 -23.5t-72.5 -66.5t-88.5 -105.5t-60 -138t-8 -166.5q2 -12 8 -41.5t8 -43t6 -39.5 t3.5 -39.5t-1 -33.5t-6 -31.5t-13.5 -24t-21 -20.5t-31 -12q-38 -10 -67 13t-40.5 61.5t-15 81.5t10.5 75q-52 -46 -83.5 -101t-39 -107t-7.5 -85z" />
+<glyph unicode="&#xe105;" d="M-61 600l26 40q6 10 20 30t49 63.5t74.5 85.5t97 90t116.5 83.5t132.5 59t145.5 23.5t145.5 -23.5t132.5 -59t116.5 -83.5t97 -90t74.5 -85.5t49 -63.5t20 -30l26 -40l-26 -40q-6 -10 -20 -30t-49 -63.5t-74.5 -85.5t-97 -90t-116.5 -83.5t-132.5 -59t-145.5 -23.5 t-145.5 23.5t-132.5 59t-116.5 83.5t-97 90t-74.5 85.5t-49 63.5t-20 30zM120 600q7 -10 40.5 -58t56 -78.5t68 -77.5t87.5 -75t103 -49.5t125 -21.5t123.5 20t100.5 45.5t85.5 71.5t66.5 75.5t58 81.5t47 66q-1 1 -28.5 37.5t-42 55t-43.5 53t-57.5 63.5t-58.5 54 q49 -74 49 -163q0 -124 -88 -212t-212 -88t-212 88t-88 212q0 85 46 158q-102 -87 -226 -258zM377 656q49 -124 154 -191l105 105q-37 24 -75 72t-57 84l-20 36z" />
+<glyph unicode="&#xe106;" d="M-61 600l26 40q6 10 20 30t49 63.5t74.5 85.5t97 90t116.5 83.5t132.5 59t145.5 23.5q61 0 121 -17l37 142h148l-314 -1200h-148l37 143q-82 21 -165 71.5t-140 102t-109.5 112t-72 88.5t-29.5 43zM120 600q210 -282 393 -336l37 141q-107 18 -178.5 101.5t-71.5 193.5 q0 85 46 158q-102 -87 -226 -258zM377 656q49 -124 154 -191l47 47l23 87q-30 28 -59 69t-44 68l-14 26zM780 161l38 145q22 15 44.5 34t46 44t40.5 44t41 50.5t33.5 43.5t33 44t24.5 34q-97 127 -140 175l39 146q67 -54 131.5 -125.5t87.5 -103.5t36 -52l26 -40l-26 -40 q-7 -12 -25.5 -38t-63.5 -79.5t-95.5 -102.5t-124 -100t-146.5 -79z" />
+<glyph unicode="&#xe107;" d="M-97.5 34q13.5 -34 50.5 -34h1294q37 0 50.5 35.5t-7.5 67.5l-642 1056q-20 34 -48 36.5t-48 -29.5l-642 -1066q-21 -32 -7.5 -66zM155 200l445 723l445 -723h-345v100h-200v-100h-345zM500 600l100 -300l100 300v100h-200v-100z" />
+<glyph unicode="&#xe108;" d="M100 262v41q0 20 11 44.5t26 38.5l363 325v339q0 62 44 106t106 44t106 -44t44 -106v-339l363 -325q15 -14 26 -38.5t11 -44.5v-41q0 -20 -12 -26.5t-29 5.5l-359 249v-263q100 -91 100 -113v-64q0 -20 -13 -28.5t-32 0.5l-94 78h-222l-94 -78q-19 -9 -32 -0.5t-13 28.5 v64q0 22 100 113v263l-359 -249q-17 -12 -29 -5.5t-12 26.5z" />
+<glyph unicode="&#xe109;" d="M0 50q0 -20 14.5 -35t35.5 -15h1000q21 0 35.5 15t14.5 35v750h-1100v-750zM0 900h1100v150q0 21 -14.5 35.5t-35.5 14.5h-150v100h-100v-100h-500v100h-100v-100h-150q-21 0 -35.5 -14.5t-14.5 -35.5v-150zM100 100v100h100v-100h-100zM100 300v100h100v-100h-100z M100 500v100h100v-100h-100zM300 100v100h100v-100h-100zM300 300v100h100v-100h-100zM300 500v100h100v-100h-100zM500 100v100h100v-100h-100zM500 300v100h100v-100h-100zM500 500v100h100v-100h-100zM700 100v100h100v-100h-100zM700 300v100h100v-100h-100zM700 500 v100h100v-100h-100zM900 100v100h100v-100h-100zM900 300v100h100v-100h-100zM900 500v100h100v-100h-100z" />
+<glyph unicode="&#xe110;" d="M0 200v200h259l600 600h241v198l300 -295l-300 -300v197h-159l-600 -600h-341zM0 800h259l122 -122l141 142l-181 180h-341v-200zM678 381l141 142l122 -123h159v198l300 -295l-300 -300v197h-241z" />
+<glyph unicode="&#xe111;" d="M0 400v600q0 41 29.5 70.5t70.5 29.5h1000q41 0 70.5 -29.5t29.5 -70.5v-600q0 -41 -29.5 -70.5t-70.5 -29.5h-596l-304 -300v300h-100q-41 0 -70.5 29.5t-29.5 70.5z" />
+<glyph unicode="&#xe112;" d="M100 600v200h300v-250q0 -113 6 -145q17 -92 102 -117q39 -11 92 -11q37 0 66.5 5.5t50 15.5t36 24t24 31.5t14 37.5t7 42t2.5 45t0 47v25v250h300v-200q0 -42 -3 -83t-15 -104t-31.5 -116t-58 -109.5t-89 -96.5t-129 -65.5t-174.5 -25.5t-174.5 25.5t-129 65.5t-89 96.5 t-58 109.5t-31.5 116t-15 104t-3 83zM100 900v300h300v-300h-300zM800 900v300h300v-300h-300z" />
+<glyph unicode="&#xe113;" d="M-30 411l227 -227l352 353l353 -353l226 227l-578 579z" />
+<glyph unicode="&#xe114;" d="M70 797l580 -579l578 579l-226 227l-353 -353l-352 353z" />
+<glyph unicode="&#xe115;" d="M-198 700l299 283l300 -283h-203v-400h385l215 -200h-800v600h-196zM402 1000l215 -200h381v-400h-198l299 -283l299 283h-200v600h-796z" />
+<glyph unicode="&#xe116;" d="M18 939q-5 24 10 42q14 19 39 19h896l38 162q5 17 18.5 27.5t30.5 10.5h94q20 0 35 -14.5t15 -35.5t-15 -35.5t-35 -14.5h-54l-201 -961q-2 -4 -6 -10.5t-19 -17.5t-33 -11h-31v-50q0 -20 -14.5 -35t-35.5 -15t-35.5 15t-14.5 35v50h-300v-50q0 -20 -14.5 -35t-35.5 -15 t-35.5 15t-14.5 35v50h-50q-21 0 -35.5 15t-14.5 35q0 21 14.5 35.5t35.5 14.5h535l48 200h-633q-32 0 -54.5 21t-27.5 43z" />
+<glyph unicode="&#xe117;" d="M0 0v800h1200v-800h-1200zM0 900v100h200q0 41 29.5 70.5t70.5 29.5h300q41 0 70.5 -29.5t29.5 -70.5h500v-100h-1200z" />
+<glyph unicode="&#xe118;" d="M1 0l300 700h1200l-300 -700h-1200zM1 400v600h200q0 41 29.5 70.5t70.5 29.5h300q41 0 70.5 -29.5t29.5 -70.5h500v-200h-1000z" />
+<glyph unicode="&#xe119;" d="M302 300h198v600h-198l298 300l298 -300h-198v-600h198l-298 -300z" />
+<glyph unicode="&#xe120;" d="M0 600l300 298v-198h600v198l300 -298l-300 -297v197h-600v-197z" />
+<glyph unicode="&#xe121;" d="M0 100v100q0 41 29.5 70.5t70.5 29.5h1000q41 0 70.5 -29.5t29.5 -70.5v-100q0 -41 -29.5 -70.5t-70.5 -29.5h-1000q-41 0 -70.5 29.5t-29.5 70.5zM31 400l172 739q5 22 23 41.5t38 19.5h672q19 0 37.5 -22.5t23.5 -45.5l172 -732h-1138zM800 100h100v100h-100v-100z M1000 100h100v100h-100v-100z" />
+<glyph unicode="&#xe122;" d="M-101 600v50q0 24 25 49t50 38l25 13v-250l-11 5.5t-24 14t-30 21.5t-24 27.5t-11 31.5zM100 500v250v8v8v7t0.5 7t1.5 5.5t2 5t3 4t4.5 3.5t6 1.5t7.5 0.5h200l675 250v-850l-675 200h-38l47 -276q2 -12 -3 -17.5t-11 -6t-21 -0.5h-8h-83q-20 0 -34.5 14t-18.5 35 q-55 337 -55 351zM1100 200v850q0 21 14.5 35.5t35.5 14.5q20 0 35 -14.5t15 -35.5v-850q0 -20 -15 -35t-35 -15q-21 0 -35.5 15t-14.5 35z" />
+<glyph unicode="&#xe123;" d="M74 350q0 21 13.5 35.5t33.5 14.5h18l117 173l63 327q15 77 76 140t144 83l-18 32q-6 19 3 32t29 13h94q20 0 29 -10.5t3 -29.5q-18 -36 -18 -37q83 -19 144 -82.5t76 -140.5l63 -327l118 -173h17q20 0 33.5 -14.5t13.5 -35.5q0 -20 -13 -40t-31 -27q-8 -3 -23 -8.5 t-65 -20t-103 -25t-132.5 -19.5t-158.5 -9q-125 0 -245.5 20.5t-178.5 40.5l-58 20q-18 7 -31 27.5t-13 40.5zM497 110q12 -49 40 -79.5t63 -30.5t63 30.5t39 79.5q-48 -6 -102 -6t-103 6z" />
+<glyph unicode="&#xe124;" d="M21 445l233 -45l-78 -224l224 78l45 -233l155 179l155 -179l45 233l224 -78l-78 224l234 45l-180 155l180 156l-234 44l78 225l-224 -78l-45 233l-155 -180l-155 180l-45 -233l-224 78l78 -225l-233 -44l179 -156z" />
+<glyph unicode="&#xe125;" d="M0 200h200v600h-200v-600zM300 275q0 -75 100 -75h61q124 -100 139 -100h250q46 0 83 57l238 344q29 31 29 74v100q0 44 -30.5 84.5t-69.5 40.5h-328q28 118 28 125v150q0 44 -30.5 84.5t-69.5 40.5h-50q-27 0 -51 -20t-38 -48l-96 -198l-145 -196q-20 -26 -20 -63v-400z M400 300v375l150 213l100 212h50v-175l-50 -225h450v-125l-250 -375h-214l-136 100h-100z" />
+<glyph unicode="&#xe126;" d="M0 400v600h200v-600h-200zM300 525v400q0 75 100 75h61q124 100 139 100h250q46 0 83 -57l238 -344q29 -31 29 -74v-100q0 -44 -30.5 -84.5t-69.5 -40.5h-328q28 -118 28 -125v-150q0 -44 -30.5 -84.5t-69.5 -40.5h-50q-27 0 -51 20t-38 48l-96 198l-145 196 q-20 26 -20 63zM400 525l150 -212l100 -213h50v175l-50 225h450v125l-250 375h-214l-136 -100h-100v-375z" />
+<glyph unicode="&#xe127;" d="M8 200v600h200v-600h-200zM308 275v525q0 17 14 35.5t28 28.5l14 9l362 230q14 6 25 6q17 0 29 -12l109 -112q14 -14 14 -34q0 -18 -11 -32l-85 -121h302q85 0 138.5 -38t53.5 -110t-54.5 -111t-138.5 -39h-107l-130 -339q-7 -22 -20.5 -41.5t-28.5 -19.5h-341 q-7 0 -90 81t-83 94zM408 289l100 -89h293l131 339q6 21 19.5 41t28.5 20h203q16 0 25 15t9 36q0 20 -9 34.5t-25 14.5h-457h-6.5h-7.5t-6.5 0.5t-6 1t-5 1.5t-5.5 2.5t-4 4t-4 5.5q-5 12 -5 20q0 14 10 27l147 183l-86 83l-339 -236v-503z" />
+<glyph unicode="&#xe128;" d="M-101 651q0 72 54 110t139 38l302 -1l-85 121q-11 16 -11 32q0 21 14 34l109 113q13 12 29 12q11 0 25 -6l365 -230q7 -4 17 -10.5t26.5 -26t16.5 -36.5v-526q0 -13 -86 -93.5t-94 -80.5h-341q-16 0 -29.5 20t-19.5 41l-130 339h-107q-84 0 -139 39t-55 111zM-1 601h222 q15 0 28.5 -20.5t19.5 -40.5l131 -339h293l107 89v502l-343 237l-87 -83l145 -184q10 -11 10 -26q0 -11 -5 -20q-1 -3 -3.5 -5.5l-4 -4t-5 -2.5t-5.5 -1.5t-6.5 -1t-6.5 -0.5h-7.5h-6.5h-476v-100zM1000 201v600h200v-600h-200z" />
+<glyph unicode="&#xe129;" d="M97 719l230 -363q4 -6 10.5 -15.5t26 -25t36.5 -15.5h525q13 0 94 83t81 90v342q0 15 -20 28.5t-41 19.5l-339 131v106q0 84 -39 139t-111 55t-110 -53.5t-38 -138.5v-302l-121 84q-15 12 -33.5 11.5t-32.5 -13.5l-112 -110q-22 -22 -6 -53zM172 739l83 86l183 -146 q22 -18 47 -5q3 1 5.5 3.5l4 4t2.5 5t1.5 5.5t1 6.5t0.5 6.5v7.5v6.5v456q0 22 25 31t50 -0.5t25 -30.5v-202q0 -16 20 -29.5t41 -19.5l339 -130v-294l-89 -100h-503zM400 0v200h600v-200h-600z" />
+<glyph unicode="&#xe130;" d="M2 585q-16 -31 6 -53l112 -110q13 -13 32 -13.5t34 10.5l121 85q0 -51 -0.5 -153.5t-0.5 -148.5q0 -84 38.5 -138t110.5 -54t111 55t39 139v106l339 131q20 6 40.5 19.5t20.5 28.5v342q0 7 -81 90t-94 83h-525q-17 0 -35.5 -14t-28.5 -28l-10 -15zM77 565l236 339h503 l89 -100v-294l-340 -130q-20 -6 -40 -20t-20 -29v-202q0 -22 -25 -31t-50 0t-25 31v456v14.5t-1.5 11.5t-5 12t-9.5 7q-24 13 -46 -5l-184 -146zM305 1104v200h600v-200h-600z" />
+<glyph unicode="&#xe131;" d="M5 597q0 122 47.5 232.5t127.5 190.5t190.5 127.5t232.5 47.5q162 0 299.5 -80t217.5 -218t80 -300t-80 -299.5t-217.5 -217.5t-299.5 -80t-300 80t-218 217.5t-80 299.5zM298 701l2 -201h300l-2 -194l402 294l-402 298v-197h-300z" />
+<glyph unicode="&#xe132;" d="M0 597q0 122 47.5 232.5t127.5 190.5t190.5 127.5t231.5 47.5q122 0 232.5 -47.5t190.5 -127.5t127.5 -190.5t47.5 -232.5q0 -162 -80 -299.5t-218 -217.5t-300 -80t-299.5 80t-217.5 217.5t-80 299.5zM200 600l402 -294l-2 194h300l2 201h-300v197z" />
+<glyph unicode="&#xe133;" d="M5 597q0 122 47.5 232.5t127.5 190.5t190.5 127.5t232.5 47.5q162 0 299.5 -80t217.5 -218t80 -300t-80 -299.5t-217.5 -217.5t-299.5 -80t-300 80t-218 217.5t-80 299.5zM300 600h200v-300h200v300h200l-300 400z" />
+<glyph unicode="&#xe134;" d="M5 597q0 122 47.5 232.5t127.5 190.5t190.5 127.5t232.5 47.5q162 0 299.5 -80t217.5 -218t80 -300t-80 -299.5t-217.5 -217.5t-299.5 -80t-300 80t-218 217.5t-80 299.5zM300 600l300 -400l300 400h-200v300h-200v-300h-200z" />
+<glyph unicode="&#xe135;" d="M5 597q0 122 47.5 232.5t127.5 190.5t190.5 127.5t232.5 47.5q121 0 231.5 -47.5t190.5 -127.5t127.5 -190.5t47.5 -232.5q0 -162 -80 -299.5t-217.5 -217.5t-299.5 -80t-300 80t-218 217.5t-80 299.5zM254 780q-8 -33 5.5 -92.5t7.5 -87.5q0 -9 17 -44t16 -60 q12 0 23 -5.5t23 -15t20 -13.5q24 -12 108 -42q22 -8 53 -31.5t59.5 -38.5t57.5 -11q8 -18 -15 -55t-20 -57q42 -71 87 -80q0 -6 -3 -15.5t-3.5 -14.5t4.5 -17q104 -3 221 112q30 29 47 47t34.5 49t20.5 62q-14 9 -37 9.5t-36 7.5q-14 7 -49 15t-52 19q-9 0 -39.5 -0.5 t-46.5 -1.5t-39 -6.5t-39 -16.5q-50 -35 -66 -12q-4 2 -3.5 25.5t0.5 25.5q-6 13 -26.5 17t-24.5 7q2 22 -2 41t-16.5 28t-38.5 -20q-23 -25 -42 4q-19 28 -8 58q6 16 22 22q6 -1 26 -1.5t33.5 -4t19.5 -13.5q12 -19 32 -37.5t34 -27.5l14 -8q0 3 9.5 39.5t5.5 57.5 q-4 23 14.5 44.5t22.5 31.5q5 14 10 35t8.5 31t15.5 22.5t34 21.5q-6 18 10 37q8 0 23.5 -1.5t24.5 -1.5t20.5 4.5t20.5 15.5q-10 23 -30.5 42.5t-38 30t-49 26.5t-43.5 23q11 39 2 44q31 -13 58 -14.5t39 3.5l11 4q7 36 -16.5 53.5t-64.5 28.5t-56 23q-19 -3 -37 0 q-15 -12 -36.5 -21t-34.5 -12t-44 -8t-39 -6q-15 -3 -45.5 0.5t-45.5 -2.5q-21 -7 -52 -26.5t-34 -34.5q-3 -11 6.5 -22.5t8.5 -18.5q-3 -34 -27.5 -90.5t-29.5 -79.5zM518 916q3 12 16 30t16 25q10 -10 18.5 -10t14 6t14.5 14.5t16 12.5q0 -24 17 -66.5t17 -43.5 q-9 2 -31 5t-36 5t-32 8t-30 14zM692 1003h1h-1z" />
+<glyph unicode="&#xe136;" d="M0 164.5q0 21.5 15 37.5l600 599q-33 101 6 201.5t135 154.5q164 92 306 -9l-259 -138l145 -232l251 126q13 -175 -151 -267q-123 -70 -253 -23l-596 -596q-15 -16 -36.5 -16t-36.5 16l-111 110q-15 15 -15 36.5z" />
+<glyph unicode="&#xe137;" horiz-adv-x="1220" d="M0 196v100q0 41 29.5 70.5t70.5 29.5h1000q41 0 70.5 -29.5t29.5 -70.5v-100q0 -41 -29.5 -70.5t-70.5 -29.5h-1000q-41 0 -70.5 29.5t-29.5 70.5zM0 596v100q0 41 29.5 70.5t70.5 29.5h1000q41 0 70.5 -29.5t29.5 -70.5v-100q0 -41 -29.5 -70.5t-70.5 -29.5h-1000 q-41 0 -70.5 29.5t-29.5 70.5zM0 996v100q0 41 29.5 70.5t70.5 29.5h1000q41 0 70.5 -29.5t29.5 -70.5v-100q0 -41 -29.5 -70.5t-70.5 -29.5h-1000q-41 0 -70.5 29.5t-29.5 70.5zM600 596h500v100h-500v-100zM800 196h300v100h-300v-100zM900 996h200v100h-200v-100z" />
+<glyph unicode="&#xe138;" d="M100 1100v100h1000v-100h-1000zM150 1000h900l-350 -500v-300l-200 -200v500z" />
+<glyph unicode="&#xe139;" d="M0 200v200h1200v-200q0 -41 -29.5 -70.5t-70.5 -29.5h-1000q-41 0 -70.5 29.5t-29.5 70.5zM0 500v400q0 41 29.5 70.5t70.5 29.5h300v100q0 41 29.5 70.5t70.5 29.5h200q41 0 70.5 -29.5t29.5 -70.5v-100h300q41 0 70.5 -29.5t29.5 -70.5v-400h-500v100h-200v-100h-500z M500 1000h200v100h-200v-100z" />
+<glyph unicode="&#xe140;" d="M0 0v400l129 -129l200 200l142 -142l-200 -200l129 -129h-400zM0 800l129 129l200 -200l142 142l-200 200l129 129h-400v-400zM729 329l142 142l200 -200l129 129v-400h-400l129 129zM729 871l200 200l-129 129h400v-400l-129 129l-200 -200z" />
+<glyph unicode="&#xe141;" d="M0 596q0 162 80 299t217 217t299 80t299 -80t217 -217t80 -299t-80 -299t-217 -217t-299 -80t-299 80t-217 217t-80 299zM182 596q0 -172 121.5 -293t292.5 -121t292.5 121t121.5 293q0 171 -121.5 292.5t-292.5 121.5t-292.5 -121.5t-121.5 -292.5zM291 655 q0 23 15.5 38.5t38.5 15.5t39 -16t16 -38q0 -23 -16 -39t-39 -16q-22 0 -38 16t-16 39zM400 850q0 22 16 38.5t39 16.5q22 0 38 -16t16 -39t-16 -39t-38 -16q-23 0 -39 16.5t-16 38.5zM514 609q0 32 20.5 56.5t51.5 29.5l122 126l1 1q-9 14 -9 28q0 22 16 38.5t39 16.5 q22 0 38 -16t16 -39t-16 -39t-38 -16q-14 0 -29 10l-55 -145q17 -22 17 -51q0 -36 -25.5 -61.5t-61.5 -25.5t-61.5 25.5t-25.5 61.5zM800 655q0 22 16 38t39 16t38.5 -15.5t15.5 -38.5t-16 -39t-38 -16q-23 0 -39 16t-16 39z" />
+<glyph unicode="&#xe142;" d="M-40 375q-13 -95 35 -173q35 -57 94 -89t129 -32q63 0 119 28q33 16 65 40.5t52.5 45.5t59.5 64q40 44 57 61l394 394q35 35 47 84t-3 96q-27 87 -117 104q-20 2 -29 2q-46 0 -78.5 -16.5t-67.5 -51.5l-389 -396l-7 -7l69 -67l377 373q20 22 39 38q23 23 50 23 q38 0 53 -36q16 -39 -20 -75l-547 -547q-52 -52 -125 -52q-55 0 -100 33t-54 96q-5 35 2.5 66t31.5 63t42 50t56 54q24 21 44 41l348 348q52 52 82.5 79.5t84 54t107.5 26.5q25 0 48 -4q95 -17 154 -94.5t51 -175.5q-7 -101 -98 -192l-252 -249l-253 -256l7 -7l69 -60 l517 511q67 67 95 157t11 183q-16 87 -67 154t-130 103q-69 33 -152 33q-107 0 -197 -55q-40 -24 -111 -95l-512 -512q-68 -68 -81 -163z" />
+<glyph unicode="&#xe143;" d="M80 784q0 131 98.5 229.5t230.5 98.5q143 0 241 -129q103 129 246 129q129 0 226 -98.5t97 -229.5q0 -46 -17.5 -91t-61 -99t-77 -89.5t-104.5 -105.5q-197 -191 -293 -322l-17 -23l-16 23q-43 58 -100 122.5t-92 99.5t-101 100q-71 70 -104.5 105.5t-77 89.5t-61 99 t-17.5 91zM250 784q0 -27 30.5 -70t61.5 -75.5t95 -94.5l22 -22q93 -90 190 -201q82 92 195 203l12 12q64 62 97.5 97t64.5 79t31 72q0 71 -48 119.5t-105 48.5q-74 0 -132 -83l-118 -171l-114 174q-51 80 -123 80q-60 0 -109.5 -49.5t-49.5 -118.5z" />
+<glyph unicode="&#xe144;" d="M57 353q0 -95 66 -159l141 -142q68 -66 159 -66q93 0 159 66l283 283q66 66 66 159t-66 159l-141 141q-8 9 -19 17l-105 -105l212 -212l-389 -389l-247 248l95 95l-18 18q-46 45 -75 101l-55 -55q-66 -66 -66 -159zM269 706q0 -93 66 -159l141 -141q7 -7 19 -17l105 105 l-212 212l389 389l247 -247l-95 -96l18 -17q47 -49 77 -100l29 29q35 35 62.5 88t27.5 96q0 93 -66 159l-141 141q-66 66 -159 66q-95 0 -159 -66l-283 -283q-66 -64 -66 -159z" />
+<glyph unicode="&#xe145;" d="M200 100v953q0 21 30 46t81 48t129 38t163 15t162 -15t127 -38t79 -48t29 -46v-953q0 -41 -29.5 -70.5t-70.5 -29.5h-600q-41 0 -70.5 29.5t-29.5 70.5zM300 300h600v700h-600v-700zM496 150q0 -43 30.5 -73.5t73.5 -30.5t73.5 30.5t30.5 73.5t-30.5 73.5t-73.5 30.5 t-73.5 -30.5t-30.5 -73.5z" />
+<glyph unicode="&#xe146;" d="M0 0l303 380l207 208l-210 212h300l267 279l-35 36q-15 14 -15 35t15 35q14 15 35 15t35 -15l283 -282q15 -15 15 -36t-15 -35q-14 -15 -35 -15t-35 15l-36 35l-279 -267v-300l-212 210l-208 -207z" />
+<glyph unicode="&#xe148;" d="M295 433h139q5 -77 48.5 -126.5t117.5 -64.5v335q-6 1 -15.5 4t-11.5 3q-46 14 -79 26.5t-72 36t-62.5 52t-40 72.5t-16.5 99q0 92 44 159.5t109 101t144 40.5v78h100v-79q38 -4 72.5 -13.5t75.5 -31.5t71 -53.5t51.5 -84t24.5 -118.5h-159q-8 72 -35 109.5t-101 50.5 v-307l64 -14q34 -7 64 -16.5t70 -31.5t67.5 -52t47.5 -80.5t20 -112.5q0 -139 -89 -224t-244 -96v-77h-100v78q-152 17 -237 104q-40 40 -52.5 93.5t-15.5 139.5zM466 889q0 -29 8 -51t16.5 -34t29.5 -22.5t31 -13.5t38 -10q7 -2 11 -3v274q-61 -8 -97.5 -37.5t-36.5 -102.5 zM700 237q170 18 170 151q0 64 -44 99.5t-126 60.5v-311z" />
+<glyph unicode="&#xe149;" d="M100 600v100h166q-24 49 -44 104q-10 26 -14.5 55.5t-3 72.5t25 90t68.5 87q97 88 263 88q129 0 230 -89t101 -208h-153q0 52 -34 89.5t-74 51.5t-76 14q-37 0 -79 -14.5t-62 -35.5q-41 -44 -41 -101q0 -28 16.5 -69.5t28 -62.5t41.5 -72h241v-100h-197q8 -50 -2.5 -115 t-31.5 -94q-41 -59 -99 -113q35 11 84 18t70 7q33 1 103 -16t103 -17q76 0 136 30l50 -147q-41 -25 -80.5 -36.5t-59 -13t-61.5 -1.5q-23 0 -128 33t-155 29q-39 -4 -82 -17t-66 -25l-24 -11l-55 145l16.5 11t15.5 10t13.5 9.5t14.5 12t14.5 14t17.5 18.5q48 55 54 126.5 t-30 142.5h-221z" />
+<glyph unicode="&#xe150;" d="M2 300l298 -300l298 300h-198v900h-200v-900h-198zM602 900l298 300l298 -300h-198v-900h-200v900h-198z" />
+<glyph unicode="&#xe151;" d="M2 300h198v900h200v-900h198l-298 -300zM700 0v200h100v-100h200v-100h-300zM700 400v100h300v-200h-99v-100h-100v100h99v100h-200zM700 700v500h300v-500h-100v100h-100v-100h-100zM801 900h100v200h-100v-200z" />
+<glyph unicode="&#xe152;" d="M2 300h198v900h200v-900h198l-298 -300zM700 0v500h300v-500h-100v100h-100v-100h-100zM700 700v200h100v-100h200v-100h-300zM700 1100v100h300v-200h-99v-100h-100v100h99v100h-200zM801 200h100v200h-100v-200z" />
+<glyph unicode="&#xe153;" d="M2 300l298 -300l298 300h-198v900h-200v-900h-198zM800 100v400h300v-500h-100v100h-200zM800 1100v100h200v-500h-100v400h-100zM901 200h100v200h-100v-200z" />
+<glyph unicode="&#xe154;" d="M2 300l298 -300l298 300h-198v900h-200v-900h-198zM800 400v100h200v-500h-100v400h-100zM800 800v400h300v-500h-100v100h-200zM901 900h100v200h-100v-200z" />
+<glyph unicode="&#xe155;" d="M2 300l298 -300l298 300h-198v900h-200v-900h-198zM700 100v200h500v-200h-500zM700 400v200h400v-200h-400zM700 700v200h300v-200h-300zM700 1000v200h200v-200h-200z" />
+<glyph unicode="&#xe156;" d="M2 300l298 -300l298 300h-198v900h-200v-900h-198zM700 100v200h200v-200h-200zM700 400v200h300v-200h-300zM700 700v200h400v-200h-400zM700 1000v200h500v-200h-500z" />
+<glyph unicode="&#xe157;" d="M0 400v300q0 165 117.5 282.5t282.5 117.5h300q162 0 281 -118.5t119 -281.5v-300q0 -165 -118.5 -282.5t-281.5 -117.5h-300q-165 0 -282.5 117.5t-117.5 282.5zM200 300q0 -41 29.5 -70.5t70.5 -29.5h500q41 0 70.5 29.5t29.5 70.5v500q0 41 -29.5 70.5t-70.5 29.5 h-500q-41 0 -70.5 -29.5t-29.5 -70.5v-500z" />
+<glyph unicode="&#xe158;" d="M0 400v300q0 163 119 281.5t281 118.5h300q165 0 282.5 -117.5t117.5 -282.5v-300q0 -165 -117.5 -282.5t-282.5 -117.5h-300q-163 0 -281.5 117.5t-118.5 282.5zM200 300q0 -41 29.5 -70.5t70.5 -29.5h500q41 0 70.5 29.5t29.5 70.5v500q0 41 -29.5 70.5t-70.5 29.5 h-500q-41 0 -70.5 -29.5t-29.5 -70.5v-500zM400 300l333 250l-333 250v-500z" />
+<glyph unicode="&#xe159;" d="M0 400v300q0 163 117.5 281.5t282.5 118.5h300q163 0 281.5 -119t118.5 -281v-300q0 -165 -117.5 -282.5t-282.5 -117.5h-300q-165 0 -282.5 117.5t-117.5 282.5zM200 300q0 -41 29.5 -70.5t70.5 -29.5h500q41 0 70.5 29.5t29.5 70.5v500q0 41 -29.5 70.5t-70.5 29.5 h-500q-41 0 -70.5 -29.5t-29.5 -70.5v-500zM300 700l250 -333l250 333h-500z" />
+<glyph unicode="&#xe160;" d="M0 400v300q0 165 117.5 282.5t282.5 117.5h300q165 0 282.5 -117.5t117.5 -282.5v-300q0 -162 -118.5 -281t-281.5 -119h-300q-165 0 -282.5 118.5t-117.5 281.5zM200 300q0 -41 29.5 -70.5t70.5 -29.5h500q41 0 70.5 29.5t29.5 70.5v500q0 41 -29.5 70.5t-70.5 29.5 h-500q-41 0 -70.5 -29.5t-29.5 -70.5v-500zM300 400h500l-250 333z" />
+<glyph unicode="&#xe161;" d="M0 400v300h300v200l400 -350l-400 -350v200h-300zM500 0v200h500q41 0 70.5 29.5t29.5 70.5v500q0 41 -29.5 70.5t-70.5 29.5h-500v200h400q165 0 282.5 -117.5t117.5 -282.5v-300q0 -165 -117.5 -282.5t-282.5 -117.5h-400z" />
+<glyph unicode="&#xe162;" d="M217 519q8 -19 31 -19h302q-155 -438 -160 -458q-5 -21 4 -32l9 -8h9q14 0 26 15q11 13 274.5 321.5t264.5 308.5q14 19 5 36q-8 17 -31 17l-301 -1q1 4 78 219.5t79 227.5q2 15 -5 27l-9 9h-9q-15 0 -25 -16q-4 -6 -98 -111.5t-228.5 -257t-209.5 -237.5q-16 -19 -6 -41 z" />
+<glyph unicode="&#xe163;" d="M0 400q0 -165 117.5 -282.5t282.5 -117.5h300q47 0 100 15v185h-500q-41 0 -70.5 29.5t-29.5 70.5v500q0 41 29.5 70.5t70.5 29.5h500v185q-14 4 -114 7.5t-193 5.5l-93 2q-165 0 -282.5 -117.5t-117.5 -282.5v-300zM600 400v300h300v200l400 -350l-400 -350v200h-300z " />
+<glyph unicode="&#xe164;" d="M0 400q0 -165 117.5 -282.5t282.5 -117.5h300q163 0 281.5 117.5t118.5 282.5v98l-78 73l-122 -123v-148q0 -41 -29.5 -70.5t-70.5 -29.5h-500q-41 0 -70.5 29.5t-29.5 70.5v500q0 41 29.5 70.5t70.5 29.5h156l118 122l-74 78h-100q-165 0 -282.5 -117.5t-117.5 -282.5 v-300zM496 709l353 342l-149 149h500v-500l-149 149l-342 -353z" />
+<glyph unicode="&#xe165;" d="M4 600q0 162 80 299t217 217t299 80t299 -80t217 -217t80 -299t-80 -299t-217 -217t-299 -80t-299 80t-217 217t-80 299zM186 600q0 -171 121.5 -292.5t292.5 -121.5t292.5 121.5t121.5 292.5t-121.5 292.5t-292.5 121.5t-292.5 -121.5t-121.5 -292.5zM406 600 q0 80 57 137t137 57t137 -57t57 -137t-57 -137t-137 -57t-137 57t-57 137z" />
+<glyph unicode="&#xe166;" d="M0 0v275q0 11 7 18t18 7h1048q11 0 19 -7.5t8 -17.5v-275h-1100zM100 800l445 -500l450 500h-295v400h-300v-400h-300zM900 150h100v50h-100v-50z" />
+<glyph unicode="&#xe167;" d="M0 0v275q0 11 7 18t18 7h1048q11 0 19 -7.5t8 -17.5v-275h-1100zM100 700h300v-300h300v300h295l-445 500zM900 150h100v50h-100v-50z" />
+<glyph unicode="&#xe168;" d="M0 0v275q0 11 7 18t18 7h1048q11 0 19 -7.5t8 -17.5v-275h-1100zM100 705l305 -305l596 596l-154 155l-442 -442l-150 151zM900 150h100v50h-100v-50z" />
+<glyph unicode="&#xe169;" d="M0 0v275q0 11 7 18t18 7h1048q11 0 19 -7.5t8 -17.5v-275h-1100zM100 988l97 -98l212 213l-97 97zM200 400l697 1l3 699l-250 -239l-149 149l-212 -212l149 -149zM900 150h100v50h-100v-50z" />
+<glyph unicode="&#xe170;" d="M0 0v275q0 11 7 18t18 7h1048q11 0 19 -7.5t8 -17.5v-275h-1100zM200 612l212 -212l98 97l-213 212zM300 1200l239 -250l-149 -149l212 -212l149 148l249 -237l-1 697zM900 150h100v50h-100v-50z" />
+<glyph unicode="&#xe171;" d="M23 415l1177 784v-1079l-475 272l-310 -393v416h-392zM494 210l672 938l-672 -712v-226z" />
+<glyph unicode="&#xe172;" d="M0 150v1000q0 20 14.5 35t35.5 15h250v-300h500v300h100l200 -200v-850q0 -21 -15 -35.5t-35 -14.5h-150v400h-700v-400h-150q-21 0 -35.5 14.5t-14.5 35.5zM600 1000h100v200h-100v-200z" />
+<glyph unicode="&#xe173;" d="M0 150v1000q0 20 14.5 35t35.5 15h250v-300h500v300h100l200 -200v-218l-276 -275l-120 120l-126 -127h-378v-400h-150q-21 0 -35.5 14.5t-14.5 35.5zM581 306l123 123l120 -120l353 352l123 -123l-475 -476zM600 1000h100v200h-100v-200z" />
+<glyph unicode="&#xe174;" d="M0 150v1000q0 20 14.5 35t35.5 15h250v-300h500v300h100l200 -200v-269l-103 -103l-170 170l-298 -298h-329v-400h-150q-21 0 -35.5 14.5t-14.5 35.5zM600 1000h100v200h-100v-200zM700 133l170 170l-170 170l127 127l170 -170l170 170l127 -128l-170 -169l170 -170 l-127 -127l-170 170l-170 -170z" />
+<glyph unicode="&#xe175;" d="M0 150v1000q0 20 14.5 35t35.5 15h250v-300h500v300h100l200 -200v-300h-400v-200h-500v-400h-150q-21 0 -35.5 14.5t-14.5 35.5zM600 300l300 -300l300 300h-200v300h-200v-300h-200zM600 1000v200h100v-200h-100z" />
+<glyph unicode="&#xe176;" d="M0 150v1000q0 20 14.5 35t35.5 15h250v-300h500v300h100l200 -200v-402l-200 200l-298 -298h-402v-400h-150q-21 0 -35.5 14.5t-14.5 35.5zM600 300h200v-300h200v300h200l-300 300zM600 1000v200h100v-200h-100z" />
+<glyph unicode="&#xe177;" d="M0 250q0 -21 14.5 -35.5t35.5 -14.5h1100q21 0 35.5 14.5t14.5 35.5v550h-1200v-550zM0 900h1200v150q0 21 -14.5 35.5t-35.5 14.5h-1100q-21 0 -35.5 -14.5t-14.5 -35.5v-150zM100 300v200h400v-200h-400z" />
+<glyph unicode="&#xe178;" d="M0 400l300 298v-198h400v-200h-400v-198zM100 800v200h100v-200h-100zM300 800v200h100v-200h-100zM500 800v200h400v198l300 -298l-300 -298v198h-400zM800 300v200h100v-200h-100zM1000 300h100v200h-100v-200z" />
+<glyph unicode="&#xe179;" d="M100 700v400l50 100l50 -100v-300h100v300l50 100l50 -100v-300h100v300l50 100l50 -100v-400l-100 -203v-447q0 -21 -14.5 -35.5t-35.5 -14.5h-200q-21 0 -35.5 14.5t-14.5 35.5v447zM800 597q0 -29 10.5 -55.5t25 -43t29 -28.5t25.5 -18l10 -5v-397q0 -21 14.5 -35.5 t35.5 -14.5h200q21 0 35.5 14.5t14.5 35.5v1106q0 31 -18 40.5t-44 -7.5l-276 -116q-25 -17 -43.5 -51.5t-18.5 -65.5v-359z" />
+<glyph unicode="&#xe180;" d="M100 0h400v56q-75 0 -87.5 6t-12.5 44v394h500v-394q0 -38 -12.5 -44t-87.5 -6v-56h400v56q-4 0 -11 0.5t-24 3t-30 7t-24 15t-11 24.5v888q0 22 25 34.5t50 13.5l25 2v56h-400v-56q75 0 87.5 -6t12.5 -44v-394h-500v394q0 38 12.5 44t87.5 6v56h-400v-56q4 0 11 -0.5 t24 -3t30 -7t24 -15t11 -24.5v-888q0 -22 -25 -34.5t-50 -13.5l-25 -2v-56z" />
+<glyph unicode="&#xe181;" d="M0 300q0 -41 29.5 -70.5t70.5 -29.5h300q41 0 70.5 29.5t29.5 70.5v500q0 41 -29.5 70.5t-70.5 29.5h-300q-41 0 -70.5 -29.5t-29.5 -70.5v-500zM100 100h400l200 200h105l295 98v-298h-425l-100 -100h-375zM100 300v200h300v-200h-300zM100 600v200h300v-200h-300z M100 1000h400l200 -200v-98l295 98h105v200h-425l-100 100h-375zM700 402v163l400 133v-163z" />
+<glyph unicode="&#xe182;" d="M16.5 974.5q0.5 -21.5 16 -90t46.5 -140t104 -177.5t175 -208q103 -103 207.5 -176t180 -103.5t137 -47t92.5 -16.5l31 1l163 162q17 18 13.5 41t-22.5 37l-192 136q-19 14 -45 12t-42 -19l-118 -118q-142 101 -268 227t-227 268l118 118q17 17 20 41.5t-11 44.5 l-139 194q-14 19 -36.5 22t-40.5 -14l-162 -162q-1 -11 -0.5 -32.5z" />
+<glyph unicode="&#xe183;" d="M0 50v212q0 20 10.5 45.5t24.5 39.5l365 303v50q0 4 1 10.5t12 22.5t30 28.5t60 23t97 10.5t97 -10t60 -23.5t30 -27.5t12 -24l1 -10v-50l365 -303q14 -14 24.5 -39.5t10.5 -45.5v-212q0 -21 -14.5 -35.5t-35.5 -14.5h-1100q-20 0 -35 14.5t-15 35.5zM0 712 q0 -21 14.5 -33.5t34.5 -8.5l202 33q20 4 34.5 21t14.5 38v146q141 24 300 24t300 -24v-146q0 -21 14.5 -38t34.5 -21l202 -33q20 -4 34.5 8.5t14.5 33.5v200q-6 8 -19 20.5t-63 45t-112 57t-171 45t-235 20.5q-92 0 -175 -10.5t-141.5 -27t-108.5 -36.5t-81.5 -40 t-53.5 -36.5t-31 -27.5l-9 -10v-200z" />
+<glyph unicode="&#xe184;" d="M100 0v100h1100v-100h-1100zM175 200h950l-125 150v250l100 100v400h-100v-200h-100v200h-200v-200h-100v200h-200v-200h-100v200h-100v-400l100 -100v-250z" />
+<glyph unicode="&#xe185;" d="M100 0h300v400q0 41 -29.5 70.5t-70.5 29.5h-100q-41 0 -70.5 -29.5t-29.5 -70.5v-400zM500 0v1000q0 41 29.5 70.5t70.5 29.5h100q41 0 70.5 -29.5t29.5 -70.5v-1000h-300zM900 0v700q0 41 29.5 70.5t70.5 29.5h100q41 0 70.5 -29.5t29.5 -70.5v-700h-300z" />
+<glyph unicode="&#xe186;" d="M-100 300v500q0 124 88 212t212 88h700q124 0 212 -88t88 -212v-500q0 -124 -88 -212t-212 -88h-700q-124 0 -212 88t-88 212zM100 200h900v700h-900v-700zM200 300h300v300h-200v100h200v100h-300v-300h200v-100h-200v-100zM600 300h200v100h100v300h-100v100h-200v-500 zM700 400v300h100v-300h-100z" />
+<glyph unicode="&#xe187;" d="M-100 300v500q0 124 88 212t212 88h700q124 0 212 -88t88 -212v-500q0 -124 -88 -212t-212 -88h-700q-124 0 -212 88t-88 212zM100 200h900v700h-900v-700zM200 300h100v200h100v-200h100v500h-100v-200h-100v200h-100v-500zM600 300h200v100h100v300h-100v100h-200v-500 zM700 400v300h100v-300h-100z" />
+<glyph unicode="&#xe188;" d="M-100 300v500q0 124 88 212t212 88h700q124 0 212 -88t88 -212v-500q0 -124 -88 -212t-212 -88h-700q-124 0 -212 88t-88 212zM100 200h900v700h-900v-700zM200 300h300v100h-200v300h200v100h-300v-500zM600 300h300v100h-200v300h200v100h-300v-500z" />
+<glyph unicode="&#xe189;" d="M-100 300v500q0 124 88 212t212 88h700q124 0 212 -88t88 -212v-500q0 -124 -88 -212t-212 -88h-700q-124 0 -212 88t-88 212zM100 200h900v700h-900v-700zM200 550l300 -150v300zM600 400l300 150l-300 150v-300z" />
+<glyph unicode="&#xe190;" d="M-100 300v500q0 124 88 212t212 88h700q124 0 212 -88t88 -212v-500q0 -124 -88 -212t-212 -88h-700q-124 0 -212 88t-88 212zM100 200h900v700h-900v-700zM200 300v500h700v-500h-700zM300 400h130q41 0 68 42t27 107t-28.5 108t-66.5 43h-130v-300zM575 549 q0 -65 27 -107t68 -42h130v300h-130q-38 0 -66.5 -43t-28.5 -108z" />
+<glyph unicode="&#xe191;" d="M-100 300v500q0 124 88 212t212 88h700q124 0 212 -88t88 -212v-500q0 -124 -88 -212t-212 -88h-700q-124 0 -212 88t-88 212zM100 200h900v700h-900v-700zM200 300h300v300h-200v100h200v100h-300v-300h200v-100h-200v-100zM601 300h100v100h-100v-100zM700 700h100 v-400h100v500h-200v-100z" />
+<glyph unicode="&#xe192;" d="M-100 300v500q0 124 88 212t212 88h700q124 0 212 -88t88 -212v-500q0 -124 -88 -212t-212 -88h-700q-124 0 -212 88t-88 212zM100 200h900v700h-900v-700zM200 300h300v400h-200v100h-100v-500zM301 400v200h100v-200h-100zM601 300h100v100h-100v-100zM700 700h100 v-400h100v500h-200v-100z" />
+<glyph unicode="&#xe193;" d="M-100 300v500q0 124 88 212t212 88h700q124 0 212 -88t88 -212v-500q0 -124 -88 -212t-212 -88h-700q-124 0 -212 88t-88 212zM100 200h900v700h-900v-700zM200 700v100h300v-300h-99v-100h-100v100h99v200h-200zM201 300v100h100v-100h-100zM601 300v100h100v-100h-100z M700 700v100h200v-500h-100v400h-100z" />
+<glyph unicode="&#xe194;" d="M4 600q0 162 80 299t217 217t299 80t299 -80t217 -217t80 -299t-80 -299t-217 -217t-299 -80t-299 80t-217 217t-80 299zM186 600q0 -171 121.5 -292.5t292.5 -121.5t292.5 121.5t121.5 292.5t-121.5 292.5t-292.5 121.5t-292.5 -121.5t-121.5 -292.5zM400 500v200 l100 100h300v-100h-300v-200h300v-100h-300z" />
+<glyph unicode="&#xe195;" d="M0 600q0 162 80 299t217 217t299 80t299 -80t217 -217t80 -299t-80 -299t-217 -217t-299 -80t-299 80t-217 217t-80 299zM182 600q0 -171 121.5 -292.5t292.5 -121.5t292.5 121.5t121.5 292.5t-121.5 292.5t-292.5 121.5t-292.5 -121.5t-121.5 -292.5zM400 400v400h300 l100 -100v-100h-100v100h-200v-100h200v-100h-200v-100h-100zM700 400v100h100v-100h-100z" />
+<glyph unicode="&#xe197;" d="M-14 494q0 -80 56.5 -137t135.5 -57h222v300h400v-300h128q120 0 205 86.5t85 207.5t-85 207t-205 86q-46 0 -90 -14q-44 97 -134.5 156.5t-200.5 59.5q-152 0 -260 -107.5t-108 -260.5q0 -25 2 -37q-66 -14 -108.5 -67.5t-42.5 -122.5zM300 200h200v300h200v-300h200 l-300 -300z" />
+<glyph unicode="&#xe198;" d="M-14 494q0 -80 56.5 -137t135.5 -57h8l414 414l403 -403q94 26 154.5 104.5t60.5 178.5q0 120 -85 206.5t-205 86.5q-46 0 -90 -14q-44 97 -134.5 156.5t-200.5 59.5q-152 0 -260 -107.5t-108 -260.5q0 -25 2 -37q-66 -14 -108.5 -67.5t-42.5 -122.5zM300 200l300 300 l300 -300h-200v-300h-200v300h-200z" />
+<glyph unicode="&#xe199;" d="M100 200h400v-155l-75 -45h350l-75 45v155h400l-270 300h170l-270 300h170l-300 333l-300 -333h170l-270 -300h170z" />
+<glyph unicode="&#xe200;" d="M121 700q0 -53 28.5 -97t75.5 -65q-4 -16 -4 -38q0 -74 52.5 -126.5t126.5 -52.5q56 0 100 30v-306l-75 -45h350l-75 45v306q46 -30 100 -30q74 0 126.5 52.5t52.5 126.5q0 24 -9 55q50 32 79.5 83t29.5 112q0 90 -61.5 155.5t-150.5 71.5q-26 89 -99.5 145.5 t-167.5 56.5q-116 0 -197.5 -81.5t-81.5 -197.5q0 -4 1 -11.5t1 -11.5q-14 2 -23 2q-74 0 -126.5 -52.5t-52.5 -126.5z" />
+</font>
+</defs></svg>
+{-# START_FILE BASE64 static/fonts/glyphicons-halflings-regular.ttf #-}
+AAEAAAARAQAABAAQRkZUTWpVwvAAAAEcAAAAHEdERUYBCAAEAAABOAAAACBPUy8yZ6dLhAAAAVgA
+AABgY21hcErwCZoAAAG4AAACcmN2dCAAKAOHAAAELAAAAAhmcGdtU7QvpwAABDQAAAJlZ2FzcAAA
+ABAAAAacAAAACGdseWYeHjMhAAAGpAAAiTxoZWFkAmJY/gAAj+AAAAA2aGhlYQoyBA8AAJAYAAAA
+JGhtdHjBwRGOAACQPAAAAvRsb2NhNI9WTgAAkzAAAAG4bWF4cAIEAaAAAJToAAAAIG5hbWXUr5nt
+AACVCAAAA3xwb3N0uUamaQAAmIQAAAiEcHJlcLDyKxQAAKEIAAAALndlYmZYr1LmAAChOAAAAAYA
+AAABAAAAAMw9os8AAAAAzwwW8gAAAADPDAkuAAEAAAAOAAAAGAAAAAAAAgABAAEA2gABAAQAAAAC
+AAAAAwSBAZAABQAEAwwC0AAAAFoDDALQAAABpAAyArgAAAAABQAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAVUtXTgBAAA3iAAPA/xAAAAUYAHwAAAABAAAAAAAAAAAAAAAgAAEAAAADAAAAAwAAABwAAQAA
+AAABbAADAAEAAAAcAAQBUAAAAFAAQAAFABAAAAANACAAKwCgIAogLyBfIKwiEiX8JgEnCScP4APg
+CeAZ4CngOeBJ4FngYOBp4HngieCX4QnhGeEp4TnhRuFJ4VnhaeF54YnhleGZ4gD//wAAAAAADQAg
+ACoAoCAAIC8gXyCsIhIl/CYBJwknD+AB4AXgEOAg4DDgQOBQ4GDgYuBw4IDgkOEB4RDhIOEw4UDh
+SOFQ4WDhcOGA4ZDhl+IA//8AAf/1/+P/2v9m4Aff49+032jeA9oa2hbZD9kKIBkgGCASIAwgBiAA
+H/of9B/zH+0f5x/hH3gfch9sH2YfYB9fH1kfUx9NH0cfQR9AHtoAAQAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAABBgAAAQAAAAAAAAABAgAAAAIAAAAAAAAAAAAAAAAAAAABAAADAAAAAAAAAAAABAUA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAA
+AAAAFAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAjwAoAviwACywABNL
+sExQWLBKdlmwACM/GLAGK1g9WUuwTFBYfVkg1LABEy4YLbABLCDasAwrLbACLEtSWEUjWSEtsAMs
+aRggsEBQWCGwQFktsAQssAYrWCEjIXpY3RvNWRtLUlhY/RvtWRsjIbAFK1iwRnZZWN0bzVlZWRgt
+sAUsDVxaLbAGLLEiAYhQWLAgiFxcG7AAWS2wByyxJAGIUFiwQIhcXBuwAFktsAgsEhEgOS8tsAks
+IH2wBitYxBvNWSCwAyVJIyCwBCZKsABQWIplimEgsABQWDgbISFZG4qKYSCwAFJYOBshIVlZGC2w
+CiywBitYIRAbECFZLbALLCDSsAwrLbAMLCAvsAcrXFggIEcjRmFqIFggZGI4GyEhWRshWS2wDSwS
+ESAgOS8giiBHikZhI4ogiiNKsABQWCOwAFJYsEA4GyFZGyOwAFBYsEBlOBshWVktsA4ssAYrWD3W
+GCEhGyDWiktSWCCKI0kgsABVWDgbISFZGyEhWVktsA8sIyDWIC+wBytcWCMgWEtTGyGwAVlYirAE
+JkkjiiMgikmKI2E4GyEhISFZGyEhISEhWS2wECwg2rASKy2wESwg0rASKy2wEiwgL7AHK1xYICBH
+I0ZhaoogRyNGI2FqYCBYIGRiOBshIVkbISFZLbATLCCKIIqHILADJUpkI4oHsCBQWDwbwFktsBQs
+swBAAUBCQgFLuBAAYwBLuBAAYyCKIIpVWCCKIIpSWCNiILAAI0IbYiCwASNCWSCwQFJYsgAgAENj
+QrIBIAFDY0KwIGOwGWUcIVkbISFZLbAVLLABQ2MjsABDYyMtAAAAAAEAAf//AA8AAgAoAAABaAMg
+AAMABwAusQEALzyyBwQC7TKxBgXcPLIDAgLtMgCxAwAvPLIFBALtMrIHBgP8PLIBAgLtMjMRIREl
+MxEjKAFA/ujw8AMg/OAoAtAAAQBkAGQETARMABcAJACwAC+wDTOwAc2wCzIBsBgvsBPWsAUysBLN
+sAcysRkBKwAwMRM1ISc3FxEzETcXByEVIRcHJxEjEQcnN2QBA7eNt8i3jbcBA/79t423yLeNtwH0
+yLeNtwED/v23jbfIt423/v0BA7eNtwAAAQAAAAAETARMAAsASgCyCgAAK7AAL7AHM7ABzbAFMrIB
+AAors0ABAwkrAbAML7AK1rACMrAJzbAEMrIJCgors0AJBwkrsgoJCiuzQAoACSuxDQErADAxGQEh
+ESERIREhESERAZABLAGQ/nD+1AGQASwBkP5w/tT+cAGQAAEAZAAFBIwErgA3AHYAsDIvsCjNsigy
+CiuzQCguCSuwAC+wITOwAc2wHzKwBS+wHDOwBs2wGjKwFS+wC82yFQsKK7NAFRAJKwGwOC+wN9aw
+AjKwIs2xHR8yMrAiELEtASuwEDKwLs2wDzKxOQErsSI3ERKwBzmwLRGyCyAyOTk5ADAxEzczNDcj
+NzM2NzYzMhcWFyM0LgIjIg4CByEHIQYVIQchHgQzMj4CNTMGBwYjIicuASdkZHEF2mSHJUt1tPJw
+PAa1M0xKHhg5RD8TAXtk/tQGAZZk/tQJMDlDMxUdSkwzrh9ha6fNdyRCDAH0ZC81ZKdajb1najdY
+MBkULFo+ZC42ZEp0QisPGjBXNaxqdZ4uq3gAAAABAMgBkARMArwAAwASALAAL7ADzQGwBC+xBQEr
+ADAxEyERIcgDhPx8AZABLAAAAAABAAAAAAAAAAAAAAAAMQAAAf/yASwEwgRBABUAHwCwAy+wDs2w
+Cc0BsBYvsRcBKwCxCQMRErELETk5MDEDFBYzITI2NCYjIgcuASMiBhUUFw4BDnFPAu54qqp4Liws
+tW6Y2AJCVQHuUHKt8qwOYXfXmRkMDmsAAAAEAAAAZASwBEwABAAHAAoADQAANQEXNwElEQkFEQGQ
+yMgBkPtQASz+1AJYAlj+1AEsZAGQyMj+cMgCWP7UAfT9pQJb/gwBLP2oAAAAA//z//MEvQS9AAIA
+BgAQAAAHJSc3FwEnNxc3NjQvASYiBw0BTd9a1gJm1lbWYw0NmQ8kDw1w31HWAmbWVtZcDScOmQ0N
+AAAAAQAAAAAEsASwAAkAMwCyBgAAK7AHzbADMgGwCi+wCNawA82yAwgKK7NAAwUJK7IIAwors0AI
+BgkrsQsBKwAwMREhAREhFSE1IREEsP4MASz84AEsBLD92v3aZGQCJgAAAQAOAAgETASvACAAACYe
+ATc+ATURJREmBw4BFx4BNz4BNRE0JgcFDgEVESYHBgQkiE9BWAJYQEpPVxISiE9GUw4K/RAKDkBK
+T4tuKRoVYCoCXpv99xAXGnI2NykZF1E3A3EKCwPBAxMK/U8RGBkAAAIAF//sBMQEmQATABsAWQCy
+DgAAK7ASL7AXzbAbL7ADzQGwHC+wAdawFc2wFRCxGQErsAXNsR0BK7EZFRESswMCEBIkFzmwBRGw
+BzkAsRIOERKwCTmwFxGwEDmwGxKzAQAHBSQXOTAxEhAAIAAVFAcBFhQPAQYiJwEGIyICEBYgNhAm
+IBcBHAGQARxOASwHB20IFAj+1HeOyIPCARLBwf7uAe0BkAEc/uTIjnf+1AgUCG0HBwEsTgJs/vDC
+wQESwQAAAAABAGQAWASvBEQAGQAVAAGwGi+wANawDs2wDs2xGwErADAxEzQ+Ah4BFz4CHgIVFA4D
+By4EZDhad3d5LDB7eHVYNkN5hKg+PqeEeUMDEEB2Uy0ESURFSAQtU3ZAOXmAf7JVVbJ/gHkAAAL/
+uABHBJUEsAAKAAwAAAMhEzMTIQETCQETAzdIAd+SApIB2P6Ckf6A/oKSlAIDIAGQ/nD+6v4/ARP+
+7QG//j8BAAAAA/+4AEcElQSwAAoADAAWABgAsA0vsBMzsAHNsAQyAbAXL7EYASsAMDEDIRMzEyEB
+EwkBEwM3ExcHNxcnNyMnB0gB35ICkgHY/oKR/oD+gpKUAkPEScDDSsHrTU4DIAGQ/nD+6v4/ARP+
+7QG//j8BAnSO4oyN5YzT0wAAAAEAAAAABLAEsAATAAAxNQE1IiY9ATQ2MhYdARQGIxUBFQGQJT+w
++LA/JQGQjwEBZJUzyHywsHzIM5Vk/v+PAAANAAAAAASwBEwAAwAHAAsADwATABcAGwAfACMAJwAr
+AC8AMwCwALIAAAArsATNsRggMjKwBy+wIjOwCM2wJDKwCy+wJjOwDM2wKDKwDy+wKjOwEM2wLDKw
+Ey+wLjOwFM2wMDKwFy+xHjIzM7ABzQGwNC+wANawBM2zCAwQFCQXMrAEELEFASuzCQ0RFSQXMrAY
+zbAcMrAYELEZASuwHTKwIM2zJCgsMCQXMrAgELEhASuzJSktMSQXMrADzbE1ASsAsQwLERKxGhs5
+ObAPEbEcHTk5MDExESERJTM1IzUzNSM1MzUjNTM1IzUzNSMTIREhNSERIQEzNSM1MzUjNTM1IzUz
+NSM1MzUjBLD7tGRkZGRkZGRkZGTIAlj9qAJY/agCvGRkZGRkZGRkZGQETPu0ZGRkZGRkZGRkZPx8
+AZBkAZD8fGRkZGRkZGRkZAAAAAAEAAAAAARMBEwADwAfAC8APwBCALINAAArsCwzsATNsCQysB0v
+sDwzsBTNsDQyAbBAL7AA1rAQMrAJzbAYMrAJELEgASuwMDKwKc2wODKxQQErADAxNRE0NjMhMhYV
+ERQGIyEiJhkBNDYzITIWFREUBiMhIiYBETQ2MyEyFhURFAYjISImGQE0NjMhMhYVERQGIyEiJh0V
+AZAVHR0V/nAVHR0VAZAVHR0V/nAVHQJYHRUBkBUdHRX+cBUdHRUBkBUdHRX+cBUdMgGQFR0dFf5w
+FR0dAm0BkBUdHRX+cBUdHf29AZAVHR0V/nAVHR0CbQGQFR0dFf5wFR0dAAAJAAAAAARMBEwADwAf
+AC8APwBPAF8AbwB/AI8AdgCyDQAAK7E8bDMzsATNsTRkMjKwHS+xTHwzM7AUzbFEdDIysC0vsVyM
+MzOwJM2xVIQyMgGwkC+wANaxECAyMrAJzbEYKDIysAkQsTABK7FAUDIysDnNsUhYMjKwORCxYAEr
+sXCAMjKwac2xeIgyMrGRASsAMDE9ATQ2OwEyFh0BFAYrASImETU0NjsBMhYdARQGKwEiJhE1NDY7
+ATIWHQEUBisBIiYBNTQ2OwEyFh0BFAYrASImETU0NjsBMhYdARQGKwEiJhE1NDY7ATIWHQEUBisB
+IiYBNTQ2OwEyFh0BFAYrASImETU0NjsBMhYdARQGKwEiJhE1NDY7ATIWHQEUBisBIiYdFcgVHR0V
+yBUdHRXIFR0dFcgVHR0VyBUdHRXIFR0BkB0VyBUdHRXIFR0dFcgVHR0VyBUdHRXIFR0dFcgVHQGQ
+HRXIFR0dFcgVHR0VyBUdHRXIFR0dFcgVHR0VyBUdMsgVHR0VyBUdHQGlyBUdHRXIFR0dAaXIFR0d
+FcgVHR389cgVHR0VyBUdHQGlyBUdHRXIFR0dAaXIFR0dFcgVHR389cgVHR0VyBUdHQGlyBUdHRXI
+FR0dAaXIFR0dFcgVHR0ABgAAAAAEsARMAA8AHwAvAD8ATwBfAFYAsg0AACuwPDOwBM2wNDKwEy+w
+TDOwHM2wRDKwLS+wXDOwJM2wVDIBsGAvsADWsRAgMjKwCc2xFygyMrAJELEwASuxQFAyMrA5zbFI
+WDIysWEBKwAwMT0BNDY7ATIWHQEUBisBIiYRFBY7ATI2PQE0JisBIgYVPQE0NjsBMhYdARQGKwEi
+JgE1NDYzITIWHQEUBiMhIiYRNTQ2MyEyFh0BFAYjISImETU0NjMhMhYdARQGIyEiJh0VyBUdHRXI
+FR0dFcgVHR0VyBUdHRXIFR0dFcgVHQGQHRUCvBUdHRX9RBUdHRUCvBUdHRX9RBUdHRUCvBUdHRX9
+RBUdMsgVHR0VyBUdHQGlFR0dFcgVHR0VyMgVHR0VyBUdHfz1yBUdHRXIFR0dAaXIFR0dFcgVHR0B
+pcgVHR0VyBUdHQAAAAEAHQAiBPIEKgAFAAATCQEnAScdAaMDMtT9oc4Bxv5cAzTU/aHPAAABAGoA
+agRGBEYACwAAEwkBNwkBFwkBBwkBagEa/ubUARoBGtT+5gEa1P7m/uYBPgEaARrU/uYBGtT+5v7m
+1AEa/uYAAAMAF//sBMQEmQATABsAJwC3ALIOAAArsBIvsBfNsBwvsCMzsB3NsCEyshwdCiuzQBwm
+CSuyHRwKK7NAHR8JK7AbL7ADzQGwKC+wAdawFc2wFRCxJgErsB4ysCXNsCAysiUmCiuzQCUjCSuy
+JiUKK7NAJhwJK7AlELEZASuwBc2xKQErsSYVERKyAhYbOTk5sCURsBI5sBkSswMXEBokFzmwBRGw
+BzkAsRcSERKwEDmxHQ4RErMABRUYJBc5sBsRshQZATk5OTAxEhAAIAAVFAcBFhQPAQYiJwEGIyIC
+EBYgNhAmIAM1MzUzFTMVIxUjNRcBHAGQARxOASwHB20IFAj+1HeOyIPCARLBwf7uRmTIZGTIAe0B
+kAEc/uTIjnf+1AgUCG0HBwEsTgJs/vDCwQESwf5ZyGRkyGRkAAADABf/7ATEBJoAEwAbAB8AXQCy
+DgAAK7ASL7AXzbAbL7ADzQGwIC+wAdawFc2wFRCxGQErsAXNsSEBK7EZFREStQMCEBIcHSQXObAF
+EbAHOQCxEg4RErAJObAXEbAQObAbErUBAAcFHB4kFzkwMRIQACAAFRQHARYUDwEGIicBBiMiAhAW
+IDYQJiADITUhFwEcAZABHE4BLAcHbQgUCP7Ud47Ig8IBEsHB/u5GAZD+cAHuAZABHP7kyI15/tUH
+FgdtCAgBLE4CbP7wwsIBEML+WcgAAAIAFwAXBJkEsAAbACsARQCwGC+wCs0BsCwvsADWsAfNsgcA
+CiuzQAcDCSuwBxCxDAErsBPNsgwTCiuzQAwQCSuxLQErsQwHERKzFxgcIyQXOQAwMRM0EjcVDgEV
+FBYgNjU0Jic1FhIVFA4CIi4CARQWOwEyNjURNCYrASIGFRfSp2d8+gFi+nxnp9Jbm9Xs1ZtbAd0d
+FWQVHR0VZBUdAli3ASg+pjfIeLH6+rF4yDemPv7Yt3bVm1tbm9UBDBUdHRUBkBUdHRUABABkAAEE
+sASxAAMABwALAA8AMACyBAAAK7EIDDMzAbAQL7AE1rAHzbAHELEIASuwC82wCxCxDAErsA/NsREB
+KwAwMTczESMBETMRMxEzETMRMxFkyMgBLMhkyGTIAQEs/tQB9P4MAyD84ASw+1AAAAIAGgAbBJYE
+lgBHAFEAYgCwEi+wUM2wSy+wNs0BsFIvsADWsEjNsEgQsU0BK7AkzbFTASuxSAARErELPTk5sE0R
+sw8VMzkkFzmwJBKxGS85OQCxUBIRErEHHTk5sEsRswMhJ0UkFzmwNhKxK0E5OTAxExQfAhYfAQcW
+FzcXFh8CFjMyPwI2PwEXNjcnNzY/AjY1NC8CJi8BNyYnBycmLwImIyIPAgYPAScGBxcHBg8CBgU0
+NjIWFRQGIiYaBpcCDhgDUC08hQUtMQUmKCIbLyYGLi8FhjgwUAMYDwGYBQWYARAXA1AsPIYFLTAG
+JigiGy8mBTIsBYU7LlADGQ0ClwYBZ36yfn6yfgJZISkmBjEsBYY7LlEDGg0ClwUFlwINGgNRLD2G
+BSwxBiYoIhwtJgYzKgWGOi9RAxkOAZgFBZgBDhkDUS86hgUvLgYmMBlYfn5YWX5+AAAABwBk//8E
+sAUUABkAIwAnACsALwAzADcAiQCyIQAAK7AkzbIoMDQyMjKwJy+yKjI2MzMzsBvNsBcvsATNsQ4s
+MjKwLy+wCc0BsDgvsBrWsCTNsCQQsSUBK7AFMrAozbAsMrIlKAors0AlAAkrsCgQsSkBK7AwzbAw
+ELExASuwLTKwNM2wDTKyNDEKK7NANBMJK7A0ELE1ASuwHc2xOQErADAxEzU0NjMhNTQ2MyEyFh0B
+ITIWHQEUBiMhIiYTESERFAYjISImNzMRIxMzESMRITUhEzMRIxMzESNkDwoBEzspASwpOwETCg8O
+C/vmCw5kA4Q7Kf1EKTtkZGTIZGQBLP7UyGRkyGRkBAEyCg9kKTs7KWQPCjILDg78bgMg/OApPDwp
+Arz9RAK8ASxk+7QCvP1EArwAAAAAAQABAAEFFQTdAAoALACyCQAAK7AEMwGwCy+wCdawCM2wCBCx
+BQErsATNsQwBK7EFCBESsAE5ADAxEwkBIxEhESERIREBApAChMj+1P7U/tQCWQKE/Xz9qAGQ/nAC
+WAAAAgBkAAAD6ASwAA4AEQAiALIMAAArAbASL7AB1rAGzbIGAQors0AGCAkrsRMBKwAwMTcRNDYz
+IREhERQGIyEiJgERAWQOCwHbAZAOC/yuCw4CWAEsGQR+Cw7+DP1dCw4OAxIBLP7UAAADAAQABASs
+BKwACwATABkAggCwCi+wD82wFC+wF82yFxQKK7NAFxUJK7ATL7AEzQGwGi+wAdawDc2wDRCxFAEr
+sBfNshcUCiuzQBcZCSuwFxCxEQErsAfNsRsBK7EUDRESswoDDhMkFzmxERcRErMJBA8SJBc5ALEU
+DxESswcADRAkFzmxExcRErMGAREMJBc5MDESEBIkIAQSEAIEICQSEBYgNhAmIBMRMxEzFQSgARIB
+RAESoKD+7v68/u4W8wFW8/P+qkdkyAG2AUQBEqCg/u7+vP7uoKACX/6q8/MBVvP9/gGQ/tRkAAAA
+AAL/nAAABRQEsAALAA8ALgCyAAAAK7AHM7AKL7AMzbAPL7ADzbIDDwors0ADAQkrsAUyAbAQL7ER
+ASsAMDEjATMDMwMzASEDIwMTMwMjZAGv0RWiFNABr/3mKfIoMeAbqgSw/tQBLPtQAZD+cAH0ASwA
+AAAAAgAAAAAETASwAAsADwBKALILAAArsAzNsA8vsAnNsAEyAbAQL7AE1rAHzbIEBwors0AEAAkr
+sAcQsQ0BK7AKzbERASuxBwQRErECCTk5sA0RsQgMOTkAMDExESEBMxEhETMBIRElMzUjAer+3sgB
+LMj+3gHq/uGvrwGQASwB9P4M/tT+cMhkAAMAAQABBK8ErwAPABcAHgBjALINAAArsBPNsBcvsAXN
+AbAfL7AB1rARzbARELEZASuwHM2wHBCxFQErsAnNsSABK7EZEREStA0EEhcYJBc5sBwRsB45sBUS
+tAwFExYdJBc5ALEXExEStQEICQAaHiQXOTAxEjQ+AjIeAhQOAiIuARIQFiA2ECYgAzMRMxEzAwFf
+oN703qBfX6De9N6gXPIBVPLy/qxQlsiW+gHe9N6gX1+g3vTeoF9foAIC/qzy8gFU8v5kASz+1P7U
+AAMABAAEBKwErAALABMAGgBhALAKL7APzbATL7AEzQGwGy+wAdawDc2wDRCxGQErsBjNsBgQsREB
+K7AHzbEcASuxGQ0RErQKAw4TFCQXObAYEbAVObARErQJBA8SFiQXOQCxEw8RErUBBgcAFRgkFzkw
+MRIQEiQgBBIQAgQgJBIQFiA2ECYgAxsBIxEjEQSgARIBRAESoKD+7v68/u4W8wFW8/P+qk/6+pbI
+AbYBRAESoKD+7v68/u6goAJf/qrz8wFW8/5iASz+1P7UASwAAAACAAAAAASwBLAACwATACkAsgkA
+ACuwDM2wEDKwEy+wAs0BsBQvsRUBKwCxDAkRErIEAQ45OTkwMTUREyEbARQGIyEiJhMzFyE3MwMh
+yAMgxwEOC/uCCw7IyDIBLDLIYf2iGQHbArz9RP4lCw4OAebIyAH0AAMABAAEBKwErAALABUAGABG
+ALAKL7APzbAUL7AEzQGwGS+wAdawDM2wDBCxEQErsAfNsRoBK7ERDBEStQQJCgMWGCQXOQCxFA8R
+ErUBBgcAFhckFzkwMRIQEiQgBBIQAgQgJBMUFiA2NTQmIAYBEQUEoAESAUQBEqCg/u7+vP7uFvMB
+VvPz/qrzAToBKQG2AUQBEqCg/u7+vP7uoKABtKzy8qyr8/P+igGRyAABABcAFwSZBLAAHABTALAF
+L7ANzbARL7AZzQGwHS+wAdawD82wDxCxCgErsAnNsR4BK7EKDxEStQUEExQXGSQXObAJEbEVFjk5
+ALERDREStAEACRQVJBc5sBkRsBc5MDESFB4CMj4CNSMUBiAmEDYzMhcHIREHJiMiDgEXW5vV7NWb
+W5b6/p76+rGIbpIBkJGdxnbVmwLO7NWbW1ub1Xax+voBYvpRkgGQkXpbmwAAAAIAFwAABJkEsAAQ
+ACEAegCyEQAAK7AfL7AWzbIWHwors0AWGgkrsA0vsAXNsg0FCiuzQA0ACSsBsCIvsADWsBDNsBAQ
+sRkBK7AazbEjASuxEAARErEREjk5sBkRtwcFCwoTFB8hJBc5sBoSsQkIOTkAsRYfERKwITmwDRGx
+CRI5ObAFErAHOTAxEzQ+AjMyFzcRITcmIyIGFQMRIQcWMzI2NTMUDgIjIicXW5vVdsadkf5wk3CH
+sfpJAZCTcIex+pZbm9V2xp0CWHbVm1t6kf5wk1D6sf2oAZCTUPqxdtWbW3oAAAoAZAAABLAEsAAD
+AAcACwAPABMAFwAbAB8AIwAnAFAAsAgvsBgzsAnNsBoysAwvsBwzsA3NsB0ysBAvsCAzsBHNsCEy
+sBQvsCQzsBXNsCUyAbAoL7AI1rIMEBQyMjKwC82yDhIWMjIysSkBKwAwMTMhESETESERJTUzFSc1
+MxUnNTMVJzUzFRMhNSE9ASEVJTUhFSU1IRVkBEz7tGQDhPzgZGRkZGRkZGQB9P4MAfT+DAH0/gwB
+9ASw+7QDhPx8ZGRkyGRkyGRkyGRk/ahkZGRkyGRkyGRkAAIAAAAABEwEsAAZACMASgCyFwAAK7Ag
+L7AJzQGwJC+wBdawGs2yBRoKK7NABQAJK7AaELEbASuwDs2yDhsKK7NADhMJK7ElASsAsSAXERKz
+BA4FGiQXOTAxNRE0NjsBNTQ2MyEyFh0BMzIWFREUBiMhIiYBITU0JisBIgYVOylkdlIBLFJ2ZCk7
+Oyn8fCk7AZABLB0VyBUdZAJYKTvIUnZ2Usg7Kf2oKTs7AuWWFR0dFQAAAAIAZAAABEwETAADABUA
+FwCyAAAAKwGwFi+wANawA82xFwErADAxMxEzERM+AR4CPgE3EQ4BLgMGB2RkZDyHeHxyamQpKHuE
+kId0WhQETPu0AZA8MA0hGwVPUQH0UUUKKCgKRVEAAAAAAwAAAAAEsASXACEAMQBBAGcAsi8AACuw
+PjOwJs2wNjKwDC+wHc0BsEIvsADWsAfNsAcQsSIBK7ArzbArELEyASuwO82wOxCxEAErsBfNsUMB
+K7EyKxESswwLHRwkFzkAsSYvERK0BxATFAMkFzmwDBGxCA85OTAxERQWOwEyNjURND4BIB4BFREU
+FjsBMjY1ETQuAiIOAhUTETQ2OwEyFhURFAYrASImJRE0NjsBMhYVERQGKwEiJg4LMgsOjeQBBuSN
+DgsyCw5jo97o3qNjyAwIoAgMDAigCAwCWAwIoAgMDAigCAwBEwsODgsBLH/RcnLRf/7UCw4OCwEs
+dN6jY2Oj3nT91QHMCAwMCP40CAwMCAHMCAwMCP40CAwMAAAAAgAAAMgEWAPoAAUAEQAAESEFEQUh
+ATcnNxc3FwcXBycHASwBLP7U/tQCsI2NR42NR42NR42NAZDIAyDI/quNjUeNjUeNjUeNjQAAAAIA
+AADIA3AD6AAFAA8AEgABsBAvsA7WsAnNsREBKwAwMREhBREFISU3FhUUByc2NTQBLAEs/tT+1AK8
+RW9qQ1YBkMgDIMg5NYevqYU2boqSAAAAAAMAAAC6BGID9wAFAA8AHQA8ALAAL7ABzQGwHi+wDtaw
+Cc2wCRCxEwErsBrNsR8BK7ETCRESsxAWFx0kFzkAsQEAERKzCQ4TGiQXOTAxGQEhJRElATcWFRQH
+JzY1NDcXFhUUDwEXNzY1NC8BASwBLP7UAZJFb2pDVl4He3cHUQaOkAYBkQGQyPzgyAHJNYevqoU3
+boqRzQiXwb2WCEIIsuPmsggADQAAAAAEsASwAAcAEQAVABkAHQAhAC8AMwA/AEMARwBLAE8BAQCy
+AAAAK7EwRDMzsBLNsikxRTIyMrAaL7InK0wzMzOwG82yJS1NMjIysCIvsQIGMzOwI82wCDKwHi+x
+DkgzM7AhzbE0STIyAbBQL7Aa1rEFHjIysB3NsQMfMjKwHRCxMAErsQ0sMjKwM82wNTKwMxCxLgsr
+sCoysCXNsEAysi4lCiuzQC4iCSuyAQsPMjIysCUQsTcBK7FESDIysDvNsSZKMjKwOxCxTAErsEIy
+sE/Nsjk9RjIyMrFRASuxMB0RErUUFRgZND8kFzmxNyURErIoKTg5OTkAsSIbERKzExQ4OSQXObAj
+EbIEOjs5OTmwHhJACQUWGTY3PD1AQyQXOTAxMSERIzUjFSM1MzUhNTM1IxEhExEhEQERIREDNTMV
+AzM1IwE1IREzFSMVIzUjNTM1AzUzFQMzETMRITUjNTMRIRMRIREDNSEVATUzFRM1MxUB9MhkyGQB
+kGRk/gxkASz+1AEsyGRkZGQBLAEsyGTIZGRkZGRkyAEsyMj9qMgBLMgBLP7UZGRkAfRkZGRkZGQB
+LPu0ASz+1AK8ASz+1P2oZGQCvGT+DGT+1GRkZGTI/gxkZAPo/tT+1MhkAfT+cAEs/tT84GRkA4Rk
+ZP1EZGQAAAAACQAAAAAEsASwAAMABwALAA8AEwAXABsAHwAjAHAAsgwAACuyBBQcMzMzsA3NsRUd
+MjKyDAAAK7AFzQGwJC+wCNawC82wCxCxEAErsAwysBPNsA/NsBMQsRQLK7AXzbAXELEYCyuwG82w
+GxCxIAErsCPNsSUBK7EQCxESsQcGOTmxGxcRErEcHTk5ADAxNTMRIxM1IRUnETMRFzUzFScRMxEV
+NTMVNREzERU1MxUnETMRZGRkASzIZMhkZMhkZMhkyMgD6PtQZGTIA+j8GMhbW8gD6PwYyFtbyAPo
+/BjIW1vIA+j8GAAAAAIAAAAABLAEsAAHABMAKQCyBwAAK7ASL7AEzQGwFC+wAdawCc2xFQErALES
+BxESsgAGCzk5OTAxERM0NjMhCQEAFBcWMjc2NCcmIgcBDwoB2gK8/gz92B0eUx4dHR5THgK8AdsK
+D/1E/gwD41QdHh4dVB0eHgAAAAMAAQAABd0EsAAHABMAGQAxALIHAAArsBczsBIvsATNsBQyAbAa
+L7AB1rAJzbEbASsAsRIHERK0AAYLFhkkFzkwMRsBNDYzIQkBABQXFjI3NjQnJiIHJTMJAScBAQEO
+CwHaArz+DP3XHh1UHR4eHVQdAgtkArz+DDIBwgK8AdsLDv1E/gwD41QdHh4dVB0eHrD9RP4MMgHC
+AAAAAAEAZAAABLAEsAAKAD8AsgAAACuwBy+wAs0BsAsvsADWsArNsAoQsQUBK7AEzbEMASuxCgAR
+ErICBwg5OTkAsQcAERKyAQQFOTk5MDEzETchEQcRIQchEWSvA51k/RJkAu4EAa/8GGQD6GT8GAAA
+AAABAMgAAARMBLEACgAAMwkBETQmIyEiBhXIAcIBwh0V/OAVHQG8/kUEfhQeHhQAAAADAAAAAASw
+BLAACwAXACcAWQCyJQAAK7AczbAKL7ADzbIKAwors0AKAAkrsAcysgMKCiuzQAMBCSuwBTIBsCgv
+sADWsAvNsAIysAsQsQgBK7AFMrAHzbEpASuxCAsRErMMDyciJBc5ADAxNREzFyE3MxEjNSEVExch
+NwMuASMhIgYHAzc+ATMhMhYfARYGIyEiJshkAlhkyMj84DUoAlA+XgIQCv4+ChACQiYCEwoB9AoT
+AiYCCwr9qAoLZAK8yMj9RMjIAtl8fAFaCw4OC/uBmAoODgqYCg4OAAAABAAAAGQEsARMAB0AJQAt
+ADEAbwCwAy+wJc2wKS+wLc2wIS+wE80BsDIvsADWsB/Nsh8ACiuzQB8vCSuwHxCxJwErsCvNsTMB
+K7EfABESsBk5sSsnERKzISQlICQXOQCxLSkRErMfIiMeJBc5sCERsS4xOTmwExK0CxkaLzAkFzkw
+MTUUFjMhMjY1ETQmKwEuBCsBIg4CDwEjIgYVADQ2MhYUBiICFBYyNjQmIiU1MxU7KQPoKTs7KZYE
+DzM3UyrIKVI6LgsMlik7AWSQyJCQyAY+WD4+WAFYZMgpOzspAlgpOwgbRTUrKTs7FRQ7Kf5wyJCQ
+yJABIFg+Plg+XmRkAAIANQAABLAErwAeACIAHgCyAAAAK7ANM7AezbICDA8yMjIBsCMvsSQBKwAw
+MTMhNSIuAT8BIRcWBiMVITUmJy4BLwEBIwEGBw4BDwEBExcTNQFtKT4kE1wBh1IQKzUBoSIoEh4G
+Bv5/Xf5xGBwMKg8PAWuyLnRCFjYs6t4tV0JCASoTLg4NA+b8EjAbDBoHBwHHAcmM/sMAAwBkAAAD
+wwSwACAAKQAxAGUAsiAAACuwIc2yIAAAK7ABzbApL7AqzbAxL7ANzbANELALzQGwMi+wBNawIc2w
+KjKwIRCxLgErsBDNsCUg1hGwHM2xMwErsSUuERKwFjkAsSkhERKwHDmwKhGwFjmwMRKwEDkwMTM1
+PgE1ETQuAyc1BTIWFRQOAg8BHgQVFA4BIyczMjY1NCYrATUzMjY1NCYjZCk7AgkWJB8B13i6FyEi
+CwwIG0U0K3amT8ihWYB9Xp+LTGyom1kHMygDOxwXHQ0PB0cBsIw3XTcoCAcDDDNBdkZUkU3IYVRa
+gWR7TVJhAAAAAAEAyAAAA28EsAAZACAAsgAAACuwAc2wGDKwCy+wDjOwDM0BsBovsRsBKwAwMTM1
+PgE3EzYmJy4BJzUhFw4DDwEDBhYXFchNcwitCihHBgkFAakCIToiGQUFgAowRzkHQy8DUTgkEwED
+ATk5CCMnJQwM/Mc0PAY5AAL/tQAABRQEsAAJACUAfgCyGwAAK7AfL7ICBRYzMzOwDM2yHwwKK7NA
+HxAJK7AKMgGwJi+wAdawB82wBxCxCgErsCXNsCUQsR0BK7AYzbIYHQors0AYGgkrsh0YCiuzQB0b
+CSuwGBCxEAErsA/NsScBK7EKBxESsQUIOTkAsR8bERKwCTmwDBGwBDkwMSczESM3FyMRMwcTETMh
+MxEjNC4DKwERFxUhNTcRIyIOAxVLS0t9fUtLffqWAryWMhAVLiEiyGT+cGTIIiEvFBHIAyCnp/zg
+pwNjASz+1B0nFQkC/K4yZGQyA1ICCRUnHQAAAAIAIf+2BI8EsQAJACUAiQCyCAAAK7ACzbAfL7AW
+M7AMzbIfDAors0AfCgkrsA8yAbAmL7AK1rAlzbAlELEdASuwGM2yGB0KK7NAGBoJK7IdGAors0Ad
+GwkrsBgQsRABK7APzbEnASuxHSURErMCCAkBJBc5sRAYERKzBAYHAyQXOQCxAggRErEABTk5sB8R
+sgEEGjk5OTAxPwEVITUXBzUhFQMRMyEzESM0LgMrAREXFSE1NxEjIg4DFSGnAyCnp/zgZJYCvJYy
+EBQvISLIZP5wZMgiIS4VEDN9S0t9fUtLA88BLP7UHScVCQL9djJkZDICigIJFScdAAAAAAQAAAAA
+BLAETAAPAB8ALwA/AAA1FBYzITI2PQE0JiMhIgYVNRQWMyEyNj0BNCYjISIGFTUUFjMhMjY9ATQm
+IyEiBhU1FBYzITI2PQE0JiMhIgYVHRUETBUdHRX7tBUdHRUDIBUdHRX84BUdHRUD6BUdHRX8GBUd
+HRUCWBUdHRX9qBUdMhQeHhRkFR0dFcgUHh4UZBUdHRXIFB4eFGQVHR0VyBQeHhRkFR0dFQAEAAAA
+AASwBEwADwAfAC8APwAANRQWMyEyNj0BNCYjISIGFREUFjMhMjY9ATQmIyEiBhUTFBYzITI2PQE0
+JiMhIgYVERQWMyEyNj0BNCYjISIGFR0VBEwVHR0V+7QVHR0VBEwVHR0V+7QVHcgdFQK8FR0dFf1E
+FR0dFQK8FR0dFf1EFR0yFB4eFGQVHR0VAfQUHh4UZBUdHRX+cBQeHhRkFR0dFQH0FB4eFGQVHR0V
+AAQAAAAABLAETAAPAB8ALwA/ACYAsg0AACuwBM2wLS+wJM2wHS+wFM2wPS+wNM0BsEAvsUEBKwAw
+MT0BNDYzITIWHQEUBiMhIiYTNTQ2MyEyFh0BFAYjISImEzU0NjMhMhYdARQGIyEiJhM1NDYzITIW
+HQEUBiMhIiYdFQRMFR0dFfu0FR1kHRUD6BUdHRX8GBUdyB0VAyAVHR0V/OAVHcgdFQJYFR0dFf2o
+FR0yZBUdHRVkFB4eAmxkFR0dFWQUHh7+6GQVHR0VZBQeHgJsZBUdHRVkFB4eAAQAAAAABLAETAAP
+AB8ALwA/ACYAsg0AACuwBM2wHS+wFM2wLS+wJM2wPS+wNM0BsEAvsUEBKwAwMT0BNDYzITIWHQEU
+BiMhIiYRNTQ2MyEyFh0BFAYjISImETU0NjMhMhYdARQGIyEiJhE1NDYzITIWHQEUBiMhIiYdFQRM
+FR0dFfu0FR0dFQRMFR0dFfu0FR0dFQRMFR0dFfu0FR0dFQRMFR0dFfu0FR0yZBUdHRVkFB4eAUBk
+FR0dFWQUHh4BQGQVHR0VZBQeHgFAZBUdHRVkFB4eAAAAAAgAAAAABLAETAAPAB8ALwA/AE8AXwBv
+AH8AUgCyDQAAK7BMM7AEzbBEMrAdL7BcM7AUzbBUMrAtL7BsM7AkzbBkMrA9L7B8M7A0zbB0MgGw
+gC+wANayECAwMjIysAnNshgoODIyMrGBASsAMDE9ATQ2OwEyFh0BFAYrASImETU0NjsBMhYdARQG
+KwEiJhE1NDY7ATIWHQEUBisBIiYRNTQ2OwEyFh0BFAYrASImATU0NjMhMhYdARQGIyEiJhE1NDYz
+ITIWHQEUBiMhIiYRNTQ2MyEyFh0BFAYjISImETU0NjMhMhYdARQGIyEiJh0VZBUdHRVkFR0dFWQV
+HR0VZBUdHRVkFR0dFWQVHR0VZBUdHRVkFR0BLB0VAyAVHR0V/OAVHR0VAyAVHR0V/OAVHR0VAyAV
+HR0V/OAVHR0VAyAVHR0V/OAVHTJkFR0dFWQUHh4BQGQVHR0VZBQeHgFAZBUdHRVkFB4eAUBkFR0d
+FWQUHh78kGQVHR0VZBQeHgFAZBUdHRVkFB4eAUBkFR0dFWQUHh4BQGQVHR0VZBQeHgAABv+bAAAE
+sARMAAYACgAaACoAOgBKACAAsAAvsCYzsAHNsC4yAbBLL7FMASsAsQEAERKwBDkwMQM1MzUXBzUT
+MxEjExQWMyEyNj0BNCYjISIGFTUUFjMhMjY9ATQmIyEiBhU1FBYzITI2PQE0JiMhIgYVNRQWOwEy
+Nj0BNCYrASIGFWXJpqbIZGTIHRUCWBQeHhT9qBUdHRUBLBQeHhT+1BUdHRUB9BQeHhT+DBUdHRVk
+FB4eFGQVHQH0ZEt9fUv+DARM++YUHh4UZBUdHRXIFB4eFGQVHR0VyBQeHhRkFR0dFcgUHh4UZBUd
+HRUAAAAABgABAAAFFQRMAA8AHwAvAD8AQwBKABcAskAAACsBsEsvsEDWsEPNsUwBKwAwMTcUFjMh
+MjY9ATQmIyEiBhU1FBYzITI2PQE0JiMhIgYVNRQWMyEyNj0BNCYjISIGFTUUFjsBMjY9ATQmKwEi
+BhUBETMRExc1MzUjNQEdFQJYFB4eFP2oFR0dFQEsFB4eFP7UFR0dFQH0FB4eFP4MFR0dFWQUHh4U
+ZBUdAyBkIafIyDIUHh4UZBUdHRXIFB4eFGQVHR0VyBQeHhRkFR0dFcgUHh4UZBUdHRX75gRM+7QC
+Jn1LZEsAAgAAAMgEsAPoAA8AEgAtALANL7AEzbAEzQGwEy+wANawCc2xFAErsQkAERKwEDkAsQQN
+ERKxERI5OTAxGQE0NjMhMhYVERQGIyEiJgkBESwfAu4fLCwf/RIfLAOEASwBEwKKHywsH/12Hyws
+AWQBLP2oAAADAAAAAASwBEwADwAXAB8AWQCyDQAAK7AfL7AbzbAXL7AEzQGwIC+wANawEM2wEBCx
+GQErsB3NsB0QsRUBK7AJzbEhASuxHRkRErARObAVEbETEjk5ALEfDRESshATFTk5ObAbEbAUOTAx
+NRE0NjMhMhYVERQGIyEiJj8BBScBExEhEjQ2MhYUBiIaEgRYExkZE/uoEhpk9wEqSgEl7PwYbE5w
+Tk5wLAP0EhoaEvwMEhoa7baDnAE+/uAB9P7OcE5OcE4AAgCU//MEHAS9ABQAHgA9ALINAAArsB0v
+sATNAbAfL7AA1rAVzbAVELEbASuwCM2xIAErsRsVERKxDQQ5OQCxHQ0RErIHABg5OTkwMRM0PgEz
+Mh4BFAcOAQ8BLgQnJjcUFjMyNjQmIgaUedF6e9B5SUm7OTkKImNdcys/wpdqa5eX1pYC6XzXgX7V
+9pVy9kJCCSJrb6BLi5Zrl5fWlpcAAAIAAQABBK8ErwAPABUASQCyDQAAK7ATzbAUL7AFzQGwFi+w
+AdawEc2wERCxEwErsAnNsRcBK7ETERESsQ0EOTmwCRGxBQw5OQCxFBMRErMBCAkAJBc5MDESND4C
+Mh4CFA4CIi4BEhAWMxEiAV+g3vTeoF9foN703qBN+7CwAd703qBfX6De9N6gX1+gAgn+nvoDVgAC
+AHUABAPfBQ8AFgAlAAATND4DNx4GFRQOAgcuAjceARc3LgInJjY/AQ4BdURtc3MeFUlPV00/JU5+
+mk9yw4B+DltbEAcWLgoPAgkJXDcBll64oZ3FYEePdndzdYZFWZlkOwQGXrh+UmwaYgYWSihJjTQz
+bpYAAAADAAAAAATFBGgAHAAhACYAVwCyGgAAK7APzbAIL7AEzQGwJy+wANawDM2wDBCxEwErsBbN
+sSgBK7ETDBESswYdHiAkFzmwFhGxHyI5OQCxCA8RErMVHR8hJBc5sAQRsyAiIyUkFzkwMRkBNDYz
+BBcHISIGFREUFjMhMjY9ATcVFAYjISImJTcBJwkBFzcvAeulAW4fuv7JKTs7KQH0KTvI66X+1KXr
+AbShAZxy/msB+XFxFVwBkAEspesGCLo7Kf4MKTs7KX3I4aXr62oyAZxx/msB+HFxVRwAAAAAAgAA
+AAAElQRMABwALgBIALIaAAArsBDNsCIvsCfNsAkvsATNsAQQsAbNAbAvL7AA1rANzbEwASsAsSIQ
+ERKyFR0kOTk5sQkaERKwJTmxBAYRErAmOTAxGQE0NjMhFwYHIyIGFREUFjMhMjY1NxUUBiMhIiYB
+PgMfARUJARUiDgXrpQEFAoVVkSk7OykB9Ck7yOul/tSl6wGnHmdnXx4dAWj+mQcYSENWQzkBkAEs
+petQIFg7Kf4MKTs7KZk1pevrASEmNBMJAQHRAUQBPtgCDhczQ20AAAAAAgAAAAAEqARMAB0AIwBS
+ALIbAAArsBDNsAkvsATNAbAkL7AA1rANzbANELEUASuwF82xJQErsRQNERKzBx4fIiQXObAXEbAh
+OQCxCRARErMWHyIjJBc5sAQRsSAhOTkwMRkBNDYzITIXByEiBhURFBYzITI2PQE3FRQGIyEiJgkC
+JwEn66UBLD1Csv6jKTs7KQH0KTvI66X+1KXrAVYBGwI3if5SkgGQASyl6xexOyn+DCk7OylFyKml
+6+sBjf7kAjeJ/lGTAAABAAAAAQSwBLEAFwBFALISAAArsBYvsA4zsALNsAkyAbAYL7AU1rADMrAQ
+zbAIMrEZASuxEBQRErEGEjk5ALEWEhESsQ0XOTmwAhGxAAw5OTAxEQEVMzUjCQEjFTM1CQE1IxUz
+CQEzNSMVASzIyAEsASfDyAEs/tTIw/7Z/tTIyAJbASjGyAEs/tTIxv7Y/tTGyP7UASzIxgAAAAAB
+AMgAAAOEBEwAEwAdALIRAAArsAszAbAUL7AA1rANzbAIMrEVASsAMDE3ETQ2OwEyFhURAREBERQG
+KwEiJsgdFWQVHQH0/gwdFWQVHTID6BUdHRX+SwHn+7QB6P5KFR0dAAAAAQAAAAAEsARMABcAHwCy
+FQAAK7ENDzMzAbAYL7AA1rARzbAIMrEZASsAMDE1ETQ2OwEyFhURAREBEQERAREUBisBIiYdFWQV
+HQH0AfT+DP4MHRVkFR0yA+gVHR0V/ksB5/4ZAef7tAHo/hgB6P5KFR0dAAABAIgAAASwBEwABgAU
+ALIGAAArsAQzAbAHL7EIASsAMDETAREBEQERiAI0AfT+DAImAib+GQHn+7QB6P4YAAAAAQDIAAAE
+TARMAAIAADMJAcgDhPx8AiYCJgAAAAIAyABkA4QD6AAPAB8AADcUFjsBMjY1ETQmKwEiBhUBFBY7
+ATI2NRE0JisBIgYVyB0VyBUdHRXIFR0BkB0VyBUdHRXIFR2WFR0dFQMgFR0dFfzgFR0dFQMgFR0d
+FQAAAAEAyABkBEwD6AAPAAA3FBYzITI2NRE0JiMhIgYVyB0VAyAVHR0V/OAVHZYUHh4UAyAVHR0V
+AAAAAQAAAAAEKARMAAYAFACyAAAAK7AFMwGwBy+xCAErADAxMREBEQkBEQH0AjT9zARM/hkB5/3a
+/doB6AAAAQAAAAAEsARMABcAHwCyAAAAK7EQFjMzAbAYL7AU1rAEMrANzbEZASsAMDExEQERARE0
+NjsBMhYVERQGKwEiJjURAREB9AH0HRVkFR0dFWQVHf4MBEz+GQHn/hkBtRUdHRX8GBUdHRUBtv4Y
+AegAAAEBLAAAA+gETAATAB0AsgAAACuwDjMBsBQvsBLWsAIysAvNsRUBKwAwMSERARE0NjsBMhYV
+ERQGKwEiJjURASwB9B0VZBUdHRVkFR0ETP4ZAbUVHR0V/BgVHR0VAbYAAAIAZADIBLAEKAAPABIA
+EgCwDS+wBM0BsBMvsRQBKwAwMTc1NDYzITIWHQEUBiMhIiYRIQFkHRUD6BUdHRX8GBUdBEz92vpk
+FR0dFWQVHR0BDwI0AAEAuQAHA/kEqQAFAAATATcJASe5AlDw/p8BYfACV/2w8AFhAWHwAAABARD/
+0gRSBHQACAAAJQkBNwEXBxUBARABYf6f8QI8FQH9sMIBYQFh8P3FFgEB/bEAAAAAAgADAAMErQSt
+AAsAFwBCALAKL7AOzbAVL7AEzQGwGC+wAdawDM2wDBCxEQErsAfNsRkBK7ERDBESswQJCgMkFzkA
+sRUOERKzAQYHACQXOTAxEhASJCAEEhACBCAkEzMVMzUzNSM1IxUjA6ABEwFEAROgoP7t/rz+7YnI
+yMjIyMgBtgFEAROgoP7t/rz+7aCgAVHIyMjIyAACAAMAAwStBK0ACwAPAEkAsAovsAzNsA8vsATN
+AbAQL7AB1rAMzbAMELENASuwB82xEQErsQ0MERKzBAkKAyQXOQCxDAoRErEHADk5sQQPERKxAQY5
+OTAxEhASJCAEEhACBCAkEyE1IQOgARMBRAEToKD+7f68/u2JAlj9qAG2AUQBE6Cg/u3+vP7toKAB
+UcgAAAAAAgADAAMErQStAAsAFwAyALAKL7AEzbAEzQGwGC+wAdawB82wB82xGQErsQcBERKxDBA5
+OQCxBAoRErENFTk5MDESEBIkIAQSEAIEICQTFzcXNyc3JwcnBxcDoAETAUQBE6Cg/u3+vP7tU9WN
+jdWOjtWNjdSNAbYBRAEToKD+7f68/u2goAEo1Y6O1Y2N1I2O1Y0AAAIAAwADBK0ErQALABEAMgCw
+Ci+wBM2wBM0BsBIvsAHWsAfNsAfNsRMBK7EHARESsQwOOTkAsQQKERKxDQ85OTAxEhASJCAEEhAC
+BCAkEwkBJwcnA6ABEwFEAROgoP7t/rz+7WsBFAGbr+xmAbYBRAEToKD+7f68/u2goAGE/usBm67s
+ZgAAAAADAAMAAwStBK0ACwA4ADwAbACwCi+wOc2wPC+wJ82wIS+wG82wNC+wBM0BsD0vsBLWsB7N
+sB4QsS4BK7AHzbE+ASuxHhIRErEhNDk5sC4RtAkEKDo7JBc5ALEnPBESsQcAOTmwIRGwKjmwGxKy
+DA8uOTk5sDQRsQYBOTkwMRIQEiQgBBIQAgQgJBMzMhYyNjQ+BToBMzIWFRQGBw4EFzM+BDU0LgMj
+Ig4CEzM1IwOgARMBRAEToKD+7f68/u3JjwQPBwYCBQIJBA4EEwMTFggXBQ8nHRgByAUSLSIcIzFE
+MRsyUUUmiMjIAbYBRAEToKD+7f68/u2goAIZAgYMCgcFAwIBFBAWDBABBBcfPSYDCikyWDIzTCgY
+Bhg1YP4uZAADAAMAAwStBK0ACwAVABkAOwCwCi+wDM2wFS+wDjOwEs2wES+wFs2wGS+wBM0BsBov
+sRsBKwCxEhURErEHADk5sRYRERKxBgE5OTAxEhASJCAEEhACBCAkNyE1IxEhFTMVIxMzNSMDoAET
+AUQBE6Cg/u3+vP7t7QGQZP7UZGRkyMgBtgFEAROgoP7t/rz+7aCgiWQBLGTIAZBkAAACAAAAAASw
+BLAAGAAvAGkAshQAACuwEi+wH82wHDKwAC+yDhkhMzMzsAHNsgwjLTIyMgGwMC+wFNayBRwpMjIy
+sBPNsgceJzIyMrExASuxExQRErMiIy4vJBc5ALESFBESsBU5sQAfERKwHTmwARGyHigpOTk5MDER
+NTM+ATc1MxUeAhczFSMOAQcVIzUuASczHgEXNTMVNjcjNTMuAScVIzUOAQczFcMfh4vINnZrEsvL
+GbdZyIyIHmAYb0vIlTTJyBllSshLbhjRAfTIfZUayMgUUINFyGaoIcXFG5d9SW0Yzs4wnshKahjM
+yxdsSMgAAAAAAwAEAAQErASsAAsAEwAfAEYAsAovsA/NsBMvsATNAbAgL7AB1rANzbANELERASuw
+B82xIQErsRENERK1BAkKAxQaJBc5ALETDxEStQEGBwAXHSQXOTAxEhASJCAEEhACBCAkEhAWIDYQ
+JiADNyc3FzcXBxcHJwcEoAESAUQBEqCg/u7+vP7uFvMBVvPz/qpJh4dth4dth4dth4cBtgFEARKg
+oP7u/rz+7qCgAl/+qvPzAVbz/duHh22Hh22Hh22HhwAAAAMABAAEBKwErAALABMAGQBGALAKL7AP
+zbATL7AEzQGwGi+wAdawDc2wDRCxEQErsAfNsRsBK7ERDREStQQJCgMUGCQXOQCxEw8RErUBBgcA
+FxkkFzkwMRIQEiQgBBIQAgQgJBIQFiA2ECYgAzcXNxcBBKABEgFEARKgoP7u/rz+7hbzAVbz8/6q
+a41XzI7+pgG2AUQBEqCg/u7+vP7uoKACX/6q8/MBVvP+I41XzY7+pwAAAAMABAAEBKwErAALABMA
+GwBGALAKL7AWzbARL7AEzQGwHC+wAdawDM2wDBCxGQErsAfNsR0BK7EZDBEStQQJCgMPFCQXOQCx
+ERYRErUBBgcADhskFzkwMRIQEiQgBBIQAgQgJBMUFwEmIyIGExYzMjY1NCcEoAESAUQBEqCg/u7+
+vP7uFj4COGR0q/PNYXCr8zsBtgFEARKgoP7u/rz+7qCgAbRzZAI3PvP98jvzq3BhAAAAAAEAAABj
+BLAD6AAGABoAsAUvsALNAbAHL7EIASsAsQIFERKwADkwMREBESERIRECWAJY/agCIwHF/tT+1P7T
+AAABAAAAYwSwA+gABgAaALAAL7ABzQGwBy+xCAErALEBABESsAQ5MDEZASERCQERAlgCWP2oAZAB
+LAEs/jv+QAEtAAAAAAEAzAAABEoEsAAGAB8AsgUAACsBsAcvsAXWsATNsQgBK7EEBRESsAE5ADAx
+EwkBIREhEcwBwgG8/tb+1AJYAlj9qP2oAlgAAAEAaAAAA+YEsAAGAB8AsgYAACsBsAcvsAHWsATN
+sQgBK7EEARESsAY5ADAxEyERIREhAWgBKAEsASr+PwJYAlj9qP2oAAAAAAEAAADHBLAETAANAAA1
+PgM3EQkBEQ4DBkaJ55wCWP2oX7CkgsiE1a1nCAEP/jv+QAEtAiREdQAAAgAAAAAEsASwAAYADQAR
+ALIAAAArAbAOL7EPASsAMDExERcBFwEXExcBFxEhF4EBJo7+2oHrjgEmgf5wgQGQgQEmjv7agQMJ
+jgEmgQGQgQACACIAIwSOBI4ABgANAAA3ASchEScJAREXARcBFyIBJ4EBkIH+2QGogQEnjv7ZgbAB
+J4H+cIL+2QI1AZCBASeN/tmCAAMAFwAXBJkEmQAPAB8AIwBPALANL7AgzbAjL7AUzbAdL7AFzQGw
+JC+wAdawEM2wEBCxGQErsAnNsSUBK7EZEBEStQUMDQQhIyQXOQCxFCMRErEJADk5sB0RsQgBOTkw
+MRI0PgIyHgIUDgIiLgEBEx4BOwEyNjcTNiYrASIGEzM1Ixdbm9Xs1ZtbW5vV7NWbAVY6BCMUNhQj
+BDoEGBTPFRgwyMgB4uzVm1tbm9Xs1ZtbW5sCRv7SFB0dFAEuFB0d/cVkAAAFAAAAAASwBLAAJgAq
+ADAANAA7ADQAsicAACuwMTOwKs2wMjIBsDwvsDHWsAUysDTNsAcysT0BK7E0MREStAsMEzU6JBc5
+ADAxETMVIREzESE1MzUjNjQmLwEuASMiDwEGByYvASYjIgYPAQ4BFBUjEyERIRMiNj8BFxMRIREB
+Nx4DI2QBkMgBkGRvAQMCIgs9JyAd7xYSExXuIR0nPQojAgJvZAGQ/nBkAyITEtXbAZD+j8oFDiAS
+AgMgyAEs/tTIZAELEwisJzARkA0WGAyQEi4msQgUCgH8fAGQAfRgMC+//HwBkP5wA4TFDClXOQAC
+AAD/6gSvBLAAGwAyABcAsgAAACsBsDMvsCfWsA/NsTQBKwAwMRU1Ny4CPgE3PgU3FAIOBC4CIwc2
+Fjc2JT4DNz4BJyYiBgcOAQ8BBAfYCQgDFTguL2llmonoaCxKaHGDeHtcUw9jEidDNwE4RmFrWykW
+BAgHFCERI509Pf6PWRaPwTU8gGKCOzxVMy0eOR69/szQm1UzCQYTDzd/DVNCqCY/X4BUMhQJBR0Z
+M3MgIMXMAAABAG8ADAREBOcASAAjAAGwSS+wAdawRc2wRRCxPAErsUoBK7E8RRESsTo2OTkAMDES
+FBceARcWPgM3PgEnHgEHDgEHDgQeAT4BNz4ENzYCJxYXFicmJy4CNw4EFx4DDgQHBi4CNw4BbwUJ
+RkYfQjo4KA8gDhRPVhEFHxYKCQ8DAwgOGSQYOURrQ0APJqWkFhUnRw8ST1MFMw0qZ0ouDwIMBAgB
+AQsQGhImOhcHDjQ/AblCHjh/LRUKJT49HkLtJ1CoZCFJLBMUIA8XCAsBBAYUHD1DbkOsAVNtLFWf
+BQIHIYbZlQgfZm2nUww7GzQbKBcZEAQKLk1WIC5uAAAD/8MAfQTtBDMAIQA/AEcAQwCwGi+wKc2w
+Oi+wCc0BsEgvsDzWsDfNsUkBK7E3PBESQAoJGRoIKSg1PkBDJBc5ALEJOhEStwARJC41PkJHJBc5
+MDEDNz4GMh4FHwEHDgYiLgUnNx4FMj4ENy4EJxYVFAYiJjU0NwYXFhc3LgEvAT0aBhxGT3N2k5CT
+dnNPRhwGGhoGHEZPc3aTkJN2c09GHAabB0MtW1R6gHdSWSxICwE3HTo5HjGw+LAuZoUxaWklTBMU
+AlgoCihXVGBHLy9HYFRXKAooKAooV1RgRy8vR2BUVygKKApgPV44KygzXDtoDgFJJUU6GUpZfLCw
+fFVJV3N8Q2kYYCQkAAAABP/DAAAE7QSwABYAIAApAEEAoQCyDwAAK7AOMwGwQi+xQwErsDYauj3v
+790AFSsKsA8uDrAMwAWxDgH5DrANwLAPELMLDwwTK7MQDwwTK7MZDwwTK7MaDwwTK7MkDwwTK7Ml
+DwwTK7IQDwwgiiCKIwYOERI5sBk5sBo5sCQ5sCU5sAs5ALcLDA0QGRokJS4uLi4uLi4uAUAKCwwN
+Dg8QGRokJS4uLi4uLi4uLi6wQBoBADAxAzc+BjMyFzczASM3LgQnNxIXNy4BNTQ3BhcWFz8BLgEv
+AQE3PgY3Jic3HgIfAQcOBD0aBhxGT3N2k0g9PCWU/saUJVKmcmknCpvStyVrjy5mhTFpLxceOg8O
+ASgmFi0vIjATLwFhKydDgS4NGhoHJVplkwJYKAooV1RgRy8RjvtQjxVlZ3k4Dyj+5jaNEqduVUlX
+c3xDL1ccUhsa/aeRDyYyJj8YQAJ/MJI2j0AUKCgMNGtiZgAAAAP/ngAABRIErAALABIAFwAAJhYz
+ITI2JwEuAQcBNwkBITUjFREbATUjbxslBQ4lGxX9fhQ4FP1+9QG9Ab3+p8hkZMhEREcgBCAiBSD7
+1mQC0/0tZGQBkP7UASxkAAAAAAEAZAAVBLAEsAApAEgAsB4vsAnNAbAqL7Al1rAFMrAWzbALMrIW
+JQors0AWGAkrsiUWCiuzQCUjCSuxKwErsRYlERKxHR45OQCxCR4RErEWJTk5MDETNTQ2NwERNDYy
+FhURAR4BHQEUBiclERYdARQGLwEjBwYmPQE0NxEFBiZkFg8Ba1h8WAFrDxYYEf6ZZBoTXt5eExpk
+/pkRGAEGKRQxDgFFAVM+WFg+/q3+uw4xFCkUDQz5/vlbFkAUEQlOTgkRFEAWWwEH+QwNABEAAAAA
+BEwEsAAJABsAHwAjACcAKwAvADMANwA7AD8AQwBHAEsATwBTAFcAADUUFjMhMjY1ESE1ITU0JisB
+NSMVITUjFSMiBhUTNTMVJzUzFSc1MxUTNTMVJzUzFSc1MxUTNTMVJzUzFSc1MxUTNTMVJzUzFSc1
+MxUTNTMVJzUzFSc1MxUdFQPoFR37tARMHRWWZP4MZJYVHWRkZGRkZGRkZGRkZGRkZGRkZGRkZGRk
+ZGRkZGRkZDIUHh4UAu5klhUdZGRkZB0V/EpkZMhkZMhkZP5wZGTIZGTIZGT+cGRkyGRkyGRk/nBk
+ZMhkZMhkZP5wZGTIZGTIZGQAAAMAAAADBXgErgAKABAAGQBBALAAL7AYM7ABzbATMrALL7AIM7AQ
+zbADMgGwGi+xGwErALEBABESsREWOTmwCxGzBw0SFSQXObAQErEGDjk5MDE9ASEBMzUJATUjCQEh
+FzcnIQE3FzM1CQE1IwEDAljxASz+1J/9qP6rAQN6jbX+qwKmjXqfASz+1PHIyAJYxv7Z/tTF/agC
+WHqOtP2VjnvG/tn+1MUAAAEAAAAABLAETAASABoAsg4AACuwEC+wDDOwBM0BsBMvsRQBKwAwMRkB
+NDYzITIWFREUBiMhAREjIiY7KQPoKTs7Kf2s/tBkKTsBkAJYKTs7Kf2oKTv+1AEsOwAAAwBkAAAE
+TASwACUAKQAtAGAAsh8AACuwCc2yCR8KK7NACQEJK7AVMrAmL7AqM7AnzbArMgGwLi+wANawJjKw
+A82wKDKwAxCxEgErsCoysBfNsCwysS8BK7EDABESsCQ5sBIRsR4fOTmwFxKwGTkAMDETNSEVFBcW
+FxYzMj4GJzQ9ASEVFA4FIi4FGQEhESERIRFkASwGEVUnNSU7KR8RCwMCAQEsBhgnTWWdwJ1lTScY
+BgEsAZABLAJYyPpxIFwZCwsUHCMoLC4YEQj6yCpSfmpxUDMzUHFqflIBVgEs/tQBLP7UAAAAAAH/
+4gC4BGgD3gAFAAADFwkBNwEe4wFgAWHi/b4Bm+MBYf6f4wJDAAABAEYA2gTMBAAABQAAEwkBJwkB
+RgJEAkLi/p/+oAMd/b0CQ+P+nwFhAAAAAAL/OgBkBXYD6AAIABEAKACwBy+wBM0BsBIvsAfWsATN
+sRMBK7EEBxESsAE5ALEEBxESsA45MDEDCQEjESEXIREBFyERIwkBIxHGASsBLMsBgdf84AGU1wF9
+xgErASvIArwBG/7l/nDIAlgBLMj+cP7lARsCWAAAAAEAEgAABKoEsAAyAEYAsiIAACuwGTOwLM2w
+LBCwJs2xFR0yMrAvL7AEzbAQL7AJzQGwMy+wJNawH82wHxCxHAErsBfNsTQBK7EXHBESsC05ADAx
+EyY3NjMhNz4BOwEyFhQGKwEDDgIrARUUBiImPQEhFRQGIiY9ASMiJjU0NjMhNyEiJicSBQ8OGQOA
+JgUbEV4UHh4UNskCCB4SHx0qHf7UHSodMhUdHRUCFzD9hyAtBQOrGBITohEVHSod/D8EDRYyFB4e
+FDIyFB4eFDIeFBUdyCoWAAAAAAIAAAAABLAETAADAA8AIACyAAAAK7ABzbAEL7AFzbANMrAJzQGw
+EC+xEQErADAxMREhEQE1MzQ2MyEyFhUhFQSw+1DIOykBLCk7AfQDIPzgA4RkKTs7KWQAAAAAAgAB
+AAAF3QRMAAMAEAAoALIAAAArsAHNsA8vsA3NsAUysAnNAbARL7ESASsAsQEAERKwBDkwMTMBIQkB
+ETM0NjMhMhYVIRUhAQEsBLD+1PtQyDspASwpOwH0/BgCvP1EAZACWCk7OynIAAAAAQEuAAADggSw
+AAkAIQCyCQAAKwGwCi+wAdawB82xCwErsQcBERKxBAk5OQAwMQEzESMJASMRMwEBLsbGASoBKsbG
+/tYBLAJYASz+1P2o/tQAAAAAAQAAAS8EsAOCAAkAHACwCC+wAs0BsAovsQsBKwCxAggRErEABTk5
+MDERARUhNQkBNSEVASwCWAEs/tT9qAJYASrGxv7W/tfFxQAAAAQAAAAABLAEsAAPABkAHQAhAEkA
+sgwAACuwGs2wHjKwHS+wIDOwBc2wEC+wFM0BsCIvsBvWsB7NsB4QsR8BK7AJzbIfCQors0AfAAkr
+sSMBK7EJHxESsBk5ADAxPQE0NjMhMhYdARQGIyEiJhsBPgEzITIWFxMBMzUjFzM1IzspA+gpOzsp
+/BgpOx+sBSQUAqATJQWs/o9kZMhkZGRkKTs7KWQpOzsBVQLjFictF/0k/tRkZGQAAAAD/5sAZASw
+BEwACwApADcAJgABsDgvsADWsAbNsAYQsSoBK7AyzbE5ASuxKgYRErEMGjk5ADAxAzU0Nj8BFS4E
+FzU8Az4FOwElESUjExYOASMiKwEiJicCARE0NjMyFhURFAYjIiZlMhkZBA4iGhbJAQICBAUHBMgC
+o/1dJi8CCgwPBQNTFB0ENwPoHRUUHh4UFR0CWDIYMg0N+gIHFRYhVfoCDAQKBAcDBQIB+vyuyP7s
+DAsBHBUBUf7iA1IVHR0V/K4UHh4AAAIASgAABGYEsAArADMANQCyLwAAK7AzzbApL7AfM7ADzbAY
+MrIpAwors0ApJQkrAbA0L7E1ASsAsSkzERKxLDE5OTAxEzQ2OwE3Ez4BNycmNjsBMhYHBhUeARcT
+FzMyFhUUBgcOBCMiJi8BLgEFHgEyNjcGIkobFBJ1Pw96UxIGEhReFBIGElN6Dz92ERQbGhIIHmRq
+n0998To6EhoBpww4RjgLMGwBXhUdrQFHTX4UIBMaFRMkARN/Tf65rR0VFCgHAwsdFRIpFBQHKdwx
+PT0xBgAAAQAVABUEnAScABcAABMXBzcXNxc3Fyc3JzcnNwcnBycHJxcHFxXpTuAtm5st4E7qtLTq
+TuAtm5st4E7pswG9LeBO6bOz6U7gLZucLOFO6bS06U7hLJwAAAMAAABkBLAEsAADACIALgAaAAGw
+Ly+wKNawFs2xMAErsRYoERKwFDkAMDE1MxEjARQ7ARY7ATI3EzY9ATQmIyE2PQE0JisBIgYPAgYV
+ExE/ATMVByEVAyMnyMgBLGQ9fA/6LiXuHT0n/rgcPScyGzAOYJEUZJZkMjIBwvrWiMgCWP3zS2Q5
+AVgfK2QsUXYHlixRKBzGxBol/okBd9XUr+F9/olkAAAAAAMAAAAABLAETAADACIALgBwALIcAAAr
+sCXNsBUvsAAzsCjNsC4vsAfNsAEysCwvsArNAbAvL7AA1rADzbADELEEASuwI82wIxCxJgErsBjN
+sBgQsSkBK7ARzbEwASuxJiMRErIIKCw5OTmwGBGwFTmwKRKwKzkAsS4cERKwKjkwMRkBMxE3ETQ7
+ATY7ATIXExYdARQGIyEWHQEUBisBIiYvAiY3HwEzNSchNQMjByPIZGQ9fA/6LiXuHT0n/rgcPScy
+GzAOYJEUZJZkMjIBwvrWiGQBkAJY/ah9AZBLZDn+qB8rZCxRdgeWLFEoHMbEGiXU1a/hfQF3ZAAA
+AAMACABkBRUEVQADACIAQQB5ALAgL7AkzbAbL7ApzbAxL7AUzbABMrIxFAors0AxAAkrAbBCL7AA
+1rADzbADELEEASuwI82wIxCxLQErsBjNsi0YCiuzQC08CSuxQwErsS0jERK0DBEbFD8kFzkAsRsk
+ERKwIzmwKRGwGDmxFDERErIXPEE5OTkwMTcRMxE3ETQ2PwElNjMyHwEWFRQPASEyFhQGKwEDDgEj
+ISImNxchEz4BOwEyNjU0JiMhKgIuBCcmNTQ/AScFCMhkHA4OAWoOCxEMbQ4LVQEuVWttVGuCBxsP
+/qsHpmRkASWDBhsPyxASEhD+NwELBAkDBwQEAgUKk1b+rcgCWP2oSwINESUKCeYGDHAOFBIOeUyQ
+Tv6tFieiG1kBUxUoHhUUHQEBAgMFAwwIDg23U+wAAAAD/5sAZQSwBFYAHgA4ADwAeQCwGC+wJM2w
+HS+wH82wOC+wA82wOjKyOAMKK7NAODkJKwGwPS+wAdawH82yHwEKK7NAHywJK7AfELEmASuwFM2w
+FBCxOQErsDzNsT4BK7EmHxEStAcMHAQpJBc5ALEdJBESsCY5sB8RsAA5sQM4ERKyAScsOTk5MDEC
+NDYzBScmNTQ/ATYzMhcFHgIVERQGIyEiJicDIyInMzIWFxMhNxElBxcWFRQHDgUqASMhAREzEWVs
+VQEuVQsObQ0QCw4BbQcUIawI/qsQGwaCa1QK3g8bBoMBJWv+qVeRCgUBBQMHBAkECwH+JAPpyAJD
+kEwBeRAQFQ1xDAbmBA0nEf3yDaEoFQFTZCkU/q1ZAfbtU7gLDwsJAwUDAgEB/gwCWP2oAAAAAAMA
+YQAABEwFDgAbADYAOgBHALI3AAArsDjNAbA7L7AV1rA3MrApzbIpFQors0ApOgkrsDMysCkQsS8B
+K7AOzbE8ASuxKRURErESNjk5sQ4vERKwETkAMDEbAR4CMyEyNjURNCYnJTU0JiIGFREnJgYPAQYX
+NxcWNz4FPAE1ETQ2Fh0BFBYXBREHIQM1IRVh5gQNJxECDQ2iKBX+rU6QTHkPJQ5wFltTtxYZAwUD
+AgEBMjIoFQFTWf4JCAJYAs/+lQYTH6YHAVYPGwaDalRua1X+0lQMAQ1uFgtWkhINAQUDBwQJBAsB
+AcgWEhMVyhAbBoL+2mT+cMjIAAAAAAMAAgAKA+0FGAAdADQAOABFALA1L7A2zQGwOS+wCtawNTKw
+K82yKwoKK7NAKzgJK7AhMrArELEnASuwD82xOgErsSsKERKxDB85ObEPJxESsA05ADAxEwYfAR4B
+PwEUBhUUFjI2PQElPgE1ETQmIyEiBg8BAxMhFxEFDgEdARQGJjURPAEuAScmDwETNSEVAhAWcA0m
+D3kBTZBOAVMUKaIN/fMRJQoKmuwB91n+rBQoMjIDBwYYFriSAlgCSR8Wbg0BC1UzzS5UbG5UaoMG
+Gw8BVgemHA4P/oIBU2T+2oIGHA/KFhISFgHICwcQCAMNEpICccjIAAAAAgAFAAAEsASrAA4AFQA6
+ALIMAAArsBDNsA8vsAXNAbAWL7AA1rAQzbEXASsAsRAMERKxCRI5ObAPEbEAEzk5sAUSsQgUOTkw
+MRM0PgIzMgQSEAIEICQCARchBwkBFQVfoN16ogEToKD+7f68/uygASUCASwCAZL+bgJVet2gX6D+
+7P68/u2goAETAQrJwgEmASrFAAIAAAAABKsEqwAQABcAOACyDgAAK7AUzbAWL7AFzQGwGC+wFNaw
+Cs2xGQErALEUDhESsBI5sBYRsgoAETk5ObAFErAXOTAxETQ+AjMyHgIVFAIEICQCNwEnITchNV+g
+3Xl63aBfoP7s/rz+7aDIAZICASwC/tQCVXrdoF9foN16ov7toKABE6X+2sLJxQAAAAIABQAABLAE
+qwAOABUAPgCyDAAAK7ARzQGwFi+wANawEc2wERCxEgErsAnNsRcBK7ERABESsQwPOTmwEhGxBRU5
+ObAJErELFDk5ADAxEzQ+AjMyBBIQAgQgJAIlMxEzETMBBV+g3XqiAROgoP7t/rz+7KABJ8jIyP7U
+AlV63aBfoP7s/rz+7aCgAROl/tQBLAGQAAACAAUAAASwBKsADgAVAE0AsgwAACuwFC+wBc0BsBYv
+sADWsBXNsBUQsRIBK7AJzbEXASuxFQARErEMDzk5sBIRsQUQOTmwCRKxCxE5OQCxFAwRErIIABA5
+OTkwMRM0PgIzMgQSEAIEICQCJQkBIxEjEQVfoN16ogEToKD+7f68/uygAScBLAEsyMgCVXrdoF+g
+/uz+vP7toKABE6X+cAGQASz+1AAAAAAEAAUAAASwBKsAEACIAJgAmgB8ALIOAAArsCrNsE8vsIwv
+AbCbL7AA1rAUzbAUELFYASuwCs2xnAErsRQAERKwEjmwWBFADg4FEyEjJDxKVXiEhYmUJBc5sAoS
+QAoNIiYwO1pndpmaJBc5ALFPKhEStxYwNjxGSFVXJBc5sIwRQAkKABRYbIWNjpQkFzkwMRM0PgIz
+Mh4CFRQCBCAkAhMGFgcUFgcyHgEXFhceAjcWBhcWFxQOARcWNz4CNy4BJy4BJyIOAgcGJyY2NS4B
+JzYuAQcGJyY3NjceAhceAR8BNDYnJjY3PgM3JjcyFjI2Ny4DJzYnHgE/ATYuAScGJw4DBwYmBw4B
+BwYWBw4BJT4BNxYyPgE3FBYVLgM3MwVfoN16ed2gX6D+7f68/uyg+QgbBiIBDBYYCBhUFj45HQgu
+AyotBgEFaHUeIiMDDi4NDkYRCT0gLhAyEAQBBikEAggZGhcTEwsGEAYoGwYMKA4OEwQEJQQFCgcY
+FgYQCB8SFwkKKSM/DAsJHzYMCwcvUg8TEg8rGj4IDz0PFT4DAxMBAzEBAwMaAwoRCxIHIgksHCSi
+AQJVet2gX1+g3Xqi/u2goAETAVkhdxwJRhkLEwQMHggvHgQSShRHCQYTCgwDcx0kPh8JAQcHEAsB
+AgsLIxcCLwINCAMWJhIdGR0cHhAGAQEHChMlCQgDSRUXKwoOKhQZCRITAwkLFycVIAcnBQ0DBQQk
+IxYMAwMMEgYKAQMHBgcnDwsXByJxcQwkBwoMEQQYVQECBgQMXwAAAAABAAAAAgSvBIUAFAAAPAE3
+ASY2NzYXBRc3FgcGJwEGIi8BDwJYIU5gpI7+/ZH7DaR7gv2sDysPb48rEAJXZck2XGWK6H6vXEYv
+/awQEG4AAAYAAABgBLAErAAPAB8ALwAzADcAOwBQALAML7A0zbA3L7AFzbAcL7AwzbAzL7AVzbAs
+L7A4zbA7L7AlzQGwPC+wNdaxMTkyMrAJzbEYKDIysjUJCiuzQDUACSuxECAyMrE9ASsAMDE9ATQ2
+MyEyFh0BFAYjISImETU0NjMhMhYdARQGIyEiJhE1NDYzITIWHQEUBiMhIiYBITUhEyE1IRMzNSM7
+KQPoKTs7KfwYKTs7KQPoKTs7KfwYKTs7KQPoKTs7KfwYKTsCWAH0/gzIASz+1GTIyMRkKTs7KWQp
+OzsBuWQpOzspZCk7OwG5ZCk7OylkKTs7/plk/gxkArxkAAACAGQAAARMBLAAAwAJACUAsggAACuw
+AC+wAc0BsAovsAjWsAfNsQsBKwCxAAgRErAEOTAxEzUhFQUhAREHEWQD6PxKA4T+osgETGRkZP4M
+/tTIAfQAAAAAAwAAAGQEsASwAAkAIQAlAGAAsAcvsAHNsAovsB0zsA7NsRgiMjKwJS+wE80BsCYv
+sA/WsCLNsCAysg8iCiuzQA8LCSuwADKwIhCxIwErsB4ysBjNshgjCiuzQBgcCSuwAjKxJwErALEO
+ChESsB85MDE9ASEVFAYjISImGQE0NjMhNTQ2OwEyFh0BITIWFREhNSMVETM1IwSwOyn8GCk7OykB
+LDspyCk7ASwpO/4MyMjIyMjIKTs7AVUBkCk7ZCk7OylkOyn+cGRkAfRkAAAAAAQAAAAABLAEsAAG
+AA0AFAAbABQAsgAAACuwEjMBsBwvsR0BKwAwMTERFzcXBxcBNxc3JzchATcXNxEhNwM3JyERJweB
+yI7Igf5wgciOyIH+cALZjsiB/nCByMiBAZCByAGQgciOyIEDIIHIjsiB/JmOyIH+cIEC5siB/nCB
+yAAABgAAAAAEqASoAAsAFQAfACkAQgBMANIAsgoAACuwD82wHi+wSjOwGc2wRTKwKC+wOTOwI82w
+NDKyKCMKK7NAKEEJK7AUL7AEzQGwTS+wAdawDM2wDBCxFwErsBvNsBsQsSELK7AmzbAmELEqASuw
+Ps2wPhCxQwErsEjNszdIQwgrsDHNsDEvsDfNsEgQsREBK7AHzbFOASuxJhsRErMKDhQDJBc5sT4q
+ERKxLTw5ObE3MREStQkPEwQvOyQXOQCxHg8RErMHAAwRJBc5sBkRsyotPD4kFzmwKBKxBgE5ObAj
+EbEvOzk5MDEYARIkIAQSEAIEICQTFBYgNjU0JiAGFjQ2MhYVFAYjIjY0NjMyFhQGIyIXNDY/AiY1
+NDYzMhYUBiMiJwcWFRQGIiYlNDYyFhQGIyImoAESAUQBEqCg/u7+vP7uFvMBVvPz/qrzbR8uICAX
+Fk0gFxYgIBYXUikfegEJIBcWICAWDg83ETNIMwEeIC4fIBYXIAGyAUQBEqCg/u7+vP7uoKABtKzy
+8qyr8/OHLh8gFhcg5CwhIC4guiAxBX4BDg4WISAuIAqRFh0kMzNSFiAfLiAgAAAAAf/YADsEugSw
+AE8AOgCwBS+wJ82wIC+wFc2wNi+wSs0BsFAvsVEBKwCxJwURErA/ObAgEbQLDxobMSQXObAVErEy
+Mzk5MDECBhceATMyNz4CNzY3AT4BJyYnJiMiBgcBBxcBNjc2MzIXFgcBBiMiJicmPgI3NjcBPgIz
+MhceAQcGDwEDHwEBPgEnLgEnJiMiBwYHARsaMCN2Rj84IUApJygRAYojGA8bWhQJLkEj/nsHRQF5
+FBMXGyYPECT93TRJN1oJBQ8wJCYYFAFcND1rNhkXX3YIB1v8/QdFAgVDOBEQZk9FU2taKEf+AAHW
+vk45QBwQMSorLBEBiiNiL1cRAiEj/nQHQwF1FhAXJCck/d00Qj8jPkAkJBUUAVw0NzUEEZtiZVv5
+/wAHPAH/Q7RdV4YkITcYR/4AAAAAAAIAUAA2BMMEWAAbADUAPQCwMy+wLTOwA82wBzIBsDYvsADW
+sBzNsBwQsSoBK7AKzbE3ASuxKhwRErMDBw8YJBc5ALEDMxESsAU5MDETNDYzMhc2MzIWFRQOAgcG
+DwEnLgInLgM3FB4BHwEWFzY/AT4CNTQmIyIPAScmIyIGUMWEj2Jnj4HCI1dDR8VgERArckZCR0NX
+I6o9PkAWXWFScQxAQz5gOUo6dnIzSDxjAxCDxYGBxYMuWmxHRr+DFxc6gUZBRkdsWi4bVkE+Flpv
+XG8MPkZYHEdhU6uuUGMAAAAAAgA5//IEdwS+ABgAMwAAExQfARYzMjcBNjQvASYnBxcBJzcnJicH
+BhMUHwEWFzcnARcHFxYXNz4BNTQvASYjIgcBBjlCjURbXUIBG0JCjQgLadT+e/dfEi4dN0LUQo0H
+DGnUAYX3XxIvHh0jN0KNQl1fQP7lQgFhX0COQkIBG0K6Qo0JCGnU/nv4XxItODdCAQRdQo0HCmnU
+AYX3YBExMx0jaitdQo1CQv7lQAAAAAADAMgAAAPoBLAAEQAVAB0ARQCyDwAAK7AZzbAdL7ASzbAV
+L7AGzQGwHi+wANawEs2wEhCxEwErsAvNsAsQsBvNsBsvsR8BK7EbEhESsgYFFjk5OQAwMTcRND4C
+Mh4CFREUBiMhIiY3IREhEhQWMjY0JiLIPGacqppkOjsp/agpO2QCWP2oxD1WPT1WZAO5FTIuHh4u
+MhX8Ryk7O/ECvPzZVj09Vj0AAAABAAAAAASwBLAAGAARALIAAAArAbAZL7EaASsAMDExATcnIQEn
+JjQ3NjIXARYUBwYiLwEBEScHAS/P0gEsAQsjDw8OKg4BGw8PDioOJP7p1NABfNDUARckDioODw/+
+5g8qDg8PI/71/tTSzwADAScAEgQJBOEAMQA9AEMAlwCwLS+wKjOwBM2wPjKyLQQKK7NALSwJK7A7
+L7AfM7ASzbISOwors0ASEwkrAbBEL7AO1rAAMrAyzbABzbAyELEsASuyBBI6MjIysCvNshQfPjIy
+MrArELFAASuwJ82wHCDWEbAbzbFFASuxMgERErACObAsEbAJOQCxBC0RErApObA7EbYADhsnOkBD
+JBc5sBISsBU5MDEBMx4BFxEuASMuBDU0PgE3NTMVHgQXIy4BJxEXHgQVFAYHFSM1JicuARMUHgMX
+FhcRDgETNjU0JicBJ4sFV0oGEwIuQk4vIViCT2QmRVI8KwOfCDZKQCI8UDcosptkmFUoGagQESoU
+HAcEPUnqqlhSAbFNYw8BTwEGDhkvOVg3XIdDB05PBBMsP2lCSEsN/s0OBxMsPGU+i6oLTU4RVyhr
+Ah4dLBgVBgcCAQESCDv9KxKFQEcZAAAAAQBkAGYDlAStAEMAjQCwMS+wKs2wAC+wHjOwAc2wHDKw
+Ey+wC82yEwsKK7NAEw4JKwGwRC+wB9awOTKwGM2wJDKyGAcKK7NAGB4JK7IHGAors0AHAAkrsBgQ
+sQ8BK7AOzbFFASuxGAcRErMCOEJDJBc5sA8RtQsfICoxMyQXObAOErAsOQCxKjERErEtOTk5sAAR
+sSw8OTkwMRM1MyYnLgE+ATc2MzIWFSM0LgEjIgYHBhUUHgEXMxUjFgYHBgc+ATM2FjMyNxcOAiMi
+JgcOAQ8BJz4FNz4BJ2SmGBQKCQMvLWGmgcqZRFAkJVQUKSEXHvHFCBUVKTojYhUhjCFMPDIpTycq
+F9IyJ1YXGDcGFQoRDBEJMAwkAlhkMTcaO1ZeKFiydzRLHB0VLDkcUyozZDKCHTs2Cw4BIh6TGRcD
+QgQEGgwLkQQOBg0LEQo3j0cAAgACAAAErgSwAAYADQAfALIMAAArAbAOL7AM1rALzbEPASuxCwwR
+ErAIOQAwMRMJASMRIxEJAiMRIxECASoBKsbIAZIBKgEqxsgBLP7UASwDhPx8AlgBLP7U/HwDhAAA
+BQACAAAD6ASwAAYADAAWAB4AIgCmALIHAAArsAYzsArNsgcAACuwCM2wEy+wFM2xAAQyMrANL7AO
+zbAdL7AfzbIdHwors0AdFwkrsBoysCIvsBjNsAIyAbAjL7AB1rAEzbAEELEIASuxDRcyMrAKzbEd
+HzIysAoQsRUBK7EbIDIysBDNsQsZMjKzEhAVCCuwE82wEy+wEs2xJAErsQQBERKwBjmwCBGwBTkA
+sRQIERKwEDmwDRGwETkwMRMzETMRMwEhNTMVMxUBNSEVIxUjNTM1AxEhESM1IxU3MzUjAsbIxv7W
+AZBkyP7UASxjZGPIASxkZAFkZAEsA4T8fP7UyGRkAZBkyGRkZAEsAfT+DGRkyMgABQACAAAD6ASw
+AAYADgAUAB4AIgCgALIGAAArsQcKMzOwDS+wH82wIi+wCM2wDy+wEs2wEM2wGy+wHM2wFS+wFs2w
+AjIBsCMvsAHWsATNsAQQsQcBK7EPFTIysA7NsREfMjKwDhCxCwErsR0gMjKwCs2xExcyMrMaCgsI
+K7AbzbAbL7AazbEkASuxBAERErAGObAHEbAFOQCxIh8RErMBBAUAJBc5sRwQERKwGDmwFRGwGTkw
+MRMzETMRMwEhESERIzUjFQM1MxUzFQE1IRUjFSM1MzUDMzUjAsbIxv7WAZABLGRkZGTI/tQBLGNk
+Y2NkZAEsA4T8fP7UAfT+DGRkArzIZGQBkGTIZGRk/HzIAAAEAAIAAARMBLAABgAMABIAFgBrALIL
+AAArsAwvsBPNsBYvsAjNsA0vsA7Nsg0OCiuzQA0RCSsBsBcvsBHWsBDNsxMQEQgrsAfNsAcvsA0z
+sBPNsBAQsRQLK7ALMrAKzbEYASsAsQgLERK0AAIDBgEkFzmxDg0RErEFBDk5MDETCQEjESMRBREh
+ESM1AzUzESMREzM1IwIBKgEqxsgCWAEsZMjIZAFkZAEs/tQBLAOE/HzIAZD+DGQD6GT+DAGQ/HzI
+AAAABAACAAAETASwAAYADAASABYAawCyCwAAK7AHL7AIzbASL7ATzbISEwors0ASEAkrsBYvsA7N
+AbAXL7AL1rAKzbMTCgsIK7ANzbANL7AHM7ATzbAKELEUCyuwETKwEM2xGAErALETCxEStAACAwYB
+JBc5sQ4WERKxBQQ5OTAxEwkBIxEjESU1MxEjEQMRIREjNSczNSMCASoBKsbIAljIZGQBLGRjZGQB
+LP7UASwDhPx8ZGT+DAGQAZABkP4MZGTIAAAAAAUAAgAABLAEsAAGAAoADgASABYAUgCwBy+wCM2w
+Cy+wDM2wDy+wEM2wEy+wFM0BsBcvsA/WsgcLEzIyMrASzbAWzbIWDwors0AWCgkrs0AWDgkrsRgB
+KwCxCwgRErMCAwYAJBc5MDETCQEjESMRBTUhFQE1IRUBNSEVATUzFQIBKgEqxsgB9AH0/gwBkP5w
+ASz+1MgBLP7UASwDhPx8yMjIASzIyAEsyMgBLMjIAAAABQACAAAEsASwAAYACgAOABIAFgBSALAH
+L7AIzbALL7AMzbAPL7AQzbATL7AUzQGwFy+wC9ayBw8TMjIysA7NsArNsgoLCiuzQAoSCSuzQAoW
+CSuxGAErALELCBESswIDBgAkFzkwMRMJASMRIxEFNTMVAzUhFQE1IRUBNSEVAgEqASrGyAH0yMgB
+LP7UAZD+cAH0ASz+1AEsA4T8fMjIyAEsyMgBLMjIASzIyAAAAAACAAAAAARMBEwADwAfACoAsg0A
+ACuwE82wHC+wBM0BsCAvsADWsBDNsBAQsRcBK7AJzbEhASsAMDEZATQ2MyEyFhURFAYjISImNxQW
+MyEyNjURNCYjISIGFeulASyi7u2j/tSl68g7KQH0KTs7Kf4MKTsBkAEspevto/7UpevrQSk7OykB
+9Ck7OykAAAMAAAAABEwETAAPAB8AIgA+ALINAAArsBPNsBwvsATNAbAjL7AA1rAQzbAQELEXASuw
+Cc2xJAErsRcQERKxICE5OQCxHBMRErEgIjk5MDEZATQ2MyEyFhURFAYjISImNxQWMyEyNjURNCYj
+ISIGFRMtAe6iASyl6+ul/tSj7cg7KQH0KTs7Kf4MKTvIAU3+swGQASyj7eul/tSl6+tBKTs7KQH0
+KTs7Kf4M+voAAAAAAwAAAAAETARMAA8AHwAiAD4Asg0AACuwE82wHC+wBM0BsCMvsADWsBDNsBAQ
+sRcBK7AJzbEkASuxFxARErEgIjk5ALEcExESsSAhOTkwMRkBNDYzITIWFREUBiMhIiY3FBYzITI2
+NRE0JiMhIgYVFxsB66UBLKPt66X+1KXryDspAfQpOzsp/gwpO2T6+gGQASyj7e6i/tSl6+tBKTs7
+KQH0KTs7KWT+swFNAAMAAAAABEwETAAPAB8AIgA+ALINAAArsBPNsBwvsATNAbAjL7AA1rAQzbAQ
+ELEXASuwCc2xJAErsRcQERKxICE5OQCxHBMRErEgIjk5MDEZATQ2MyEyFhURFAYjISImNxQWMyEy
+NjURNCYjISIGFRMhA+ulASyl6+2j/tSl68g7KQH0KTs7Kf4MKTtkAfT6AZABLKXr66X+1KLu7T8p
+OzspAfQpOzsp/nABTQACAAAAAAUUBEwABgAaADwAsgcAACuwCM2wAC+wAc2wES+wEs0BsBsvsAzW
+sBfNsRwBKwCxCAcRErAFObEBABESsAQ5sBERsAM5MDEZASE1CQE1EzUhMjY1ETQmIyE1ITIWFREU
+BiMBLAGQ/nDIAfQpOzsp/gwBkKXr66UBkAEsyP6i/qLI/nDIOykB9Ck7yOul/tSl6wAAAAEA2QAC
+A9YEngAhACgAsA4vsBPNAbAiL7Ac1rAWzbEjASuxFhwRErAZOQCxEw4RErAPOTAxExYzIQIHBh8B
+MzI3NgAzNicmIwU2Ejc2LwEjIgcOAQAHBtkIFwEumwUFCQkJDgwLAg8BDgkIF/7TAZoCAgcJCQ8K
+BLz+80sQAgcT/koUFQsIDw0CaRMREQEEAa8MDwwJEAbT/tFWEwAAAAACAAAAAAUUBEwAGAAfAD8A
+sgMAACuwCM2wCBCwBs2wGS+wGs2wEC+wEs2wFM0BsCAvsADWsAvNsSEBKwCxGgMRErEdHjk5sBAR
+sBw5MDERFBYzITI3NSEiJjURNDYzITUuAS8BIgYVAREhNQkBNeulASwvNf4MKTs7KQH0DshdXaXr
+AlgBLAGQ/nABkKXrD7k7KQH0KTu5BAcCAuul/tQBLMj+ov6iyAACAAAAAASwBLAAHQAkAFQAsgMA
+ACuwD82wFi+wGs0BsCUvsADWsBLNsBIQsQsBK7AHzbEmASuxCxIRErUYGR4fICQkFzmwBxGwIzkA
+sRYPERK1CAkeIiMkJBc5sBoRsB85MDERFBYzITI2PQEnBxUUBiMhIiY1ETQ2OwE3JyMiBhUlASch
+EScB66UBLKPtTno7Kf4MKTs7KZx2SmSl6wHwAWGVAfSV/qoBkKXr66ViSXuUKTs7KQH0KTt6Tuul
+CQFWlf4Mlf6fAAMABAAEBKwErAALABMAGwBaALAKL7APzbAbL7AXzbATL7AEzQGwHC+wAdawDc2w
+DRCxFQErsBnNsBkQsREBK7AHzbEdASuxGRURErcECQoODxITAyQXOQCxFxsRErcBBgcMDRARACQX
+OTAxEhASJCAEEhACBCAkEhAWIDYQJiACNDYyFhQGIgSgARIBRAESoKD+7v68/u4W8wFW8/P+qhdy
+oHJyoAG2AUQBEqCg/u7+vP7uoKACX/6q8/MBVvP+EqBycqByAAAAAwAAAAAETASwAAkAEAAUAC4A
+sgkAACuwEc2wFC+wBc2wCzIBsBUvsBLWsAjNshIICiuzQBIACSuxFgErADAxMRE0NjMhMhYVEQkC
+IREhEQEzNSMOCwQYCxD8GAG9AcL+2f7UAfRkZAETCw4PCv7tAyD+DAH0AZD+cP12MgAAAAADAAAA
+AARMBLAACQAQABQAKwCyCQAAK7ARzbAUL7AFzQGwFS+wEtawCM2yEggKK7NAEgAJK7EWASsAMDEx
+ETQ2MyEyFhURASERIREhCQEzNSMOCwQYCxD8GAEsASwBJ/5DAV5kZAETCw4PCv7tArz+1AEsAfT7
+5jIAAAAAAwAAAAAETAR/AAkADwATAC4AsgkAACuwEM2wEy+wBc0BsBQvsBHWsAwysAjNshEICiuz
+QBEACSuxFQErADAxMRE0NjMhMhYVEQkCJwEnATM1Iw4LBBgLEPwYATECVJr+RpYChWRkARMLDg8K
+/u0Cwf7PAlSb/kaX/ToyAAQAAAAABEwEsAAJAA0AFAAYACsAsgkAACuwFc2wGC+wBc0BsBkvsBbW
+sAjNshYICiuzQBYACSuxGgErADAxMRE0NjMhMhYVEQEXNycDJRMHJwcXATM1Iw4LBBgLEPwYYdRh
+cAK5A/qV1JUBzmRkARMLDg8K/u0D3GLVYfzgAQK775XUlf4NMgAEAAAAAARMBLAACQANABQAGAAu
+ALIJAAArsBXNsBgvsAXNAbAZL7AW1rATMrAIzbIWCAors0AWAAkrsRoBKwAwMTERNDYzITIWFREB
+FzcnExcHFzcXCwEzNSMOCwQYCxD8fNRi1QPvldSV+QFjZGQBEwsODwr+7QJk1GHUAev6ldSU7QK5
+++kyAAAAAAIAF///BLAErwAFAAgAFwCyBAAAKwGwCS+wBdawBs2xCgErADAxEwERCQERFwkBFwSZ
+/iX+yk8CoP1gAZ8DEPvJARD+dwGgzQOq/TgAAAAAAgAAAGQETASwABUAGQBNALARL7AGzbIRBgor
+s0AREwkrsA4ysgYRCiuzQAYECSuwCDIBsBovsADWsBLNsAbNsBIQsQ8BK7ALzbEbASuxDwYRErIJ
+Fhc5OTkAMDE1ETQ2OwERIREzFxEUBisBESERIyImATM1Ix0V+gH0ZMgeFJb9RJYVHQJYZGSWA+gU
+Hv7UASzI/K4VHQGQ/nAdA2fIAAMAAAA+BRQEsAATABkAHQBAALAPL7AGzbIPBgors0APEQkrsgYP
+CiuzQAYECSuwCDIBsB4vsADWsBDNsAbNsR8BKwCxBg8RErILFxg5OTkwMTURNDY7AREhETMXFQEn
+ByERIyImJTcXARcBAzM1Ix0V+gH0ZMj+7Hh+/oaWFR0CRXt4AWF7/iXhZGSWA+gUHv7UASzI2v7t
+eH/+cB2xe3gBYHv+JAOqyAAAAAADAAAABgUOBLAAEwAXACMAFQABsCQvsADWsBDNsAbNsSUBKwAw
+MTURNDY7AREhETMXEQcnASERIyImATM1IxM3JzcXNxcHFwcnBx0V+gH0ZMhnqv7W/reWFR0CWGRk
+ZKqqf6qqf6qqf6qqlgPoFB7+1AEsyP7zZ6r+1v5wHQNnyPvVqqp/qqqAqap/qqoAAAADAAAAAASw
+BLAAEgAZAB0AbACwDi+wBs2yDgYKK7NADhAJK7AGELAMzbAaL7AbzbEECDIyAbAeL7AA1rAPzbIP
+AAors0APCwkrsAAQsAbNsA8QsRoBK7AdzbAMMrEfASuxGgYRErATOQCxDA4RErEXGDk5sRoGERKw
+CjkwMTURNDY7AREhETMXESEVIREjIiYlCQEjESMRAzUzFR0V+gH0ZMj+cP4MlhUdAlgBLAEsyMjI
+ZJYD6BQe/tQBLMj+1Mj+cB2r/tQBLAEs/tQCvMjIAAAAAAMAAAAABLAEsAASABkAHQBbALAOL7AG
+zbIOBgors0AOEAkrsBovsBvNsQQIMjIBsB4vsADWsA/NsAbNsA8QsRoBK7AdzbEfASuxGgYRErAT
+ObAdEbANOQCxBg4RErILDBk5OTmwGhGwCjkwMTURNDY7AREhETMXEScBIREjIiYlMxEzETMJATUz
+FR0V+gH0ZMjI/tb+bpYVHQJYyMjI/tT+1GSWA+gUHv7UASzI/m7I/tb+cB2r/tQBLAEsAZDIyAAA
+AAADAAAAyASwBEwACQATABcAADUUFjMhMjY1ESE1ITU0JiMhIgYVEzUhFR0VBEwVHftQBLAdFfu0
+FR1kAZD6FR0dFQImZJYVHR0V/RLIyAAAAAYAAABmBLAErgAGAAoADgAVABkAHQCBALAFL7EWGjMz
+sALNsRccMjKwBy+xCw8zM7AIzbEMEDIyAbAeL7AH1rAKzbAKELELASuwDs2wDhCxFgErsBnNsR8B
+K7ELChESswIFBgEkFzmxFg4RErMEAw8QJBc5sBkRsxIUFREkFzkAsQIFERKwADmwBxGxARQ5ObAI
+ErATOTAxEQEVIRUhFQM1MxUzNTMVMzUhNQkBNQM1MxU7ATUjASwBkP5wyGRkZGQBkAEs/tRkZGRk
+ZAGQASrGyMYCusjIyMjIxv7W/tbG/gzIyMgAAAACAGQAAASwBLAAGAAvADoAshQAACsBsDAvsADW
+sATNsAQQsRcLK7AQzbMJEBcIK7AFzbAFL7AJzbAQELEKCyuwDs2xMQErADAxExE3FxEzETcXETMR
+NxcRBxEUBisBIiY1ESUUHgIfAREUFjsBMjY1ETQmBwUOARVkMjJkMjJkMjJkHRXIFR0CWBUdHQsK
+HRXIFR0kGv7sGSUCvAGQZGT+1AEsZGT+1AEsZGT+cMv+QRUdHRUBv2QdNSEYBgX+cxUdHRUEUh8T
+EXQRRR8AAAAAAQBkAAAEsARMADMAOACyAAAAK7AMM7AzzbICCw4yMjKwKC+yGBwlMzMzsCfNsBoy
+AbA0L7E1ASsAsSgzERKxBiA5OTAxMyE1IiY1ESERFAYjFSE1Ii4DNRE0Nj8BNSEVMhYVESERNDYz
+NSEVMh4DFREUBg8BZAGQSxkB9BlLAZAEDiIaFjIZGf5wSxn+DBlL/nAEDiIaFjIZGTgMJgGK/nYm
+DDg4AQUJFQ4DeBYZAQI4OAwm/nYBiiYMODgBBQkVDvyIFhkBAgAGAAAAAARMBEwADwAYABwAIAAq
+AC4AMgCyGAAAK7AQzbAWL7ASzbISFgors0ASFAkrAbAvL7EwASsAsRIQERKzBAMZHCQXOTAxERQW
+MyEyNjURNCYjISIGFRMhNzMlESEHIQM1IRUBNSEVASEXFSUzNSEnIQE1JRU7KQEsKTs7Kf7UKTtk
+AZDIaQEn/ldk/olkASz+1AEs/tQBkMgBJ2n+V2T+iQH0AZABLCk7OykB9Ck7Oyn9RMhi/tZkASzI
+yAEsyMgBkMhiYshk/UajhaMAAQAQABAEnwSfACAAABIeAxceAzM/ATYmLwEmBg8BLgEnNz4BLwEu
+AQ8BEAEfPpJmZ9GXex8foxEHE8ATNBB2jvxldhEGDosOLRKiA+QriY/UZmeSPSEBohIuDogOBBF2
+ZfyOdhExFMITBhGiAAAAAAIAAAAABLAETAAdAEAALwCyGwAAK7AMzbAoL7A4zQGwQS+xQgErALEM
+GxESsSAvOTmwKBGzJikyQCQXOTAxPQE0NjcBNTQ+AzIeAh8BFQEeAR0BFAYjISImERQWPwE+AT0B
+NiAXFRQWHwEWNj0BLgQjIg4EDwEVDgFtAhYmUnBSJhYBAQFtDhUdFfu0FB4dFMoUHY0BPo0dFMoU
+HQYaZHzaflymdWQ/LAkJMtQUMw4BLzIEDSAZFRQbHAoKMv7RDjMU1BUdHQKrFRkEIQQiFZIYGJIV
+IgQhBBkVyAgZQTEpFSEoKCELCgACAGQAAASwBEwAAwAZABQAsgAAACuwAc0BsBovsRsBKwAwMTM1
+IRUlISc1NxEjFSM1IxUjNSMVIzUjERcVZARM+/8Dtn1kZGTIZMhkZGRkZMiW+mQBkMjIyMjIyP5w
+ZPoAAAAAAwBkAAAEsARMAAkAEwAdACQAsgoAACuwFDMBsB4vsArWsBPNsBMQsRQBK7AdzbEfASsA
+MDEzIRE0JisBIgYVARE0NjsBMhYVETMRNDY7ATIWFRFkASw7KWQpOwGQOylkKTtkOylkKTsBkCk7
+Oyn+cAPoKTs7KfwYArwpOzsp/UQAAAAABf+cAAAEsARMAA8AEwAfACcAKwBIALINAAArsBDNsBMv
+sATNAbAsL7AA1rAQzbAQELERASuwCc2xLQErsREQERK1FBUgIygqJBc5ALETEBEStRQaICYoKSQX
+OTAxAxE0NjMhMhYVERQGIyEiJjchESETIREjNTM1IREzFSMFMzUzESM1IxMRMxFksHwCvHywsHz9
+RHywyAOE/HxkASzIyP7UyMgBkMhkZMhkZAEsAfR8sLB8/gx8sLAYArz9qAEsZGT+1GRkZAEsZP5w
+ASz+1AAAAAAF/5wAAASwBEwADwATAB8AJwArAEgAsg0AACuwEM2wEy+wBM0BsCwvsADWsBDNsBAQ
+sREBK7AJzbEtASuxERARErUUGSAjKCokFzkAsRMQERK1FBogJigpJBc5MDEDETQ2MyEyFhURFAYj
+ISImNyERIRMzNTMVMxEjFSM1IwEzNTMRIzUjExEzEWSwfAK8fLCwfP1EfLDIA4T8fGRkZGRkZGQB
+kMhkZMhkZAEsAfR8sLB8/gx8sLAYArz9qMjIAfTIyP4MZAEsZP5wASz+1AAABP+cAAAEsARMAA8A
+EwAbACMARACyDQAAK7AQzbATL7AEzQGwJC+wANawEM2wEBCxEQErsAnNsSUBK7EREBESsxQVHB0k
+FzkAsRMQERKzFBocIiQXOTAxAxE0NjMhMhYVERQGIyEiJjchESETITUjETM1IQEhNSMRMzUhZLB8
+Arx8sLB8/UR8sMgDhPx8ZAEsyMj+1AGQASzIyP7UASwB9HywsHz+DHywsBgCvP2oZAEsZP4MZAEs
+ZAAAAAAE/5wAAASwBEwADwATABYAGQBEALINAAArsBDNsBMvsATNAbAaL7AA1rAQzbAQELERASuw
+Cc2xGwErsREQERKzFBUXGCQXOQCxExARErMVFhcZJBc5MDEDETQ2MyEyFhURFAYjISImNyERIRMF
+ERMtAWSwfAK8fLCwfP1EfLDIA4T8fGQBLGQBLP7UASwB9HywsHz+DHywsBgCvP6ilgEs/tSWlgAA
+AAAF/5wAAASwBEwADwATABcAHwAnAFoAsg0AACuwEM2wFC+wGM2wIzKwHy+wJTOwFc2wEy+wBM0B
+sCgvsADWsBDNsBAQsRQBK7AYzbAYELEcASuwIc2wIRCxJAErsBfNsBcQsREBK7AJzbEpASsAMDED
+ETQ2MyEyFhURFAYjISImNyERIRMRIRElMzI2NCYrAQQUFjsBESMiZLB8Arx8sLB8/UR8sMgDhPx8
+ZAK8/aiCKTY5JoIBEzYpgoImASwB9HywsHz+DHywsBgCvP2oAfT+DGRUglZWglQBLAAABf+cAAAE
+sARMAA8AEwAfACMAKQBIALINAAArsBDNsBMvsATNAbAqL7AA1rAQzbAQELERASuwCc2xKwErsREQ
+ERK1FBUgISQnJBc5ALETEBEStRQaICImKCQXOTAxAxE0NjMhMhYVERQGIyEiJjchESETIREjNTM1
+IREzFSMFMzUjEzMRMxEjZLB8Arx8sLB8/UR8sMgDhPx8ZAEsyMj+1MjIAZFkZGNkZMgBLAH0fLCw
+fP4MfLCwGAK8/agBLGRk/tRkZGQBLP5wAfQABv+cAAAEsARMAA8AEwAZAB0AIQAnAEwAsg0AACuw
+EM2wEy+wBM0BsCgvsADWsBDNsBAQsREBK7AJzbEpASuxERARErcUFRocHh8iJSQXOQCxExARErcU
+GBobHiAkJiQXOTAxAxE0NjMhMhYVERQGIyEiJjchESETIREjNSMTNTMVFzM1IxMzETMRI2SwfAK8
+fLCwfP1EfLDIA4T8fGQBLMhkZWTIZGRjZGTIASwB9HywsHz+DHywsBgCvP2oAZBk/nDIyGRkASz+
+cAH0AAAAAAb/nAAABLAETAAPABMAHQAhACUAKwCbALINAAArsBDNsB4vsSIpMzOwH82wIzKwGi+w
+G82wFC+wJjOwFc2wJzKwEy+wBM0BsCwvsADWsBDNsBAQsR4BK7AUMrAhzbAhELEcASuwF82zGRcc
+CCuwGs2wGi+wGc2wFxCxIgErsCXNsCUQsSoBK7ApzbApELAmzbAmL7ApELERASuwCc2xLQErALEb
+HxESsBc5sBQRsBg5MDEDETQ2MyEyFhURFAYjISImNyERIRc1IREjFSM1MzUDNTMVITUzFQM1MxEj
+EWSwfAK8fLCwfP1EfLDIA4T8fGQBLGNkY8dkASxkAchkASwB9HywsHz+DHywsBgCvMhk/tRkZMj+
+cGRkZGQBkGT+DAGQAAADAAQABASsBKwACwATAB0AeQCwCi+wD82wHS+wGs2wGS+wFs2wEy+wBM0B
+sB4vsAHWsA3NsA0QsRQBK7AazbAaELERASuwB82xHwErsRoUERK1Cg4TAxYdJBc5sBERtQkPBBIX
+GyQXOQCxGh0RErQHDRAAFCQXObAZEbAVObAWErMGDBEBJBc5MDESEBIkIAQSEAIEICQSEBYgNhAm
+IAM1NyEVIRUhFSEEoAESAUQBEqCg/u7+vP7uFvMBVvPz/qodZAEs/tQBLP7UAbYBRAESoKD+7v68
+/u6goAJf/qrz8wFW8/3+yGRkyGQAAAQAAAAEBKgErAALABMAIAAkAKAAsAovsA/NsCEvsBQzsCLN
+sBsvsBXNsBMvsATNAbAlL7AB1rANzbANELEUASuwIM2wGzKyIBQKK7NAIB4JK7AgELEhASuwGTKw
+JM2wFzKwJBCxEQErsAfNsSYBK7EgFBESswoOEwMkFzmwIRGwFjmwJBKzCQ8SBCQXOQCxIiERErQH
+DRAAHiQXObAbEbIXGB85OTmwFRKzBgwRASQXOTAxGAESJCAEEhACBCAkEhAWIDYQJiADESEXFSM1
+IxUzFSMVMzUzFaABEgFEARKgoP7u/rz+7hbzAVbz8/6qGQEsZGTIyMjIZAG2AUQBEqCg/u7+vP7u
+oKACX/6q8/MBVvP9mgGQZGRkZGRkZGQAAAL/8v+cBMIEQQAZACAAcgCwBS+wEs2wEhCwDSDWEbAI
+zbADMgGwIS+wANawBM2wBBCxGwErsB7NsB4QsQcBK7ALzbEiASuxBAARErIVFxo5OTmxHhsRErES
+IDk5sQsHERKxDx85OQCxBQgRErMAChwdJBc5sA0RswsPFRckFzkwMQMUFjsBESERMzI2NCYjIgcu
+ASMiBhUUFw4BATMRMxEzAQ5xT94BkIB4qqp4LiwstW6Y2AJCVQE6yMjI/tQB7lByASz+1K3yrA5h
+d9eZGQwOa/6VASz+1P7UAAAC//L/nATCBEEAGAAfAB4AAbAgL7Ae1rAdzbEhASuxHR4RErIRGgU5
+OTkAMDEDFBY7AQkBPgE1NCYjIgcuASMiBhUUFw4BCQIjESMRDnFPCAGeAZNeeap4LiwstW6Y2AJC
+VQE6ASwBLMjIAe5QcgGe/m0anWR4rQ5hd9eZGQwOa/6VASz+1P7UASwAAAEAZAAABEwEbQAQAAA3
+IRUHISc1IQEzATMJATMBM2QBkEsBXksBkP7yqv7yqv7U/tSq/vKqyJstLZsBLAEsAU3+s/7UAAAA
+AAEAeQAABDcEmwApAAATFBYXBhUUFjMyNxEHIScRFjMyNjU0Jz4BNTQmJy4BIyIGFRQWFSYjIgZ5
+OS8EaUo4LEsBXksuNkppCTI7e1kak150owIOCUppArw1WBUQFkppHv7OLS0BMh5pShgfIGY9WoMG
+WXGjdAQPBAJpAAABAAAAAQBBpf/yjF8PPPUAHwSwAAAAAM8MCS4AAAAAzwwJLv86/5wF3QUYAAAA
+CAACAAAAAAAAAAEAAAUY/4QAAAUY/zr+0wXdAAEAAAAAAAAAAAAAAAAAAACfAbgAKASwAAAEsAAA
+BLAAAASwAGQEsAAABLAAAAKMAAAFGAAAAowAAAUYAAABsgAAAUYAAADZAAAA2QAAAKMAAAEEAAAA
+SAAAAQQAAAFGAAAEsABkBLAAyAH0AAAEsP/yBLAAAASw//MEsAAABLAADgSwABcEsABkBLD/uASw
+/7gEsAAABLAAAASwAAAEsAAABLAAAASwAB0EsABqBLAAFwSwABcEsAAXBLAAZASwABoEsABkBLAA
+AQSwAGQEsAAEBLD/nASwAAAEsAABBLAABASwAAAEsAAEBLAAFwSwABcEsABkBLAAAASwAGQEsAAA
+BLAAAASwAAAEsAAABLAAAASwAAAEsAAABLAAAQSwAGQEsADIBLAAAASwAAAEsAA1BLAAZASwAMgE
+sP+1BLAAIQSwAAAEsAAABLAAAASwAAAEsAAABLD/mwSwAAEEsAAABLAAAASwAJQEsAABBLAAdQSw
+AAAEsAAABLAAAASwAAAEsADIBLAAAASwAIgEsADIBLAAyASwAMgEsAAABLAAAASwASwEsABkBLAA
+uQSwARAEsAADBLAAAwSwAAMEsAADBLAAAwSwAAMEsAAABLAABASwAAQEsAAEBLAAAASwAAAEsADM
+BLAAaASwAAAEsAAABLAAIgSwABcEsAAABLAAAASwAG8EsP/DBLD/wwSw/58EsABkBLAAAASwAAAE
+sAAABLAAZASw/+IEsABGBLD/OgSwABIEsAAABLAAAQSwAS4EsAAABLAAAASw/5sEsABKBLAAFQSw
+AAAEsAAABLAACASw/5sEsABhBLAAAgSwAAUEsAAABLAABQSwAAUEsAAFBLAAAATEAAAEsABkAAAA
+AAAA/9gAUAA5AMgAAAEnAGQAAgACAAIAAgACAAIAAgAAAAAAAAAAAAAA2QAAAAAABAAAAAAAAAAA
+AAAAFwAAAAAAAAAAAAAAAAAAAGQAZAAAABAAAABkAGT/nP+c/5z/nP+c/5z/nP+cAAQAAP/y//IA
+ZAB5AAAAKgAqACoAKgBmAKQApACkAKQApACkAKQApACkAKQApACkAKQApACkATABSAFQAYQBqgHO
+Af4CNgKYAswC7gMsA0wD9ARyBWQGDgYiBkQG4gdMB7AH6AiUCTAJYAmUCgoKRAqICu4LVguQC+YM
+PgywDRwNdg2qDjoOYA6KDtwP2BBMEIgQ1hEOESYRlBIUEmAS2hMWE44UDBRiFLoVJhWSFmIW2hdM
+F4YX6Bg4GIIYvhksGZgZ/BpKGnwathrWGuQbFBswG04bhhu2G+Ab9BwOHFocpBzuHTIdwh4QHooe
+7B9GH6AfwB/iIAYgKiBGIG4gkCDyIWohxCJCIsgjfiOuJBQkkiTmJRQliCWcJbIl7iZaJogmvibo
+Jw4naifOKDgoZCi4KTYp1CpuKuwraCuyK/osRCyYLb4t5i5mLpIu+i86MBgwtjEmMX4x0jIIMrgz
+YDOQNBo0ojUENWY1vjYWNlw2tDcKN2A3rDf8OFA4tDkYOVg5ljnUOhg6XjqGOtY7LDt0O948QDxo
+PNw9RD2oPhA+SD68Pu4/MD+aQAJAYEC0QSJBiEHwQoJC+EOIQ/ZEPERgRJ4AAQAAANsAmwARAAAA
+AAACAAEAAgAWAAABAAEBAAAAAAAAAA8AugABAAAAAAATABIAAAADAAEECQAAAGoAEgADAAEECQAB
+ACgAfAADAAEECQACAA4ApAADAAEECQADAEwAsgADAAEECQAEADgA/gADAAEECQAFAHgBNgADAAEE
+CQAGADYBrgADAAEECQAIABYB5AADAAEECQAJABYB+gADAAEECQALACQCEAADAAEECQAMACQCNAAD
+AAEECQATACQCWAADAAEECQDIABYCfAADAAEECQDJADACknd3dy5nbHlwaGljb25zLmNvbQBDAG8A
+cAB5AHIAaQBnAGgAdAAgAKkAIAAyADAAMQAzACAAYgB5ACAASgBhAG4AIABLAG8AdgBhAHIAaQBr
+AC4AIABBAGwAbAAgAHIAaQBnAGgAdABzACAAcgBlAHMAZQByAHYAZQBkAC4ARwBMAFkAUABIAEkA
+QwBPAE4AUwAgAEgAYQBsAGYAbABpAG4AZwBzAFIAZQBnAHUAbABhAHIAMQAuADAAMAAxADsAVQBL
+AFcATgA7AEcATABZAFAASABJAEMATwBOAFMASABhAGwAZgBsAGkAbgBnAHMALQBSAGUAZwB1AGwA
+YQByAEcATABZAFAASABJAEMATwBOAFMAIABIAGEAbABmAGwAaQBuAGcAcwAgAFIAZQBnAHUAbABh
+AHIAVgBlAHIAcwBpAG8AbgAgADEALgAwADAAMQA7AFAAUwAgADAAMAAxAC4AMAAwADEAOwBoAG8A
+dABjAG8AbgB2ACAAMQAuADAALgA3ADAAOwBtAGEAawBlAG8AdABmAC4AbABpAGIAMgAuADUALgA1
+ADgAMwAyADkARwBMAFkAUABIAEkAQwBPAE4AUwBIAGEAbABmAGwAaQBuAGcAcwAtAFIAZQBnAHUA
+bABhAHIASgBhAG4AIABLAG8AdgBhAHIAaQBrAEoAYQBuACAASwBvAHYAYQByAGkAawB3AHcAdwAu
+AGcAbAB5AHAAaABpAGMAbwBuAHMALgBjAG8AbQB3AHcAdwAuAGcAbAB5AHAAaABpAGMAbwBuAHMA
+LgBjAG8AbQB3AHcAdwAuAGcAbAB5AHAAaABpAGMAbwBuAHMALgBjAG8AbQBXAGUAYgBmAG8AbgB0
+ACAAMQAuADAATQBvAG4AIABKAGEAbgAgADIANwAgADAAOAA6ADAAMQA6ADMANAAgADIAMAAxADQA
+AgAAAAAAAP+1ADIAAAAAAAAAAAAAAAAAAAAAAAAAAADbAAABAgEDAAMADQAOAQQBBQEGAQcBCAEJ
+AQoBCwEMAQ0BDgEPARABEQESAO8BEwEUARUBFgEXARgBGQEaARsBHAEdAR4BHwEgASEBIgEjASQB
+JQEmAScBKAEpASoBKwEsAS0BLgEvATABMQEyATMBNAE1ATYBNwE4ATkBOgE7ATwBPQE+AT8BQAFB
+AUIBQwFEAUUBRgFHAUgBSQFKAUsBTAFNAU4BTwFQAVEBUgFTAVQBVQFWAVcBWAFZAVoBWwFcAV0B
+XgFfAWABYQFiAWMBZAFlAWYBZwFoAWkBagFrAWwBbQFuAW8BcAFxAXIBcwF0AXUBdgF3AXgBeQF6
+AXsBfAF9AX4BfwGAAYEBggGDAYQBhQGGAYcBiAGJAYoBiwGMAY0BjgGPAZABkQGSAZMBlAGVAZYB
+lwGYAZkBmgGbAZwBnQGeAZ8BoAGhAaIBowGkAaUBpgGnAagBqQGqAasBrAGtAa4BrwGwAbEBsgGz
+AbQBtQG2AbcBuAG5AboBuwG8Ab0BvgG/AcABwQHCAcMBxAHFAcYBxwHIAckBygHLAcwBzQHOAc8B
+0AHRAdIB0wHUAdUB1gHXBmdseXBoMQd1bmkwMDBEB3VuaTAwQTAHdW5pMjAwMAd1bmkyMDAxB3Vu
+aTIwMDIHdW5pMjAwMwd1bmkyMDA0B3VuaTIwMDUHdW5pMjAwNgd1bmkyMDA3B3VuaTIwMDgHdW5p
+MjAwOQd1bmkyMDBBB3VuaTIwMkYHdW5pMjA1RgRFdXJvB3VuaTI1RkMHdW5pMjYwMQd1bmkyNzA5
+B3VuaTI3MEYHdW5pRTAwMQd1bmlFMDAyB3VuaUUwMDMHdW5pRTAwNQd1bmlFMDA2B3VuaUUwMDcH
+dW5pRTAwOAd1bmlFMDA5B3VuaUUwMTAHdW5pRTAxMQd1bmlFMDEyB3VuaUUwMTMHdW5pRTAxNAd1
+bmlFMDE1B3VuaUUwMTYHdW5pRTAxNwd1bmlFMDE4B3VuaUUwMTkHdW5pRTAyMAd1bmlFMDIxB3Vu
+aUUwMjIHdW5pRTAyMwd1bmlFMDI0B3VuaUUwMjUHdW5pRTAyNgd1bmlFMDI3B3VuaUUwMjgHdW5p
+RTAyOQd1bmlFMDMwB3VuaUUwMzEHdW5pRTAzMgd1bmlFMDMzB3VuaUUwMzQHdW5pRTAzNQd1bmlF
+MDM2B3VuaUUwMzcHdW5pRTAzOAd1bmlFMDM5B3VuaUUwNDAHdW5pRTA0MQd1bmlFMDQyB3VuaUUw
+NDMHdW5pRTA0NAd1bmlFMDQ1B3VuaUUwNDYHdW5pRTA0Nwd1bmlFMDQ4B3VuaUUwNDkHdW5pRTA1
+MAd1bmlFMDUxB3VuaUUwNTIHdW5pRTA1Mwd1bmlFMDU0B3VuaUUwNTUHdW5pRTA1Ngd1bmlFMDU3
+B3VuaUUwNTgHdW5pRTA1OQd1bmlFMDYwB3VuaUUwNjIHdW5pRTA2Mwd1bmlFMDY0B3VuaUUwNjUH
+dW5pRTA2Ngd1bmlFMDY3B3VuaUUwNjgHdW5pRTA2OQd1bmlFMDcwB3VuaUUwNzEHdW5pRTA3Mgd1
+bmlFMDczB3VuaUUwNzQHdW5pRTA3NQd1bmlFMDc2B3VuaUUwNzcHdW5pRTA3OAd1bmlFMDc5B3Vu
+aUUwODAHdW5pRTA4MQd1bmlFMDgyB3VuaUUwODMHdW5pRTA4NAd1bmlFMDg1B3VuaUUwODYHdW5p
+RTA4Nwd1bmlFMDg4B3VuaUUwODkHdW5pRTA5MAd1bmlFMDkxB3VuaUUwOTIHdW5pRTA5Mwd1bmlF
+MDk0B3VuaUUwOTUHdW5pRTA5Ngd1bmlFMDk3B3VuaUUxMDEHdW5pRTEwMgd1bmlFMTAzB3VuaUUx
+MDQHdW5pRTEwNQd1bmlFMTA2B3VuaUUxMDcHdW5pRTEwOAd1bmlFMTA5B3VuaUUxMTAHdW5pRTEx
+MQd1bmlFMTEyB3VuaUUxMTMHdW5pRTExNAd1bmlFMTE1B3VuaUUxMTYHdW5pRTExNwd1bmlFMTE4
+B3VuaUUxMTkHdW5pRTEyMAd1bmlFMTIxB3VuaUUxMjIHdW5pRTEyMwd1bmlFMTI0B3VuaUUxMjUH
+dW5pRTEyNgd1bmlFMTI3B3VuaUUxMjgHdW5pRTEyOQd1bmlFMTMwB3VuaUUxMzEHdW5pRTEzMgd1
+bmlFMTMzB3VuaUUxMzQHdW5pRTEzNQd1bmlFMTM2B3VuaUUxMzcHdW5pRTEzOAd1bmlFMTM5B3Vu
+aUUxNDAHdW5pRTE0MQd1bmlFMTQyB3VuaUUxNDMHdW5pRTE0NAd1bmlFMTQ1B3VuaUUxNDYHdW5p
+RTE0OAd1bmlFMTQ5B3VuaUUxNTAHdW5pRTE1MQd1bmlFMTUyB3VuaUUxNTMHdW5pRTE1NAd1bmlF
+MTU1B3VuaUUxNTYHdW5pRTE1Nwd1bmlFMTU4B3VuaUUxNTkHdW5pRTE2MAd1bmlFMTYxB3VuaUUx
+NjIHdW5pRTE2Mwd1bmlFMTY0B3VuaUUxNjUHdW5pRTE2Ngd1bmlFMTY3B3VuaUUxNjgHdW5pRTE2
+OQd1bmlFMTcwB3VuaUUxNzEHdW5pRTE3Mgd1bmlFMTczB3VuaUUxNzQHdW5pRTE3NQd1bmlFMTc2
+B3VuaUUxNzcHdW5pRTE3OAd1bmlFMTc5B3VuaUUxODAHdW5pRTE4MQd1bmlFMTgyB3VuaUUxODMH
+dW5pRTE4NAd1bmlFMTg1B3VuaUUxODYHdW5pRTE4Nwd1bmlFMTg4B3VuaUUxODkHdW5pRTE5MAd1
+bmlFMTkxB3VuaUUxOTIHdW5pRTE5Mwd1bmlFMTk0B3VuaUUxOTUHdW5pRTE5Nwd1bmlFMTk4B3Vu
+aUUxOTkHdW5pRTIwMLgB/4WwAY0AS7AIUFixAQGOWbFGBitYIbAQWUuwFFJYIbCAWR2wBitcWFmw
+FCsAAAABUuZYrgAA
+
+{-# START_FILE BASE64 static/fonts/glyphicons-halflings-regular.woff #-}
+d09GRgABAAAAAFsYABEAAAAAoUAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABGRlRNAAABgAAAABwA
+AAAcalXC8EdERUYAAAGcAAAAHgAAACABCAAET1MvMgAAAbwAAABDAAAAYGenS4RjbWFwAAACAAAA
+ARsAAAJySvAJmmN2dCAAAAMcAAAACAAAAAgAKAOHZnBnbQAAAyQAAAGxAAACZVO0L6dnYXNwAAAE
+2AAAAAgAAAAIAAAAEGdseWYAAATgAABODAAAiTweHjMhaGVhZAAAUuwAAAA0AAAANgJiWP5oaGVh
+AABTIAAAABwAAAAkCjIED2htdHgAAFM8AAABFAAAAvTBwRGObG9jYQAAVFAAAAGrAAABuDSPVk5t
+YXhwAABV/AAAACAAAAAgAgQBoG5hbWUAAFYcAAABggAAA3zUr5ntcG9zdAAAV6AAAANAAAAIhLlG
+pmlwcmVwAABa4AAAAC4AAAAusPIrFHdlYmYAAFsQAAAABgAAAAZYr1LmAAAAAQAAAADMPaLPAAAA
+AM8MFvIAAAAAzwwJLnjaY2BkYGDgA2IJBhBgYmAEwltAzALmMQAADagBDQAAeNpjYGZpZJzAwMrA
+wszDdIGBgSEKQjMuYTBi2gHkA6Wwg1DvcD8GBwbeRwzMB/4LANVJMNQAhRmRlCgwMAIAC2EJ1gB4
+2s2RP0vDYBDG723aSIrSUESsiHcIWqqDXbvFRe0gBJw6tTgUCx2Kk926dusixc0P4OiXaQZzjx2c
+nNRFhPiagENdHBx84P693P0O7iUihzLbJGM9mb6tTFrnTWhjSAEVyLfZCgnt060U5UDacrdd3vnY
+NVWvWlJHPa1oTRva1JZ2tKdDHesUHiqooYEjNNFCD0OMcY2bR0qSr10pcc8S6QfRaEF9Fa1roKEl
+nutARzqBgQ9BHQFOEKKDAUaYYJoSTfKWzJMo6epSPI/v44sHJ9qI1malWVEqsi5lWRZXiN/5lV/4
+mZ8YfMWX3Ocud7jNLT7jUz7mQw62ouwafyvj0jfW5KzLLTZkX5EpX6B/LXfxYfU3U5+Pg2iWAAAA
+AI8AKAL4eNpdUbtOW0EQ3Q0PA4HE2CA52hSzmZDGe6EFCcTVjWJkO4XlCGk3cpGLcQEfQIFEDdqv
+GaChpEibBiEXSHxCPiESM2uIojQ7O7NzzpkzS8qRqnfpa89T5ySQwt0GzTb9Tki1swD3pOvrjYy0
+gwdabGb0ynX7/gsGm9GUO2oA5T1vKQ8ZTTuBWrSn/tH8Cob7/B/zOxi0NNP01DoJ6SEE5ptxS4Pv
+Gc26yw/6gtXhYjAwpJim4i4/plL+tzTnasuwtZHRvIMzEfnJNEBTa20Emv7UIdXzcRRLkMumsTaY
+mLL+JBPBhcl0VVO1zPjawV2ys+hggyrNgQfYw1Z5DB4ODyYU0rckyiwNEfZiq8QIEZMcCjnl3Mn+
+pED5SBLGvElKO+OGtQbGkdfAoDZPs/88m01tbx3C+FkcwXe/GUs6+MiG2hgRYjtiKYAJREJGVfmG
+Gs+9LAbkUvvPQJSA5fGPf50ItO7YRDyXtXUOMVYIen7b3PLLirtWuc6LQndvqmqo0inN+17OvscD
+nh4Lw0FjwZvP+/5Kgfo8LK40aA4EQ3o3ev+iteqIq7wXPrIn07+xWgAAAAABAAH//wAPeNq9vQlg
+G+WVADzfzEijWxpJo5FkS7IkS/IpxZJlxfGR4Nx3yM2dgIBCOMIVrhAghXK0CYZCKA0tKSyQco6U
+UNpu2G3pwoq26hnSQrcsvVhajm0hu90m8fC/981Ilu0Eyu7//3EkzSXNe+973/vePQzLtDEM+QzX
+wnCMwKRLhMkMlgWefS9bMhr+bbDMsbDJlDg8bMDDZcHIHRssEzyeE6NiIifG28gs9e0//5lrOfZm
+G/sThjBFpsgv4ZcwMtPKKExGsecUUlWsWaL4M4rnkGLIKu6qImRLAdLJTOvx5KOpgizmxIIsRKWo
+LKTEuCikCkXCPb/j+Qq8CKeO1TYPTzqgjtHLAA0G/tH7WplFTNnCMJ14c4He3JAtE8bSuW8W4cyd
+RLFlFMshhc0q5qrCZ8tmC54yC+bOssWMmxbG3FmyU+gCJCrW/sgo6SKj6mb14PiWupmMUpwN/Bf4
+Z5gCs4VRshmlrVpuy+JPtaXNFI4ohSOSVQwZpTmnGKtKMKtIGcVaLUtWvFByIWTTM0qBQharlkKR
+LHy6St2kU3FllXRVcWZL/aSzFCuIbkXoV7rFsrUl29/fj1Qs5HoL8UKur9CXy8o+Od6bZuMxBytE
+hahRgrcwn8sOs/mcUTDGY6k0SRWLlxleL96WWHzV/g82Dxqfyy1ZFPb3z5npIdcX1YNGsgvezdP6
+Z+ek0KIluWciGzc9Xr26dcRGDhcz+eLjp+544fwLC+unBbxdpw4X033FRVeOdDqD09bln7rwqq+m
+n7yGwTGpkFF+CXsA+MtNeYGrEoXPlAzayANRK9wtx7YiORlGH8Pavx7Y/+gD0sW/yJ/ESEyEUbiM
+4qjCmBHFlynJ8BMlMye6S1axv39aD+f15aLZvt5kPCakSTxmlLyygzguW86+f80TT1yT7up67pIv
+/ZIdWUPeX3H50x885dh49S8eCNgcm5Bt4FXkFeAdHuaBhbEzTJ7IBZIQzQYY9QpgcXQF6VIPsuvZ
+9TD6XUU8qG6u0L3DY4+yp6k20jW2F36H++jDjz7kX+BfYFjGyLgYRkgAexN4Ffp6MyQZE+xk6b+f
+eog979DaQ+fY7Q84W532zf9+snbgdHvK8YDdXqMFwKQwZibHlI3Iz0JV4WAaWTKK6RCQssyZkHM4
+AzCuicNNkxEY10qJK0aJCNMpHxV5BYE79iaQUhl7fez1YpFN4u87GBPMl2eZFoZJhklhmOTFhJgU
+HETW93qTgsFBJDhm5FtvX34SID9r0fJ1bvfty+etcljGXBYH7H/+kvagtKGDPXP32F9dcvDyvkJ7
+QD65wF1msXLf5TyWseWiP8AANeSP3uX/hX+A8TBNzClM2YEYuTOKXFWaNMZozijkkCJVFcmFskEx
+wBwAdg9Ionsfx7rcrXK/YhCB85mS2wFTwNyvyKLi6lea3PsIIxjg/LQetwsQkrwC8XmdxBhLEWB3
+1uVr6XMlW2TSDKzWvIx0CcLFJq9JPXj1zspnXyTu735XfZ+8h+fU31d2Xq0ehJMXCwLpWsZepP75
+xe/CFRp/Fpn1/LP8HCYAHEmUYEZhDiFPOqqlJo2le4fZMJHhjZW8Dk5I88Xpp1599bVd066/5qr1
+fbOvvWXv8PDjt1w7m3PN2rKqm184Z+4CvnvVlln91950Y3nNmvKNN10LtProm8x8/j4YewtjA5aK
+enKeKPGYiYcrLCD/fg97D/mluv1u9SZ1+z33slwLFUV/UmcSj/oe+Wf4pHzY+Bs+xs8odhC/VAzx
+wERypuSnIE/4dY8sFORUIZ4Spt5n9r8s/M73Fn33naXLjnNH9sqdv/3Cjj984ec/n8C7HpjHeZKP
+JYdIb1/WFyJeY1wiEhlNzFT+R5mZIKN3EVK8L1fZqihbK7n7iupHdzE4/+j3l9B1yco44Xdk4JoI
+E2dSTCeTgRmhMGUGOYivlvwtICiFjBLLKaaq0ppVrBklmVNsVaUtqzgzSkdOcVWVrqziySjpnOKt
+KtOyiH84m0NyEKWXjiNf3WeyubytclbhXSii9pntooS7/qrSDO8aV4aySkt1X2tb1zQ81eIqReHK
+RHt3D+5y1VIeBZPNCoIp2NTfrzjFUnMIBVQPXS/z8fykF0pBmKVRcpxzvHJ0f7H+D8TN2F76OjB+
+kF/SeAnKUhBOx7bWjzC6fNPWRifQMMPMZEaYsh2p15UDtJFkoYwySEnTC7wxi9LDRddHP7y7Si2A
+OBCtvapMz5ZOonwD8qEPJK5PEmFMo7FkgEzcJ59wPgRcIIVCkroZ38e32fUnOpNtOMxe3LAz9sKJ
+zjAgPSfjvpw5i7mUuZG5C9ZqSoXS4EU5pEOpt5hFSpSWbM0hLUpzroT97kzp9C/Afmu1tPqWLFBn
+FKlTciHTmYH52rKUQtNAUs1aAdv91dKC9fjpKm2AY5tvgu0LqqVrbs9mS3dTyuFcGCDabOgksaSY
+//h9kv//9vqQVEGCneCNjP7fzmfre+TR420e+6//6wWwztbkReMYr9V5fJDyeC+d/ktySnNVmYOj
+qpyOY6qshhHdMGFE5ROMaGnj8UfP64PdPjichF2jNPk8jgbyPZV9UY36H7f/ydRmD+DO2Bx8P/52
+I83Hv/0pKIoyPMTE+A/4DsbAMLA4pEgqRB7hsgfHvvYj8rJ6OtcLWz/G6y5kLuTn8fNATuN1BTOR
+zUQwkwtJUH3rIAmS4EH1LfoGH8MT9w/iNbBWTdANUszzE7QDUAviOSVUVaLZcnMI1ZzmJGg8oWbc
+DEVAv9b1h7YG/SEJAiucVRJVpSVbTiTx0kQcvpVM4GayGb6VqGsZ7TDSSdAyyqwPRHa/khAVd78S
+AK1DdgUbtA7ZDVqHq78UAu1jH2OQ/HiuSSx7A6S//xN0Dw7keU7KSXEpnv9YPWResQKi/hO0EfUU
+vAile412X6a0izBnHE+zapmqWUV1zeo51KyaQx+jWz2HulVz+BO1Kw6WsY/HDLUG8r6O2I5r1VcF
+H1xlqiH2InG9CIhRXZGR+QdAf2iC1X4ug4ajBdDoouuSUC0L1JgTwJhTBFfJBhh5qmWbBw/awI5C
+k6lkE2CQZH9zHACnmpm7IIE26wVg873JVN7nBg2NjaVZok1g1HfpBJZ/9vj5W4+Qs49sPf/xn522
++9V3X919Gvl1SCri7CjiAvU8aRt+rFC5pnTkSOmaSuGxYfWXz2+Bq+BiYhtfs2DdLTIE5FKprsdM
+Y8o8rjgmWy5HFFdG4REfRMIESFjBTNbQcVZLIpU2BbCwCRjHtb8iGCNdFRj6CkGDhBxWbWh5g6Kw
+AukWZJr4XfwuZj5zMnM2g0ywoqoszih9QL2VlHoLqsoCV2kp3AMWtFVApwUM2lBDwPZLxX1OKdeP
+rNDqLgUyYFiWVgDLlwRQYJTF4j4umpqLZ/vcpc6TkOE93gjrixDBJxdkH2zmsjPZvplE7iukCn2w
+me/NsMkMKSRTQioJm/GYkzU6ScooyIIRNg2oFEpeYywZNN7POvzciu7BWw3dPYZkW6wpkzSmM4bP
+TZ+2gvM7yZcMhi8Rl8yt6Br8nKF7mlG7wpDtMtw6kF7BBezs/UZy/rbyNvjPnhJtTxp7ugyfG0if
+zAXhlMFwP2sPcid3DX3O0NWDX27uThpzHYbPzciczAUc2s87AtzJmRmfM2TSxuS0wPpt29afsm0b
+yEKBKX70Ea8YvKD3j2ugBeYOphzFudYK1v603iwsFalMuSPblwN1oakKKiYqFY4uOJ7JULsVzPvg
+IVx1Wl2lBM7DrNKGmmk50UYlFAMM3eZCeaRMAy3VVeqBre6s0ltV7Nlybw9e1OuBi3pdqGeCUESH
+AHWi4CJSX0kalhMPqJ3aFrKSB16obnr07aLTQjwD7aSrfYB4LE6H9ehbVkeRu2WgfWxO+0CRyhjk
+M03a8CRrcRbbBwba4XtZq8Nx7BJkvvbBwXb2wNgc9gBYxkf3a5uavQR/Bon/NdggXUzZTPV14HvQ
+z82HUFc3UT0bqQRMXzKYQPAQOlnNJF5zurCj7C0V9SD+saewt4xtHduLcoRdj/yOAvBtkBMORmRi
+TBmMpU6CXA/SzlgtGwkSzGgCieDRZhPVSesUISIpOqzkV2TUYT32jNXBriddAX6b1aHaxs4A9Dg3
+4o4ylmd4/in+KZjDHuCB7Qza4M6q4kUhW5a9eBtZgnHx4JBTwxAgsMOouUpeQHD8ogBcJLtwcsO8
+R6Ox5LWDnLJwDg/MrJIow46Zd6Kty5S8TtgTGLsLT3nwlJGINl0Qu1tbeLeL5Vta3boA9qCEkPg9
+xE3mEPeePer76gH1fd+HZO2HH6pPzAeR8Y3GE3v2sGepT3yIp8dUIOlBaiuwHz3IMAYv0BTlVVq3
+soQcYgwWlTNDHQ9O6nggZmRhlGO6tIqTHAd/JMrFOU+OixfJsz+VHvb+hDw79lb7B209bzY9wSvo
+QDm6gq4FhzW/D6vr6No9FzFlK95TuxuYICQ7LirLvIC35hlN9NuBjhYqK0sCD5KKNYOksosgX6lX
+DL0g6KcEiKjtRf6kvoHyU30Dtn7z7LPUjwciFP14lSKMM/Ar2PfPAhQyE2bO0TVID53LBhjYCB1Y
+saqI2kIKymSzqyTBFiiOLbikiqJ7v513y1Q3aBaVcL8iuffbDB5fiI6p7IE1l5jMTFBfUXuH2WyY
+pUsRqY0kR4U9R87a88bhN/acpX2c/gFZ/cEH6lMrdlV2HSENJ+CDZdWnPsDzKp2uwLQTeTbIbKzx
+rM6iTQ0sipiAjeuv82UzYgJ8uR/50ouY+EVF6lfgCDKnj2LicSImRoGhetDxWZJrgokcF0/Ek8uP
+HNl1Yq5Uz9ZwoUzC1n0KiE+7Lk2AR1xUsWcBJW8GRwKMbzOocjxxUJ0sL3qiTTVZmJOjhRwXrXAt
+/0pA1m23OiqVLOnKVjaOPRwgv0LJpSZg4pO3YJk9PIGGEuNn5jXMe6RhgNIQYLDVKRcEyok2IAxv
+tnA+f30aU0L55CmE8uj6SAvMbMOJyPQhmUHaJ5OJ7IcRf+pJOH8nubsCnFvTmZqZVQy6mWFsxYwS
+ADhDFE6A2+kqWTReDQOcFoTLwHu8cgCH2CyWJB+u+SKOPGHMXgkPB0SFAu0Ns+hAjnuNLUkXOpmF
+qCjAiu4gsq4k7TqifhU0otsvuYeM3v2Vl0EjYn/0rqYWbQFVCTSqk/HMdaftZjQdj6Hwupgocx1T
+FnE8YX75qmVfBOe4Lwhz3I7zrmw34AE7gy7ymOacgIHXGDdYLcUBGReqMaK7HwF+XjBYLaCbRBH+
+oLtkNiFavggsL1EqHsx4nQGd6JrLDrApiNFCEt3GnBgVQJHpy+dgTsZjKcRuy8tfuVvd/MXNt5WO
+LCSj9HOXdphdj4rfdXh2xZESLk34SY8xsOoVdZ49nh9rBaOYMoo/hyIumMWgRHMOBy2URWnXkkMx
+E80ir7XmUHdPZKmJYzpUtrm8qGxYq2WH2wdbqDCAtMOVDZf7BBgaqYaXBxb8IRKVEnntpfmMuFuO
+vVlzEqEMHH+h1wnd8tryr/0f21us7zbIa9SHQF7LOHYtmo7TCiN2CEalbAjioBlQUgdduNQpDgC4
+CQ86QIdBBYgpteCqxjsMQToz0Kc0MG4w5xq8SaDcaOo5KB9bVpKulVuoInJsK2guIMWp3Vpk17cP
+VFZu2bKyAgrMXjjP/mEX1cR1XYH6gTiYy7K2rmEkAbmJq9J4ApAQ5K5nmITZYVIQHSTNGQVAe/C2
+a7ZefmGxve36W0Zvu/JUL9KPjA5Os0ebDMtPJodPnmtpa7PMPRnJwuly6n7g6h7mJOZ8ppxB6gzn
+lGRV6aPjHAIyjei2DK5iMaBNZ1XpdJWysDVQVQZcJRdVG0qzgbWznUAjmzXUTKVJMgOzU3B5vBxy
+tw3WOifKObFuxQyTljCRxvfTbMzBSh5Rc0sgQdEtkZi077CCQrfj98T4+x1085xH3nj7jUfOqdhM
+e0w2+sauH98mHpCSVtJ1408vv/ynN6oHtb0r4QvwvSvHXiU/xAvVXnxv2NbleIVfz73NGEBnY8So
+QTRESQHjIzJYBSkwczWpzyo7dsyv/SejILMr6pMNh2q/xW2mv+Vk3AxVExyHUL6JehAEfz1RABtD
+SIGYrf/2gbmXXjh7rfar/fnbnv36rX2X3HlPbfy+zZ/N/ZX+ZogZpHEr9BKH9d9G35BHEzwRGB0P
+rDb7XD5ZW94Jgwqcw6Pxc4BEE2KC1O8PVpIEhrNcQMuIaNCQeygsZwrXXy2cbNw5aiR3A1zH3qyQ
+VwCwJ24tXHLn3VXT/d99YZdpxFT+3VtlU90/roBUEYGbAwBnlNokM5nZYPstZpYTonF4adocMEbc
+1XJ7z1yUGcFMOdW5RDNQyonupXgslimxRjgSB4U8C2iWHAtgL1ot9S5Ef+cKNFpKhjD6RqslDqOS
+Ic07ZkfTJldV8vDuKqWtnUoHdbnMypbT1M+Sjpk7y8TqxLskXKUCfGfOAtgeqJaSi/DTVVoClBzJ
+Ksur5f6heSjLToaLpoVgZfJK/kDvTFR9CwlY0Nvap2OosxRrAgp7vNOpnRoXy/yMAfTZhN2zzAZf
+oK8wODRrNiV+T1SM59HdkstH0ZmuCUcCLw6EIofqYB5UQ+qRwYu0oyAAorirXc2BuCQoQuFFDqPd
+TUaLRdVGtSw0xFF4dmkWueajh+3K2F78wEuobNVlbBcIDYwhHsB3lKfsAfwlelGxAltF7m1kzgqK
+4814EQpo7hYQvnM0P765Pu5T15PNmvVT5r3NOLr2akkKZbP0GNVcW2nQUPMwoGyxZVGtRX0QTBQr
+yhq0S/ywBZZrk+bxj1dRSJdcGMwQjP39pSaQ1jScgf5/NCGBPCmgmIwrDXxK8JnXP3Gfol2pryKV
+Cvf20RWwxb19zF857bTjfk7Q9QRN1xN0jxZPtTxUZmCKU13PLQBrMEYr1fVED64cZsJ4ZV+20Neb
+SsYEAhbu6+wBsOh+GQqvCofwDYbgVxYn6Ho27nerQ+FwCN/o3Cdg+/xav28A5Ld2Zzmn3VzxZmu2
+nVmL+NH774f7+wKU55rIVAgSOfSeElA4dUB+od0Q3lhrEY9kyYsIktUxCSQF9+FkLfao0cQCs1y3
+yjS910qXEktVsUwwpy0MejQFE501Au4Q3kDplBMLoLuBnhMVi89yXymOuYvs+zx59pgfWLBIhwBj
+93S9LMH9GMBA7E3COmyUKuRF8mJIOvamFCIH1Ln8Nm847G1Y91A/l0G7OYUpJxBGsJAs1Ga0cLXU
+CkXIljnLBAuyjaIA3MlmkUFNmm9E0FyzJiuuf85UTPPkAYOhGg+TOyp5YItLE4RM4ArDBPWGCPFR
+laEC6gCw3LE3823siuEzWZdFHba42JEk67GQwxYPm2StlrG9FhwDmLNzKhX2ta1byam4lh29+UsW
+h8OCbxPyA0JMgukGvriUZiOAqGvPKN2gpmVgMhFM/AAsItVyhPonIxnALuIqpejyXsoBKhEYBiXQ
+X+pMAUrR1kQLXTS622EvEoujRahExVK6BwSax73fGghmpmmKkZbdoPko0zws2A7WSbMcGHSheY0x
+1uvD7IcYKn8D7dzbqBzt4p25wqqOSvvKGWmrbRdoSsXRyuhoxTi8fnh4PQHq4FWoNJma5uY7YUfy
+DrSDKQzXjJIWvGj4TKrv5enYPgs2cQxeGvfZc0q4WmZtKN2JEs+UWnUtNA+W7EwSlWEYpGg+mUoT
+WOviYAA5iJMQj+zJk4vbh1s9p5PbVro68+RrsTZ32GhUbzxDvczfbOtwOsmmcvrKEV9f15/e6F43
+MkI6PGmHnXvrmHtaky0oCORfyStfUL8HPIf+n+8Bz7WAlOhhzmXKLQhZtKp9Ejo+HVWlJ6NZusBh
+dJT4Q3ANLlZRWLYwvQa065ZDIjArHaVEGkbJBwPTHoWN5n6lQ4RdpQed/4BgniZHpLlU3oDeSxyJ
+MA+fJJ5CuwGHKK9txEFHZc2+1gj5xTXflqMxqw0I3du55bHlla+dctMNZz70+SUX7d19ipBr4waa
+5ZDdKcwnyhcKZxTaTAJny520Zd7qu5dWNq4+9ebi9UtXbqzPS+5Sqnu36CNBaJgWxIADo94oovR0
+BAS14OnDIUjlo7KDcxLO6JOlytIrTE9b2uYbzQbydTY6IxYwGG6yTJvfL8zOcCdPb/UQjvT3m+Kp
+hM127F97B439DPvRc7pfyAxzYBtTbtLstTJr8OGCYwOut1GudwHXW4AjklRQahouWp0wW0AHCFFf
+Q9lPAzn+IAZy/DSQ0wRf82trk7OKc6ZkAdlaMlDbLdKkxSRsosLDEKRg9hfkuJgTPGIuCjswGp1E
+lIHdCiKYpJy0ePHiG26A15Fd7IFdWZeUjsYqRXVzsRKLZrwiqH2PP37szce5c3CZDaUkM3vsmWyx
+mOVWsmYpFaJrUPSjb/B3gfxDfO9gQO0CfNkqNVEb0bUA3E4NXcuhT49kCHSbfazJTFDRcfnRGgJR
+RsUCawL8GRDZSkQE2R2ksnsmASRlAWQfdwLUo49r2BU11L2ZcdTTkit3g0YZ7sd11Me2IOrsnTXU
+9XyBxngqowsgjHLSZeDT7ockfglaYkf34zvXgu+4hsD223TbTyOY62kEcy+oLris0IhL5WO3/h5Y
+xUn7nk84PxHW8e3KCcOtdXDI4fqmuvl4R48Db1L3MoJ+0Z3B4EAog4kYQxmlt4q5GHq+xRCZGCf2
+5D/dfiMmxUayVxrHozJhELSQFwDPXlTfVN8+3tGPx0vDSMPuk/ASP3W8/PijdaLtcaTIrE/YRJRM
+x80twPyRlTp+S2h+wRyaQ3M6zaFZTfMLLqL5BcUsYrw1hzGcK0FM3IQ6QtnVMi1Lsw3K/rbpaPXc
+/L/KDDle5sf/jZa1IOfHv6G/ZcIc/sTtT0H1Y6OfZoSMH+3Wx8cImmqQ6WBmMItgZUSrPUmz3dJA
+9cUZNDQ185yuIBiOBylK42CfXrRNSPg495XHHkPzBmcOznOcOTDnu3BbPTg+/1VbDWoUBWAWohxW
+bfySo2/9vcIO/hmpjSI18ONswFdmyrOoP2txRpl1SJldpehO6yn8H3HD0LNHpulo5NPhx7UUo49X
+Kn+vHD/6FjrV2OQNi4uLdR+Rwr1NvTrdNHMRphhafx6qYoP15YW108zQfAymxNt15y+6XCammYHl
+0hVh3490dUXG3JEu7hYw1z3snXR/C7yTopa4yzXMcxkoe4o+u2G5r4VyaR7FBN9zqIquED38gxkV
+oQBAJPYrkljyuKniApCVXR4JXRRNouLtn5o4N5MYUsQjRt26Jh908+s9gYDn6F53sPhX0rGIJN49
+5r9o2eZlyzZ3cYfdwaD7mA3e3/vGZx8kw+qb5LD6Izy3DOh270cf8s38C4wXtPQhHYOQBnuEwq7l
+gKAz1qQFrJokIJ2dR1hDCKvA+Kme4ekFayobJl6qtaf5VBJ5iZoYxnuv/el11//k2oUL/7G/3xI7
+54wrOme+eP+Fm+6//9Au9o9bf3Hztlf/+77L/3tkxBzbdOmexZ/fRc/cjzrVeHxNYhaOR9e8WnTN
+1xBd82hEldHDJuogYojCgJG9ktcDihJG0Y4bQ8uJsYmhs6VHFWVyxMysfvUItxZguorhuX83OBkf
+6HkMoM0VwkbU6oU0WwgTuZBmU8m+mcRBrppz8RVXhKWFy9ctnZlYtu3Lyy//3k3bHKed5hJ8aYuT
+NZtPL5BdZ37za195acP8u7ZcfcVVn5t7ygPFAd545je3rbwoeLbRt6ht4Y7e3CW76vbyS/xnmGYm
+CmvlOqYcRGo4qxgVwAFL0QHToktIDV+11IbUsGEcOBRG01HxiaVIDAliwlCxFNJCHry4ryUWT+gu
+SOA2XhYmKDoFSWO9RIGkzIBihrzzKLkk8m31FTQIyeH2gco7j6oHH32H7P8aefBydRP522WXSaej
+o/3Rd4ymb4ORaMMrb6j85tF33rkwSx68DK75n8suW9M8Hs+9D+ZSM5NmFuiYwbSJZZRUVTFrs9ml
+GAHLDMXSXkWHIlOKuYAFpVArsGDJHIS5lOgv8Ub4TNantmwU4uO45GuokGEuQiQzkWIOAyBjYG9d
+c/dkZB4Pn3/+WeEQ+Yz6gOBfMHvt7H4NoxUt62sYPZAHhEg02esxE/JTMocM/5J1yLnZF4/jtZf6
+AeK4/jfpeJm1EWvVcRkP+1P/GY3wC+EI+i8wqyoK42UGRPf5wObXxqvUEm0QXicYLTObIinArWto
+pKw+Mhm5taSJLdyhrrxHw0ku1VCaW/k64rRD/T2eP/mLWn62lpckM3OZshux8FHrEewbs1ao4z2k
+cFnEzUQLdUouL0xCI5VpPswJssswH1mxxNio541IsEaYSRw+zCQPH2bMZ5bQGwoCN/U96g2tfE99
+Dd4r7Gmk7WXtyMvqL9WDL1eoM/Xlcfv2FqCxB6isRQWtOer202gL8Ej1ZA4tgkHgT1OAKpp6cli1
+0Y2spuWqi8l/HN1P3lYX1XIba7IeJX1ZQj+53YkZWX56F7GGNVMLSdXuMn4n/UY0e2DKzdSAfkN/
+/aaEub2up3j1eg7MhREy6O3CnBft129ne/E32SSbHP+VBn/cEuRCoC4tnMGrKF9WmCJ3C10vIwxT
+mJTQNjnBrXL85N1dx9fe9HsX+SX095nCuCtKcwg2fmkXLugN30M6t9Vwpr4KQyPOwDciLNDkMNs7
+9kN+CSKMFSrk7SljRGMZINlzNebksyg0AvWfIZPiWXk8BsMzrrSiqoV3gNdz4yYn+QYOEtwPswy4
+t2t8R2F1aHznphVZ1qrOd9Hj3aur8U70PhPuocUfQafh26hO49Z1GlRoUFQgO0/WzaNkgpnGLxl7
+/UhdCydOthdo9C1G4P7Gf53m6GLqbepb7Io/qw+RjX9m140pfyYbYQtxc330M34lfyVaMwkzKRBZ
+kOAg2ag+9Bd2UCJjyov00rGXfISMlTRZxzEc/zT/NPXnjtDMB0cVS9YQav/UzIeAnvmwDzMfqP9C
+wjRZzHuYmvWQAzmBSmVcinN7iAfkrGfPHvU99YD63h0V+o+mO9QP7tlDTqaHJ8DlBB1iPC8J4XI1
+wGXX4MLcIPsEuGwWjGcwsMTwsGqWiLF/MnjRfHQKWFh4cRygptIqS2HS9VV/3QmmUUggcEebC8Uo
+j2DYpSk3lwtyIVVICSlBngzEqld37Hh15054P7hjCixttTPwPhEmcSJM7gaYPHWYHOMwOafABJwl
+pCZDs4l4ye5n3z1vCiS3qO+Q3c+8e54WTx2HYzozyFxEIemvKoNUF4hS9bpXG70hOtfCVSWsuWUB
+vmGAL4zrTbQX1pu0uN/Mt80YoMOYGtSHUYmKSgdmKpdtzjQq2r1iyUim4JDLood82DCD5hV4jYKD
+l3PDfL43zWGlpAf4cTKGr9zFOwUja2DNvIP3cB6fSTY4UyE/qRjc3bHmeM+cnqbsyXOTt0/lVzbA
+Gm0WwcCxxOvy2VyElyNDSc7Snl2fzS1p8xv9+Q1qujiBPhjJHahxtEQXZDdN4vFVMdeIH3ftltxS
+jYd9qB1PRbcQxYgnJpwfD7H3yKgWeJwK+B1gEBUrcL4xDucHS/MCpuzV43ARWhDFZMqOQDRHi6jK
+tng3jQNMQ+lcNjS3o3/DUy0L4RT6N3pQcwUVYl8sns7Q4XPDniL1lxhMywn1K0Qsh9vatThePjdM
+CvmcFGZlQMBBBCmeT5NUDtRxONpXiOdzsAsH4VRO+l7kts9X+rZscv/gB4HnT6l84fbwBv+liyv3
+9b5SCZy7qLL4Ev9PyeHKDfcFKxXvis/OrZy3N/rSS03337DwYv+PfjTtq5VFF/p/+AP5ogUVjV8b
+8+Yi4zlfnroJWM+b0yUfGn6YM0VzvrzBiclxNC/gBMlxDVkPJ0r9WnjbbRfX/p84ffNXDVcxU/NV
+J+MQnIpD0wQc/JNwCHwMDoABORH0m3as++FO9bETZ/jFd6yr7lQfnwJzkw6zj7I/Xy8O1SR7QIOZ
+FofWcu2cXgqz6NNhdjQdJ9dOJpji5aHpXb2pKVAPs9OLVz75YXXj5ic/HJiab3dFkS0Mfzj2wcCH
+T27eWKtXPof6KYxMkObcYThW125KrAEYm6HKMc1kxuLhsb1snLxEs5l/PuX7ep5J7ft1XxXWoIOW
+pH2fpqx2qQPqLNKtwfBDmKOLYI4aUU8yUC+QQHOw+Cr+UIk3NKRVIyA/JC+SA+ohrZx5bC/WFOLv
+fAYG4a3a7xhrv0PGfweWCcXYrxdug3ryGdIGsHSoM2u/U6PJv1K9DauowZhG0B2ccd4d//EgXnWW
+8g/bK7e8+vT5JuLUsGBb51zVKGuM8E2xlp/lyJScuo4nE/jzwEuMyjeT5E719Zvf2UmSN6ubbyaj
++gHOjEdgF34vxsT5nfxO+nsMGLpREWxd7VdiJIUXqa+RvTeT1E71tZsVOKJu3q6+xubxx1I71Ne2
+Y20Nzal8gOrVcWY51dpaqkqc+rNDmVpmBWl0Cpk1qy/gwuxKm52PxrUs0DjIaTMuVyER6Nk/2W9B
+PGGCajrG61BNR7Fdy6zUPsjaGXzc2+eN8zN4v/fHkn8aSO/fjp+HD3ae+jNvKOQlaXgfewlkuKFO
+1yTTwUxjemGF6WXKKZTkPTkMjqLUhsW4h3Zm6KWdGYYA/t4e0b3favPkZ2hhdzEnRWlyDMDV15vM
+EKyyd8JUg02cVU7iIF6JlrN6YlgEQrNtCmHMAh/F9eRSwrEx61CqJfSfPrdHej8aSg1Z4ix7aRFz
+wYtczON+9Vewedf3DY4WN8u1aBZikVg9pqdS08RRu89vG3WnkyWT10Jo14DDG6Zl/hm31M3cLS/Z
+2tf1Ix999Cf+WVo7lB3P88uBtoEpsKVeyk1SvpDGHL9hQ8HLOvg0Gxf6fIW+xDAmEaSSMS1WzQu/
+NJs4aXo6c8G5X77j7c90LfrMZZ+95vrTVznPcadmF8j0eRs3ndbu402CNyrGvzI0pN51iu+u7+YH
+bzp7+8Dgmlx3uD/8gvrDn+xekzMbPc7CjfZVI3uTM8+6aXXWazaEArkrWlpe+iHOmUsZGz+H/w9m
+AXAZURZSjppbVea6SoMwFIvgNTgX2GdGH029cXtlWAl9GrBhArCCLhMmiA9f6GNTPtmXSqbSbAE0
+nDDn4AUjbpNLDeZ58yIjM6a3OVsc3uVrRUPEZzE7Oc7kCLT6++dsmj3LmXz0H3xSar7TvXyVIWfv
+OH9R2snaeBMhVlfQnZwhC47emeRbI+HpN3ZLlsTwUHjkvdSKvcXowi6Pt8Upm6yEN3qbh2ZfMvsp
+surirjUPGVgh+rnX7jNFzrv48VW2gabepjY54OIt6aVrW9KXYJ3695gb+Pf4HBNlZjLzmdkMLk/t
+VWWGlk66IKMMHlIK1dJCIEIBVL5ZFnMgaGpvyw/TPC+mZJ4hup9nxNZ0fnhkPhX6QBdjNmyIAFmM
+sbQhVQgbskCZNJ/Sio3yvQWj7JMLmJgwFDQ2z1t+xZYvjn5xyxXL5zUbg5MP7BZmd5+2+rqbrl55
+StcCKymEZvSHe5T/UdLn3dpzwQWJJR4vu77N0rZu9Yb5mcz8DavXtWE26MR9y4ahM6d3tuVOH/iM
+gyxMzJ0RWHQKlryvWbjuiq2zL/BvaG3FaQq0YIAWCuOjGQ0nMV9jys6aJTqSwWxQpS/47aH//M9f
+M1KnRXGmHYrtO4aSg/zNodi/ozhd+6xOm6dzn4u+B+h7kL630vcEvpfhbMudLXfGjWCg9SuBfiXY
+r7T2K4l+xdrPPG+12V2BYGsirf8jsyxwyOGccDCdVmYFCaPRGtOncySOBC64kaw6gWcSmvoBVxSS
+MAgsDghfJ/iCocHEverL9yZWPnb5BSnL7p89n9h0FyVqRg7PcDpIW9LXnYlN82TIxs7U7JvT9mBQ
+SJx67hfHyS3uPLriLunc86+d7mxT3+rb4X78Eo2imXXNK5uCY4/f7UxmkzP9s9gbp93Td9csb1ub
+rXfT2efR/ghfBeHopvqGG3PRk9StkQKQBbSkQX2WxCaSj1/alDA4Ek3S2DbvdO/Ytv8iL5AX1Mcx
+4DNnzvwWviVmaDl6qMj+fKy7iIIMu4PU8rUkKnfbYVZj8ihyc0dGSVA568OOOGUfzZL0+c2d5YSv
+VqNa6gRO9yVguofCaJOZw7DpS1CnfL63r4DeB+qPChP0FaQSIvUZZEhcMGKfhYJoMCaLPifZtH7r
+erLJ6fOL6gPFoOfMN870BIvqA6KfGNu9PQ4yl6waXr9+WH1a/UdHj7fda7f9Tf3bab5ZXtG8bJlZ
+9M7ynUaEv9lwNa7le5sndWEowGpSzzllVjHr6tH3PJaZabkwmAUEhj5G3huz0j/ltuYLObqfXxKS
+dmHi5C4pVPzYfzT2xL5fuzAkHVtUS2GH9ebv2tL89JzhGv4ZxsK4QJc+ieppfhpZ9NCkGxNtL8Fl
+x40zQmsRfLDUW8V9gt1N6yhcYKU5cBCHCPZ6QC8pcBmY+lFSkLV9WCDX/wUXvYfG9qpPEu66Hc+p
+T7KP7bjuITz4l0qFXf8yelBfQpXtup37x+7beb12oNFf5gZdUqsBdoEhmZvoZZoYHiNiPJasZYuN
+PaX+pIjZ9JgQpuXPIzcPMFqeFR3/BHBzN7OBKUfw983VspmWapgxj0/KYg5MRw7N+k6gRpr6UpPY
+FAMbcXCukpvQDGEZSx5LGeByDlVckDxusRSOALlkTI7TekJJXhAgoKgPG1O9WLzgdRhAlNfaMYGN
+ahTXpPKJgfaIaAUbG/b9qaXnfuU7Xzl3acpvxPZMpItdXzlyWcvpAavV2xxv60r7RdORSsfKbRde
+tiKXW3HZhdtWkrVaIi9W+WG/od8y3+Q/w72BWhMno6Ms/DuygWz87dg/kd2/Q3fZ79jZSOt5zOv8
+D3mmVhtvJvPYOezIb9WH1D1caOwFdvbv0Amn1dPNYIqGLaDjm2AetTGoU+tOGIGq1uiB4QVNRdc2
+HLiE0QpIGTQoeKFjXXyZdJKuH5Cbf3HsTXLvL8gNuN9ZYQ+QJvUPtBUR1rVtVv9AmlCdBxjdMGZP
+wJhlAdpyDMcrkFO6gPYuJallB2Pwha8im6BsAhWpFbMXMWWxWYtegLJUkpsBpG46KskC8A7oHOj7
+RM8n52A7CV1R6QjRzzgur3hZNJZMuQ1OR4C7KWloEs/Eydj3CmsKuyOhjpB6EN6yNI1GnjZ2W0u3
+gXvS7/Y8LEpw/NhM3u6jszervYe9UqjS4WMacoOxjsPZmAHHozau2LMUl3pFInZdIfmczvRRCQul
+K3rB62EsXuVu0Qpatd/W8n/xt10wVvXfdtL8QYP222IGGbnBPsuRKBgW4/eIEmy1pB5suNMxP9aW
+1aYWOhoISQOPbacyNapVs9HOTtQzhz2cNLccb6YaH8lpTJCDr738MukgHS+/rB5CDteSyXX+hf8Z
+sCe3w2820+oitEctGdoSajydjIZroihxotL4T8An/VH1Fy+91JADpgCVtfqChVqGuRKsYmeFEC1R
+MlDu8VZpWVZTzXcXoVZQOUKbqUWwmRpWaJkjoj69J6f8NBEtc1f2YNAIhGG8JpOO+dsHIk8ZWr3s
+Hk/C8JR6V1FLtKdDBm9kDfs7X6pbHmul3iy6ru/Wc3WtIKsKYPXQsmsGC4IVo6vUAbBladl0qcOI
+fs8gJTAHTDuTSGlezg9yw4YBkhATcY/PAfyMHv4US9vZ6HIzljw3GwjwjljQ9wphWd4g8BX2kbEz
+khnWYnMauFXeEF/g3g5JyLzYMCDrz9rtR1hB8kXXHAF92sILnIElR449U1HftVlJs0ROVn/LraS+
+/mdoXgvLLAL6nwf074R1Nq9XEeVoRmskhzLVny2305zq9gTWxfVmtNZD7TnAqqtHi+H3DZCCB+yC
+VJIGLASjFEYbuu4ABVTQkDOE0fA0xhY1ed1XzXRet8ptdHvP9ML7quucM7eI3qag2xQuXvjQ8hv+
+MmOGO0get02fN9067SJyphR6msxfus3b4glKnlbiuXGp+q2nAfM2gbOGJHe71yu0/1vP0FCPEflT
+Ap3oQf5B1Ldoqyn8S6G3uyCgwzslC7L0x2Vvdu/e3f3msj/t3/+n2vYf95EX6Mc+evrBrt8s++P+
+/X9c9puuB7U1uqjXRcSYNKx/NK7cdghj5lio4msD1vPWqhaId4BgRAwsbS3xpZ7v4mRBRxFnkpwk
+RCUunsLgZXFoq/NIOvF+aCilfrN5KJVtmubYcLe3uKsIhvOLRw7djm2ZPlxc7CfrI53FrpO3CLu6
+Tm5rfvlfggn1DnL1qwef/c0N6h3FxtqwJTqcm5lyM45qgnp7mRw2A4BVU8CSZ2x2YanHx2G4Yf3k
+aU2GEtfam2gVu9grQNSwTMZFd9nU1oUucK1et92tdMKqkkYR3kE9STmxIPYOEOQG2aNPwHr6WIZN
+FiIwBVPRPBcX4jDTPgn3Ioq0sb03kFEggLp3MgEOvgrIk6vpvIT1r2iQ+DUU95OYaxl0pbbSFiXt
+NEPbi2iXe2idfA8t9Rw5Lu7dWnJtN82o7R4E6YJFct2A/H6b2OSdSY3CplZAOQ4UEBV/f8nbA5SR
+B0+i3uWCSIkA0z0BMzpCaElWtLaiEdoqQY566DJHk7ijHSzmv+TB8k0ZTJVis8NBLnRYRdvFDusa
+kl6z6eLVm7YLTU71SeExsAESnzU2OX/gcrtdaoFYeTMn8DxrsHxxrfo07eC1mLWLCYv5LaNts8Pr
+dly7ZHSZ+rQv9XDTKWSV1BaWvCFCWM7A2UwO+/Or3tVl2rnAN2uZMI2hXEs7omiZorBeT8f6CmVG
+tjydioPp/Ui7IbqUYC0CbYIQ6dJqEZBxgNBeF0pAZVALsCQjWFJoa+bbKe1CrTThQomICtNf4qZj
+5Uiqi9KOBSFo0EiBJcCGMFvLYkpx8VgqhzI8WhATAha6CQ5DB0ElMyeeexESyuq42O6yOsjFgjf6
+lEl90tVk3L5pteUNZ5PxsySxSf36urstBmIAgpl5K1FbuT9W2NmjS8i1Lpdkv8xmfIu3p8SxD+xf
+a5PIqmK7V336FPLf7636ptVpNXMYaSGqDSmszbWNqLMaHGCx9DEzwEIpF3CuTYc5NZBRpENKAfuZ
+ldslKkJnAHlycMCFein280O/SzsGWdx9/f0lR4bmdTFY4RNma/HvVCKP6VCSmEoancSITVAKw4ZB
+rA7ow0nlkw2iEMUaso0UdNZuf7hNUp9eNrrkWmfCsdl32qrnfQEN8mwWkTpFNZvY9eyP1fuMnshj
+AlmLpLlw9SWb1qg/W20j9kt81rX3uO11GpEKutK+j4RUXwe7paLHMFjGwr1n8MO63QscM5dR8loP
+mH6apJ7PKp3VcictwemcDphHs1h8mtKy0mcA5p0YB7SBSl5ypgBzO1X/jBEwOWeCrJCw1mSIJLQm
+kZgF4CScJyqLBgc1SZN5cRBWlVTSSVCTZ12+zfak81qydHQZWeVtf9g+9iHMAMuX3yV/PUV9ytuW
+zXKC0e/75j2A+sKI7xI7sa7JVdOrL7pk9YU4mcha4bFmh1PdDqOuvr7d2Oz8vs/t9pGKVXCZOLv7
+HvYyijiL+jjMkycZB6w0M3R9xUX1Nz2/jKbvac1DXTZ0yLq1Hn2Mh1aEl0ze/npNuB42YEEFF8xE
+Mpy159fXPVwPlb27hyRYUJ/IPeol7Jrrfr3nrD3qu3oA1EMsr7xIkqTjJV1ffRJgcsGqN123zGAK
++jSYtGwGi5bKUPJi7yU35nWVLYzYr1Wpo0tLpBBhV0kKErqzC9E8QHRt450r5B4EST2oAUQB1gB6
+VH39xVdemkKjYZ1GYp06Wvadezz7TkRj1ubsp1aaQcIsPHfJ6tW6zk6gU4J2rSBT6QTraKUGUwOR
+HkXLi4xOhmmpDpO3cdC0vMUGsKQJYLl0sESaHGjDdZBx9U8dyoSZ9qM4Doi0irNyHBg3oyWp6dd8
+HU4XczvzJebLzFZ9PDuqyvKM8oUMUXZTcDURu17rTvIg5oAx2sCuF2c5HAZPNN46uGjNNbfcese9
+6BuwuGdZ7LHktIFTz9/ywJepEF7eIbqf903rG5y3YM06vOYL4iyzhfGuv+jWHTvvpW5Oz0Se8Bh9
+gtcnZNE1LIfZgg9dcF4HQaHEFmA6wn/sCGwEZRCjqX1pgtuFvkKYlcMkAko5nCkMc4VkAUPlhTSX
+6kvhjIcrU8aUAyYptocV4D4OnPwFXxbevD4pzRVylKTXUuJpJP2bqckYIzaf3+Rf7RvuD5nSXEe3
+kRg+c1U4Fuccabtjnmgeakm7si6eGNt51hQIyh6P1egytjUZbW0Oh4fnE7zBIvh9Rpcp4pbNlvb4
+TJvVHOmzWYXMSqfH7ewMDpucQ05pmOM8hOshHBfkLKLVLcTMXc2tD5Mp84CcEr262TwvYPXwtrAp
+E+bdi7zzzUaPxcZdEWodjpiJILishLVa4zKbYe0mzpd0hwKh5rDLSIhg8STMJm6hJHdaHB3egNnt
+4cxWOSW1CCmDnTPwrXGfjeNsbqOFALWElNMqC7HLLrO1ChabyPvXENbI286qxclY/ln+VsbLMIOk
+QID0fbJBLoCSniLGWIY42fXRZRv+Yac6dvdR+z9cv33sKWen89K7Ol3sunNf6Tv93Dvf3vbs6fMy
+Y0+5XJcwtAfiBuDNp/S8cM03t4LBfgO9VaVArePmDPaVAkMfphPol9OruBQmqjT+kz9U6ukf72lZ
+zlPrLY/WG3ZGxJjQ/6Jag2CzKdpwaqJRd6JtsEIPqzatdrpS+ZdxQ+9bx9tUH0BHIHugON7fAW0A
+rNjS6rX0kKrWMVmzq5kSY9INd1ycDKCfCGKRe/vYIu4W9eEKv6SIBd7qQWwAwzTaFminJ5gN1IND
+aFVrKIeagj+G1e1aBWgyozgPKTHaddAZQwKCagJg0Ebeca0nIRaGxWlhGHYhZLO47jIlB6y4SkRz
+D0qNHVPrJR7Ua0fd0rQzbI12pGugvdI+gH4GIBz9Rw1jMto+oBEKSzppHTozwa7HuKgXtKNaZp47
+h1F2jKpr4VbMTCA0Fwk9lNgfhStgEFW4ubKzglFX7YN9Td+rYEi1gi84wLXQj2MPaCfZt7RrGL1X
+515+L813iYCNPsIsYX6md2x3VtFTviinBKrK3CyWBffTvgS92XIbpVnbSebOWvudpQ0pAbAk6IXr
+UWsndtpIaqb+cFUZdtG4yYLqvsKC2aZOpYdaGwXaB0/PfliGSjD2FbA4aFuN0jBI31L3IOg/BTAd
+njM7PXxGyzoKaz25bKLWG2dfR/fgMG62aUk4SlwsZQZw4fGT43X58ekd7+KxPupPwC0ZbBGWes20
+/ZSghakSWkEA2Ogn6gt0cSTd0iL7lsKrpcUnr2yPXEfM2o7DCXbOghwJt6QjcKqFlE/QPug27fzv
+u6It6ZZvt/QYthGHw4c7lrt9odZcbqWvBW9D/aO/ZAb4bwPvLAftCvMdUlW04kCa9MGoVbFXBPZv
+YEopzDmY2a+0iPutzmBTD1JIcpeyOWpEGGG5yWVxVeorEIy3pjCALBDgN71/vYCNJeGwfgk26AnD
+wgNqZoTgN1C5jMdAwpKm4LT4lnkzp0dntafaRHJn3O9sOtVrTp8UV68X5pJrvR65Kel0tY79undh
+4VSzwTmtNen3ktN7hzb1BeSztpiE046NCXNZw+zpouu85XNXbTq1bb7KkEP/tKx/VrOrp6OzC3/1
+7Mw6kY3G1SuF2eQqn0tuTeEvjsyMD89qbZXw9wp5Xtx99rmn/e0jRhgkH83ef8a6z7VGC374Mc23
+uILp47/Hr4cZl2eGGJTC3dSPI2QJkg+0Bq2bWIemNWCzjI5mbH0uOLV8HC4HRDVofh0gCHVHYZ0C
+dlRMsylYhb24jPtkMG2HWbRcY05KJ+OKl2656+zz77r5xfi62fNf2iC6Oi+fNzJ/9rr4E0PDs3xn
+bFx5mW3W7OEN/YtmbLk8t2DwHM712Zduvvmlz6ZPvWj+vH/+rCzPuHneSfPmX3RqumntScO+Uy89
+/VLb8Lz1zfM3rnrymRXnaPj1f/QBfzX/T4wf1h7G4wVAYIwJbXqfErADPoyzYKQnQKgQkC7wCSZE
+L80fgBHvH9kx57QzRkjTyMgOk/WCg+r1fz3LnQ4VRg6O7BBsFxwkt8J+JhyKF0Z2jJxx1iz1DyNk
+41mzdo7gV749ssNswu/8z1nu7umFEcKfAd+y0G9tEHtyofiFnXBkZET9wyxNrlf03oHYQSWEefA0
+0hqgVrWbemSMWtcXGBnYd2tVGLSDBhU1Gdr+pckNyqbR4NMew1AQtZSOmlVciIpRt16ZXxk878En
+vlycoYVWimio/svQ2qGhtUXuW1I2HQ6ns9Kx+SCx/8IeOPYanhia0EvdP54VE8hgozEU0wTjR6lk
+b6EvKxOfV0DFgYCMJpkf/wxUWmvc6XR0OEgT/WhV/3jwJ2TrTw4SuRV2nU71LSd+xNX/Ug/+7McM
+R1KMG+zK3zA9wKGzmfsZrGPsoPWNw9lyN089LuhJGKBOSHe17B7AY24Puhzm0AY5sNZlq7hAZl2l
+LtJZ5t0zMBUQDE5vZJhuuUqzgJAgOpqx5r6pWpqLTY4wu4jtV7pExYyBkG7Ybe9XBsRvMI6m1Awa
+61fcmDGI3nDQccU0iaf5fK+eKcjLcRAKooyV+EbMF8Sid483zAGXiQ7ioU1fSerzhnWLjB42PbIs
+E12/fXkxOXflYCf3kKlv0azY4IpCW3l38Utr2gJ7XWKHt1nghxb+6Yn1K0lp6TlOspwYHYFM//rC
+6bfNFpYt5z1dMy8YWbDYrlYdgqdr8Nzhzz9hXbpMXNe2iQ2HuvySUQCz3m0aGOt03zprfkCPCZ/H
+3cs/DbTdweAqBHYDqChhGk1spo3srNWyhz4QxOPQaSocUvppD/rWbNlPux/6w+bOskD9XwKjVZQ7
+Na8FUtKPjW/Z6SOUYk7xOWukpaMnhzsOt9IFtO3owcUNjUtGLHUNaoHlHNILaEmlSryXPkJDAEsf
+KJ2T4j7YFoZJrg/ntIx90ZI0QyY1bMAclOJjfq/FzGW6Nz528/cfmLOiNbHa2x6Vw395ySRJ7TPi
+Z0vRL0SXDGbbl6c65J9lU2tlf8EoWUSbaJ5ma2XXF3sKwYG1Z7atL1/du7g5JHX1N6/qyBWz20MD
+fVYHiYW/GJC5EZ4P2qx38w6j3SpaCnfNB5kD1jX/jK7LRGr9Px0ZxYbNRJAoJSsYg4qp3lQ0LppZ
+fGdpDAXsZf2TRgFpSQUNhxzbyt2C0T1WlxFG+gwF7H7xmN4TxpgDIa1tmmhipbdaYnhgbzvNk6ee
+uXKIRkdDMrZAwz5LOIosbZah5dXhgwYwtc4uwxct+iNfLLSisNSE7chdoLIGstl9bpdkopVyHpRN
+2Gmjlo6nmERYE8DoNdFaSMUuKiIOqGaLR2nPaQz0aI2QOFFrilQAFZJ9uYIxpNEirb45p3gOOruL
+BFv2ICFo01c8q7U4OowNiiqVCTRx0DrDGLNHyxcsCRbsPER9koCrifpdQHK6qJO3mYpU31QCCICM
+UwJkgX9FJIDDReNfoRaNKB4gzr6gxWrSNLwMNt5qJICgESAWwWoD3oDVBqVmF5zzYx2mEmigho49
+N5kqDdRAGhTrJDlnnBoaBdgD41Q5thVLcigPLtF5xA1csqnWvxRNAnRfACEoU5TtDtrGUMSJLWcU
+EX1R+zwu0UQf7SLQRyV5aB4hdmSyUuzxIR20A85+huWMtEuEA6tdDTydt7o/gyLGYXBDREtL527k
+ZRgzbUxrDA4aOiDCvQ1GDj4oosJ8HA4Chd6NmJTdtL+2G9t7YLFYleJgRd/VPg8dHTvFU6A4WDQc
+RMrCFAfPRBx8k3FIUOg1Bk014kBbEBfPacShSIHHP8qVuERSvtTtGgtwJmKxktERsNZqRFz6VKWw
+Ow+VBasHlyRgUmw7Sbva+ixmfAfpq8FtNaE45YxaFUuN4LQvWO2Vk2rihNaD0da2mLrYQHTatrv+
++t/BawV4nRReEDAgfCx0nbC4EV6L7xPgzUlcA8x1eCsakHoz3hODW+/5qNWdd4zX7jZPLY2W6wXR
+zNSC7Mn1Y1jQ+PD77z2CRYwVraRRq1zU6hi1E++cVCt3HGivxdFqsMTQizkJmvhUaFBkyCAWaKkl
+U2r24GbseCXjkyH0dJP3H0ZYsNLykfcmAFkhS9V9COkj72l1mI2QqrYjR8bjfv9reGPj8Eb/Hnjl
+JiznrUM0Ad7ikSMatO8/PBnaIiCy9P932kY5hLU2zhNhJYePaEyAiACPzGwg7WaAlfKkwUvrC4PM
+IFNfjqnbBysH3FqnY1AHZNrVGESpQI2oWvaGIooKp+XYY0KEJ18HLl+DWnvUW6UGFxlFeBCuivqw
++jA+BmxCIS7V814DQXeI/yoTxYwfh+YbgiWxmUakMRnC16wlQ5Q86PF34kwFwoAtF0HLuI/J9YHh
+ZuhzF/oyoImBrsUIxtdMMknvNhjMZrPDZmWdxGE2yerPyZdZVjCbnRb+gPrhYhcreNRFXslqctrZ
+CzyiSHjyrM1pM7uMP1d/utZTn8uUbn4Y45lMmdPpZsKabCw1CtK8DhCL3vrUtmoTuhTk9MxExSUq
+zVrnURjSQj6KhZDUY4VZn7R5BKUpjm8mr9Uik8OOyhlnPPoOrkxU6AAxnd/S6PctXmDZd2hQQKNs
+Q01AiGllVutwOumiGgTAEg22mVXz5CRR5QOT7Dl/IBxpaUWtF/SDOFYtYzWLyRyOxenRoEi9bfUi
+65Sge920gt9CCvMVE7RqQJ9Ny66rVVQ/uGVR8dF3yJ/JxvvI4fvUJzSWOHvh9ffWGPS6Ze88aiZr
+71Nt96kPTaltObVWj9NEH9Lhaaxw0apysKUEWKKBuoeq9iC053mzxeF0e7RKRrkJjhCjYLO7ROaE
+NTqs3ljiRFU68uV7Lr98z4mLdNx4+vIGOYa+UBfofmm9C7eod3CgD3mUaBGfCfQF+nQ6NzqQfbpP
+sSYLzCxt7Q+rvMPK+62uY37yAnkRMxmxWyY2l3Va1Pe4FuxGjGwytiXLHOf+nZPu//fdXEshNE+4
+excWqauzyZnjd2cP0PDU4aNvTbj3jXBv7LtZw11boQ1aY0rQ6GxZvL1Iby/i7aUpuIMZOuHmPezq
+L6vzdrG3Ntz8u+qP2dW71Xn3j83I1p/fhXijz9Zfx1yqYgDRoPUi91HMffTWPrx1cDLmciHFJTxY
+WdoIwMaDGzez3+KO3HfwPvKjBvL/29mvbjz2JmH/8T/hjGo/HhzpE8Dhyf4doHhkQS7I1gZQth48
++1UO7/Y3ck4DMYoHNx4k7wB8977HfuvoH7OaDJPxmRz8s6BJmbDOg6e2n5lWPhmr2HFOK6rHmh8z
+kfkH1IT6/eXsnrEN5CHOdfQV4lKvJnuq3BNj02sysUhxwyrMpQyuHkYYSCMdSHzmhiNbNor0gRI8
+7Jmytef/gfwxUhHkpO4hWkrnNIrustkna14hTaTgcwhkWjGOOm4siXiHpCPA8ZWwd9fYnF2YKVYs
+7uLe9oapEDz2DBboq5tD3PkVyn/DtP+eh+bjzWJQPwQInRRCJxgVZaNzAnjh2kJtpJ2KmZIRRGDZ
+Kvv1xvh1oCSQfhSkRAHLo7hxwNR3r9mmfg4hm3v9NWTj9WriN40Qvq6+d82NAGAJTm64Xm3lnqjU
+5orR4KCwykycPiuxtQGYRENnBY0qQorUaeJpKIvUwTj/CfWQ+rxOoOITT9xY+z8OivohvYgS6+ir
+9ORNX8f3Cb1J3ZR2F9E1GWjnoLRzoEljdKHKHcRy5BJvytbJ5wQKM+OBHLpAOl3Iz9j9x5alTsAg
+tijxYGk5rOYlJLB2yDKRzvhATkpmTSnnaFa7RufNqo2ip4WhKw00BjsCsHqSCiPaPrhSYY6D02nH
+wel42EyAvxF4JSRinkcJi0LKVlsA/UOwSE5GQR8oLdZvJuMoVID6l1AcaLRfPdiIwyUVOjY6Fvj0
+1BoOFZoPZ6acMrl2QNMQwVzR+rcdXcErev86MnqE5g4ni7RrxZib/iDGls6D33tGt6m0ztg3Y6Si
+5AvmsL1JSW6mD4ssWZ05fFxkyebSqSPUWuhaqSsNvRA+ugpTIlktaFUZNOPVh40NeM7p0mNAbq8k
+ah0btZJPUDlKxAv0MyFhtXRb+KNuB/qiehHuDmDWv6Zf0h7Ro3rTaLoJBtrL7LdpRA/zcg+9TON7
+9V72tbrsGVpdNi29ZmpOFdmKS9M+s0s2Yf9njNWYqcZusVJHYY8mHkX9ycvam1DvZ5HwYrXOeA95
+7UmwxWxW/08bhtBGgVYL3W4Nqu8GEuwB2h4ba2Bq75t/oJ5Ee2D8czGUj/qNBvUK2o9vZcQjXinO
+jTT2Nl7C5DBDhkYjbTklVy2zVgfau22Zsr85gZXmKXxWwniyaxsmuxpbaFPjaB4hp8/2kbAHLZen
+SX7APjRwiksPboc51OqdBCi8OEAOBxaTUZrJmw0E1M2LA6otsFjdXDsy3ZYkd6pbkrbp04nBLDm4
+a3wBwk6Hw+oWcmf98LHb8bAe29RsJz/TzLSAnZxmskzZr2sKvgz1mdNSH7cX3UCZjNb4yO2iLBVo
+plqcOMVKKuQS2K+5bsNHZSkB6KSiJJ+QtCxz0E4PotE0WrkAdJl1RfWOYq24AQswUxfQY6hQaVdr
+Bs3YnMrZ6qFi3dwfrZx9dqU4Nu+RWx+BcXExLv4h/iF8RrA7zMlhLjeT9GHBJxAwTVKFYYLpw07i
+IpHhe847/6f3Xx+JPCIKnu94el1bdh47d4todHze0e1+mPt95x13HTzv/HuGouRhd9pxu4MXt5x7
+bOcWscf7oscoPjwxtx/Xt4zeXwmf45qheXsnZUoj9AEvTWhfZmCCtYn7ku3ZWZRomJpQIPneYS6L
+zCvp9VE0K8Hrm0mGyRDpa5ElL3aIBo0/zcdjDt5JJAe5mPUlV25emfQRQi52SChkvOGQ9/ve0A4y
+vINuGIPFra9vO/2xq4ozu8zm7EFvzkEyWd7eEpC8Tc0WS1b9qSPnxXZ47JNSgI/yMekev/8eKQab
+AaliCpzU0y5F29qiVkt9/mIecKAefycTO/dGpUQ0hT1dJa2LPX2JMn16x0fcN26gj+PQus5Xdh2h
+T6TGf+rmou5zqN3DTDvatOoRdm+OSjvLIepN1vpUaQuB9gSReuO/WoubXH2riKkGtEKIfhT1Hc0c
+r6VwsAc0rqImJj5LSu+ph70UsGpsge5PcNXtnq4Gf4Ko+RPw+X2iiz4DoCXe1qF1I6D7wZZkW7tW
+5DmpjR6G2jzoPMxpXf0NOXQogjqBfeiVrewBrLccm7NVoZ2TKMNjLyqgm/6UM3IYr1Bt8I7VGns1
+IUa930XNoff/Ek6BT4cTXTI0NiAfj5P+oIETYlShDj/69II6RvwEfJpAW5szBZvWqdgkdGz2eaXm
+UB2Xfd5gc+xjRgcYGEaH6J8nHBXqXKlo5tdEDCjkFH4qKibA7oO5NBX24FTYm8Zhl/3jsEs+vc/F
+cWE3iJ5uclyIdSk7EVT14V14eNeuqTwjU645dRxSL40LxbPYojFBH/Wjw97WALu3nvGPtVnRKrYu
+byW15zbomGnPATou/PTp0xiH7iQ8LuugxB0HG6Tx9va+/uR24ulr3749eZxpgXGQ1dvXrt2+Gltm
+TZ4PcVrvOnkUOqaOQmfDHI+2pibMh1iy7e+d43Ea24l/3Ay/u4jRg8rHznD0fzPGCbhoVU8pZskU
+bNqmYtOuY/O8Vwo2hyOxRB2f573+YFO4pTX58RjFsdZV/gR8iufixD4BMqM0/7uODOrDE/AJ0fy1
+Tmb3OD7hTCnWDlpVhLIfNReQG5OUCVPZ40mzMBYQZHUG1MoE9wXkZhOtCwvi88aQH2P1fu+YzdJe
+VdpdNCkrgxn24wKRKTVhURho0V6s0zg+eWQYaz1OBySK0kgGhoqOS6Jziuf8K52TlSnyr0LHGhdI
+KiRpCGly35kQ1lZovrkQ9YIGaMhSp0N40mMdEeO6h46aUl7gX4vDw9GH/Smi+JzZybvlJsoMwRBW
+WdhdjFd/rJrUr/jc+4w2kZy4vU6+EKW2Q/REzrvQuJJ34qc70gVBy/3j+b06ri2gE+ypYRvNgGaA
+iYtNmQYBlJiEcAucz5ZbaIlOSxgszBYXOoWVQBarUeQsPtdUHHfEtnhpSh11VmKTLh8+WHaf2enm
+KUFiUZ0gYf05yrI/glan1ECUxiy6OlGAJ6hChM/uwdXxBKQJ4PxGnah4YtJ8GQ0W7R/W6n7w0YP8
+i/xJ9NkKl9MMN+pdVuyYqWLSqryjDWYWNtLVah4FzfkTw8A0PmtFkrFffymMqqobDJSSFZ9m4Ixg
+fAQfdLqPsWhPXbaL+6xOSXsyIEclM4g2FNTxmECzMCSv7CBEi2A7Llv+Bhm96Zonnrgm3dX13CVf
++iU7sobMoBY3eX/F5cgHT3/wlGPj1b94IGBzbFLv0x8H2YAb+vzDDHXrhw+h7kcbF4cBZjFo0BxW
+FA4zweSsiWBoyRMAhYl8lXzxzGsngqE5LygcX1UvDn6leM3TUyDBNYPouboXg33BAIMLoOhGSY5g
+01CSQ8OMnAlmmfrBE/gfvoSfld3d3bup92Cpuq9W73ot/E6B3w1rDuPx+mSsTMllCyL8oKg3eaI4
+pHQMfBJmw13bn+EvWDS9C++S7lt0gTk7cP0pwS+eeeUjrMO86AL2QH695PItuiCs/qi7m2TDFyzy
+R1rOGzr1s8ZTLnvkSt7Jsxcw/w8un4kSeNpjYGRgYGBkcFz6/1NPPL/NVwZ5lg1AEYbzPJx6MPq/
+1f85rHdZJYBcDgYmkCgAaDML2XjaY2BkYGCV+N8CJq3+XWa9ywAUQQHzAYk7Bkt42mPcwaDBsoGB
+AQmnwNhMPQwMrBIImnETELsxMDDchOLFQD4LkPaA0CA5qP4TjF9A7P+fIGb9/ww1kw+IxSFq/u+A
+YBS7YVgWiLOgasURehikoDQjlGYBmjEHqocRwgezWdD0ofgLB4aZeQJJzBQh9n8rkFbErvf/bKh+
+mNgUKL8Ui3qY+R1Q9glUOxl1oHbuBLIFgDQzDgzzJwuSv0H4DBBnIPGVoOEA4+cD3XsYiudjCRdQ
+3DwC0m5A2gpICyHCh1EPzc9eQCyKpJcDKp4IxExAzAoVZ0XCDCxHIPYwgMH/GwwBDJYMJ4DpRx0o
+xoQCEeAmmGRBEhFnQAUpYBMFIKz/c1AhSOf/T/8/AeUqAVIarnx42mNgYNCCwjSGJfggowGjB2MA
+YwvjKsZzjP+YzJhmMJ1hesesw+zD/IWliDWFjY9Nic2F7RG7D/sG9hccUzgNOBM4p3BxcblwdXC9
+4w7jnsD9jMeOZwOvDG8Z7yo+K74Evi6+O/w3BHwEOgSuCfIJqglOERIRShC6JSwm3CfCI5IksktU
+TXSSWJLYLXEf8TbxFxIWEk0S+yR1JGdI/pHykqqR2iZ1TeqJtIi0gbSfdJv0NukH0l9k+GSiZJbI
+vJM1kj0kJyDXJfdG3k1+gfwB+UcKbApaCm4KeQoTFD4pZikeUXJSOqFcp7xORURlksozVRHVDtU5
+qptU36lFqXWo7VN7oc6nnqV+TsNCI0Vjh6aZ5hWtPK032hnam7R/6bjozNDdp/tML01vkt4vfSsD
+CYNthmqGdYaXjDiMdhgnGE8wkTJZZMpimma6z0zMLMZsizmXeYL5GvM/FgEWWywlLCMsp1lesZKw
+irNqs7pmrWNdYn3PxsEmw+aOrYvtCjsBOw+7PXbv7A3sZzkwOSQ4bHFUcuxw/ODU5PTDucP5m4uN
+S4LLPABRwojtAAABAAAA2wCbABEAAAAAAAIAAQACABYAAAEAAQEAAAAAeNqtUs1OwkAYnBY0Eo0a
+STj34MGLDSAiwsl4EP+JRtGjVCiVQomtVBKfwmfw4sWDR59A38On8GCcXRYkyMEYaXZ39ut8s7NT
+AMzhBRrEL44FzhFo0RjXK+56WMMS7hTWMYsHhSPYw7PCUeTwqfAEbrWswpPIak8KTyGhvSscI/5Q
+eBqL+rzCM8QZhePEZwq/IqH3Pbwhqd+HYWjabrdddyyv5ZuW18QmPLTRxTUc2KgjgIFHjjSSSGGF
+qMK3BnZwgRbXXfI7xILfgMnKBlw+xpCCL3dVrlWuHc6XZG7x5ucooYhtnnqIAxyTV6SWixqHQ32b
+PUfk27hhRZySYmdSeinghKeX2VcYq/VTaXlE67cOjJG+U3kPn+89mcGwp5LU6O2+q3UyA1iS3xl0
+mFjjXECTqg1qCk6NVXFyhYmbWJUjx9zTWP/jLcd/qfHVUD4mu11+5TZ9O8q1z6pAzX/jlOmyQuei
+Ggwy2VeZ9v2lmZHIM4e8zDLPLDKD/2PmC43JiIUAAHjabdVV15RlAEbh2YBggd3drXO/89bYCPPZ
+3d0CioAoKnZ3d3d3YXd3x4E/wp+g+M32zPfkXjNrZj/PwTVrOmM6o8/fCzpF5/+ePzsdxjC2M7Yz
+sTOJcSzCeCawKIuxOEuwJBOZxFIszTIs2/mL5VieFViRlViZVViV1VidNViTtVibdViX9VifDdiQ
+jdiYTdiUzdicLdiSregSCnqUVNQ0tPTZmm3Ylu3Ynh3YkcnsxBSmMmCEndmFXdmN3dmDPdmLvdmH
+fdmP/TmAAzmIgzmEQzmMwzmCIzmKozmGYzmO4zmBEzmJaUxnBidzCjM5lVnMZg6nMZfTOYN5nMlZ
+nM18zuFczuN8LuBCLuJiLuFSLuNyruBKruJqruFaruN6buBGbuJmbuFWbuN27uBO7uJu7uFe7uN+
+HuBBHuJhHuFRHuNxnuBJnuJpnuFZnuN5XuBFXuJlXuFVXmMBr/MGb/IWb/MO7/Ie7/MBH/IRH/MJ
+n/IZn/MFX/IVX/MN3/Id3/MDP/ITP/MLv/Ibv/PH+Gkz58+ZngnzZs3odrtThzu5++8WC99w4xZu
+zy3dyq3dxm3dvjt5uMXIcKuRcYN5c2ePvqhGpoxu7WGNX2q6ox8eeImBlxh4iYGHDzx84OEDDx94
++KCbrmsndmInpWsv9mIv9mKvsFfYK+wV9gp7hb3CXmGvsFfY69nr2evZ69nr2evZ69nr2evZ69kr
+7ZX2SnulvdJeaa+0V9or7ZX2KnuVvcpeZa+yV9mr7FX2KnuVvdpebae2U9up7dR2aju1ndpOY6fx
+Xo29xl5jr7HX2GvsNfYae6291l5rr7XX2mvttfZae6291l7fXt9e317fXt9e317fXn/Yi+6j++g+
+wx/fwq3c2v3ve607vEf0H/1H/9F/9B/9R//Rf/Qf/Uf/0X/0H/1H/9F/9B/9R//Rf/Qf/Uf/0X/0
+H/1H/9F/9B/9R//Rf/Qf/Uf/0X/0H91H99F9dB/dR/fRfXQf3Uf30X10H92ntqf/6D/6j/6j/+g/
++o/+o//oP/qP/qP/6D/6j/6j/+g/+o/+o//oP/qP/qP/6D/6j/6j/+g/+o/+o//oP/+579vpDzsL
+/z3+AcxdM0C4Af+FsAGNAEuwCFBYsQEBjlmxRgYrWCGwEFlLsBRSWCGwgFkdsAYrXFhZsBQrAAAA
+AVLmWK4AAA==
+
+{-# START_FILE templates/default-layout-wrapper.hamlet #-}
+$newline never
+\<!doctype html>
+\<!--[if lt IE 7]> <html class="no-js ie6 oldie" lang="en"> <![endif]-->
+\<!--[if IE 7]>    <html class="no-js ie7 oldie" lang="en"> <![endif]-->
+\<!--[if IE 8]>    <html class="no-js ie8 oldie" lang="en"> <![endif]-->
+\<!--[if gt IE 8]><!-->
+<html class="no-js" lang="en"> <!--<![endif]-->
+  <head>
+    <meta charset="UTF-8">
+
+    <title>#{pageTitle pc}
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+
+    ^{pageHead pc}
+
+    \<!--[if lt IE 9]>
+    \<script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    \<![endif]-->
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.js">
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/js-cookie/2.0.3/js.cookie.min.js">
+
+    \<!-- Bootstrap-3.3.7 compiled and minified JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous">
+
+    <script>
+      /* The `defaultCsrfMiddleware` Middleware added in Foundation.hs adds a CSRF token to the request cookies. */
+      /* AJAX requests should add that token to a header to be validated by the server. */
+      /* See the CSRF documentation in the Yesod.Core.Handler module of the yesod-core package for details. */
+      var csrfHeaderName = "#{TE.decodeUtf8 $ CI.foldedCase defaultCsrfHeaderName}";
+
+      var csrfCookieName = "#{TE.decodeUtf8 defaultCsrfCookieName}";
+      var csrfToken = Cookies.get(csrfCookieName);
+
+
+      if (csrfToken) {
+      \  $.ajaxPrefilter(function( options, originalOptions, jqXHR ) {
+      \      if (!options.crossDomain) {
+      \          jqXHR.setRequestHeader(csrfHeaderName, csrfToken);
+      \      }
+      \  });
+      }
+
+    <script>
+      document.documentElement.className = document.documentElement.className.replace(/\bno-js\b/,'js');
+  <body>
+    ^{pageBody pc}
+
+    $maybe analytics <- appAnalytics $ appSettings master
+      <script>
+        if(!window.location.href.match(/localhost/)){
+            (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+            })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+            ga('create', '#{analytics}', 'auto');
+            ga('send', 'pageview');
+        }
+
+{-# START_FILE templates/default-layout.hamlet #-}
+
+<!-- Static navbar -->
+<nav .navbar.navbar-default.navbar-static-top>
+    <div .container>
+        <div .navbar-header>
+            <button type="button" .navbar-toggle.collapsed data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+                <span class="icon-bar"></span>
+
+        <div #navbar .collapse.navbar-collapse>
+            <ul .nav.navbar-nav>
+                $forall MenuItem label route _ <- navbarLeftFilteredMenuItems
+                    <li :Just route == mcurrentRoute:.active>
+                        <a href="@{route}">#{label}
+
+            <ul .nav.navbar-nav.navbar-right>
+                $forall MenuItem label route _ <- navbarRightFilteredMenuItems
+                    <li :Just route == mcurrentRoute:.active>
+                        <a href="@{route}">#{label}
+
+<!-- Page Contents -->
+
+<div .container>
+    $if not $ Just HomeR == mcurrentRoute
+        <ul .breadcrumb>
+            $forall bc <- parents
+                <li>
+                    <a href="@{fst bc}">#{snd bc}
+
+            <li .active>#{title}
+
+    $maybe msg <- mmsg
+      <div .alert.alert-info #message>#{msg}
+
+
+$if (Just HomeR == mcurrentRoute)
+    ^{widget}
+$else
+    <div .container>
+        <div .row>
+            <div .col-md-12>
+                ^{widget}
+
+<!-- Footer -->
+<footer .footer>
+    <div .container>
+        <p .text-muted>
+            #{appCopyright $ appSettings master}
+
+{-# START_FILE templates/default-layout.lucius #-}
+.masthead,
+.navbar {
+    background-color: rgb(27, 28, 29);
+}
+
+.navbar-default .navbar-nav > .active > a {
+    background-color: transparent;
+    border-bottom: 2px solid white;
+}
+
+.navbar-nav {
+    padding-bottom: 1em;
+}
+
+.masthead {
+    margin-top: -21px;
+    color: white;
+    text-align: center;
+    min-height: 500px;
+}
+
+.masthead .header {
+    max-width: 700px;
+    margin: 0 auto;
+    font-family: Lato,'Helvetica Neue',Arial,Helvetica,sans-serif;
+}
+
+.masthead h1.header {
+    margin-top: 1em;
+    margin-bottom: 0em;
+    font-size: 4.5em;
+    line-height: 1.2em;
+    font-weight: normal;
+ }
+
+.masthead h2 {
+    font-size: 1.7em;
+    font-weight: normal;
+}
+
+.masthead .btn {
+    margin: 1em 0;
+}
+
+
+/* Common styles for all types */
+.bs-callout {
+  padding: 20px;
+  margin: 20px 0;
+  border: 1px solid #eee;
+  border-left-width: 5px;
+  border-radius: 3px;
+}
+
+.bs-callout p:last-child {
+  margin-bottom: 0;
+}
+
+.bs-callout-info {
+  border-left-color: #1b809e;
+}
+
+/* Space things out */
+.bs-docs-section {
+  margin-bottom: 60px;
+}
+.bs-docs-section:last-child {
+  margin-bottom: 0;
+}
+
+#message {
+    margin-bottom: 40px;
+}
+
+{-# START_FILE templates/homepage.hamlet #-}
+<div .masthead>
+    <div .container>
+        <div .row>
+            <h1 .header>
+                Yesod—a modern framework for blazing fast websites
+            <h2>
+                Fast, stable & spiced with great community
+            <a href="http://www.yesodweb.com/book/" .btn.btn-info.btn-lg>
+                Read the Book
+
+<div .container>
+    <!-- Starting
+        ================================================== -->
+    <div .bs-docs-section>
+        <div .row>
+            <div .col-lg-12>
+                <div .page-header>
+                    <h1 #start>Starting
+
+                    <p>
+                        Now that you have a working project you should use the
+                        <a href=http://www.yesodweb.com/book/>Yesod book</a> to learn more.
+                    <p>
+                        You can also use this scaffolded site to explore some concepts, and best practices.
+
+                    <ul .list-group>
+
+                        <li .list-group-item>
+                            This page was generated by the <tt>#{handlerName}</tt> handler in
+                            <tt>Handler/Home.hs</tt>.
+
+                        <li .list-group-item>
+                            The <tt>#{handlerName}</tt> handler is set to generate your
+                            site's home screen in Routes file
+                            <tt>config/routes
+
+                        <li .list-group-item>
+                            We can link to other handlers, like the <a href="@{CommentR}">Comment</a>.
+
+                        <li .list-group-item>
+                            The HTML you are seeing now is actually composed by a number of <em>widgets</em>, #
+                            most of them are brought together by the <tt>defaultLayout</tt> function which #
+                            is defined in the <tt>Foundation.hs</tt> module, and used by <tt>#{handlerName}</tt>. #
+                            All the files for templates and wigdets are in <tt>templates</tt>.
+
+                        <li .list-group-item>
+                            A Widget's Html, Css and Javascript are separated in three files with the
+                            <tt>.hamlet</tt>, <tt>.lucius</tt> and <tt>.julius</tt> extensions.
+
+                        <li .list-group-item ##{aDomId}>
+                            If you had javascript enabled then you wouldn't be seeing this.
+
+    <hr>
+
+    <!-- Forms
+        ================================================== -->
+    <div .bs-docs-section>
+        <div .row>
+            <div .col-lg-12>
+                <div .page-header>
+                    <h1 #forms>Forms
+
+                    <p>
+                        This is an example of a form. Read the
+                        <a href="http://www.yesodweb.com/book/forms">Forms chapter</a> #
+                        on the yesod book to learn more about them.
+
+        <div .row>
+            <div .col-lg-6>
+                <div .bs-callout bs-callout-info well>
+                    <form .form-horizontal method=post action=@{HomeR}#forms enctype=#{formEnctype}>
+                        ^{formWidget}
+
+                        <button .btn.btn-primary type="submit">
+                            Upload it!
+
+
+            <div .col-lg-4.col-lg-offset-1>
+                <div .bs-callout.bs-callout-info.upload-response>
+
+                    $maybe (FileForm info con) <- submission
+                        Your file type is <em>#{fileContentType info}</em>. You say it has: <em>#{con}</em>
+
+                    $nothing
+                        File upload result will be here...
+
+
+    <hr>
+
+    <!-- JSON
+        ================================================== -->
+    <div .bs-docs-section>
+        <div .row>
+            <div .col-lg-12>
+                <div .page-header>
+                    <h1 #json>JSON
+
+                    <p>
+                        Yesod has JSON support baked-in.
+                        The form below makes an AJAX request with Javascript,
+                        then updates the page with your submission.
+                        (see <tt>Handler/Comment.hs</tt>, <tt>templates/homepage.julius</tt>,
+                        and <tt>Handler/Home.hs</tt> for the implementation).
+
+        <div .row>
+            <div .col-lg-6>
+                <div .bs-callout.bs-callout-info.well>
+                    <form .form-horizontal ##{commentFormId}>
+                        <div .field>
+                            <textarea rows="2" ##{commentTextareaId} placeholder="Your comment here..." required></textarea>
+
+                        <button .btn.btn-primary type=submit>
+                           Create comment
+
+           <div .col-lg-4.col-lg-offset-1>
+               <div .bs-callout.bs-callout-info>
+                   <small>
+                       Your comments will appear here. You can also open the
+                       console log to see the raw response from the server.
+                   <ul ##{commentListId}>
+
+    <hr>
+
+    <!-- Testing
+       ================================================== -->
+    <div .bs-docs-section>
+       <div .row>
+           <div .col-lg-12>
+               <div .page-header>
+                   <h1 #test>Testing
+
+                   <p>
+                       And last but not least, Testing. In <tt>test/Spec.hs</tt> you will find a #
+                       test suite that performs tests on this page.
+                   <p>
+                       You can run your tests by doing: <code>stack test</code>
+
+{-# START_FILE templates/homepage.julius #-}
+document.getElementById(#{toJSON aDomId}).innerHTML = "This text was added by the Javascript part of the homepage widget.";
+
+$(function() {
+  $("##{rawJS commentFormId}").submit(function(event) {
+    event.preventDefault();
+
+    var message = $("##{rawJS commentTextareaId}").val();
+    // (Browsers that enforce the "required" attribute on the textarea won't see this alert)
+    if (!message) {
+      alert("Please fill out the comment form first.");
+      return;
+    }
+
+    // Make an AJAX request to the server to create a new comment
+    $.ajax({
+      url: '@{CommentR}',
+      type: 'POST',
+      contentType: "application/json",
+      data: JSON.stringify({
+        message: message,
+      }),
+      success: function (data) {
+        var newNode = $("<li></li>");
+        newNode.text(data.message);
+        console.log(data);
+        $("##{rawJS commentListId}").append(newNode);
+      },
+      error: function (data) {
+        console.log("Error creating comment: " + data);
+      },
+    });
+
+  });
+});
+
+{-# START_FILE templates/homepage.lucius #-}
+h2##{aDomId} {
+    color: #990
+}
+
+li {
+    line-height: 2em;
+    font-size: 16px
+}
+
+##{commentTextareaId} {
+    width: 400px;
+    height: 100px;
+}
+
+{-# START_FILE test/Handler/CommonSpec.hs #-}
+module Handler.CommonSpec (spec) where
+
+import TestImport
+
+spec :: Spec
+spec = withApp $ do
+    describe "robots.txt" $ do
+        it "gives a 200" $ do
+            get RobotsR
+            statusIs 200
+        it "has correct User-agent" $ do
+            get RobotsR
+            bodyContains "User-agent: *"
+    describe "favicon.ico" $ do
+        it "gives a 200" $ do
+            get FaviconR
+            statusIs 200
+
+{-# START_FILE test/Handler/HomeSpec.hs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Handler.HomeSpec (spec) where
+
+import TestImport
+
+spec :: Spec
+spec = withApp $ do
+
+    describe "Homepage" $ do
+      it "loads the index and checks it looks right" $ do
+          get HomeR
+          statusIs 200
+          htmlAnyContain "h1" "a modern framework for blazing fast websites"
+
+          request $ do
+              setMethod "POST"
+              setUrl HomeR
+              addToken
+              fileByLabelExact "Choose a file" "test/Spec.hs" "text/plain" -- talk about self-reference
+              byLabelExact "What's on the file?" "Some Content"
+
+          -- more debugging printBody
+          htmlAllContain ".upload-response" "text/plain"
+          htmlAllContain ".upload-response" "Some Content"
+
+{-# START_FILE test/Spec.hs #-}
+{-# OPTIONS_GHC -F -pgmF hspec-discover #-}
+
+{-# START_FILE test/TestImport.hs #-}
+{-# LANGUAGE QuasiQuotes       #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module TestImport
+    ( module TestImport
+    , module X
+    ) where
+
+import Application           (makeFoundation, makeLogWare)
+import RIO                   as X hiding (Handler)
+import Foundation            as X
+import Test.Hspec            as X
+import Yesod.Default.Config2 (useEnv, loadYamlSettings)
+import Yesod.Test            as X
+import Yesod.Core.Unsafe     (fakeHandlerGetLogger)
+
+runHandler :: Handler a -> YesodExample App a
+runHandler handler = do
+    app <- getTestYesod
+    fakeHandlerGetLogger appLogger app handler
+
+
+withApp :: SpecWith (TestApp App) -> Spec
+withApp = before $ do
+    settings <- loadYamlSettings
+        ["config/test-settings.yml", "config/settings.yml"]
+        []
+        useEnv
+    foundation <- makeFoundation settings
+    logWare <- liftIO $ makeLogWare foundation
+    return (foundation, logWare)


### PR DESCRIPTION
CF: yesodweb/yesod#1602
CC: @snoyberg

This template takes `yesod-simple` and replaces `classy-prelude-*`
with `rio`. I have checked that everything builds and runs out of the
box, and that the tests are green.

I have not (yet) used it in anger to develop an app, and I am but a
Yesod and RIO neophyte, so it needs careful reviewing.

Some points:

  * bounds on `aeson` and `yaml` were relaxed to allow those in the
    latest lts release (13.25);
  * `http-types`, `yesod-newsfeed` and `persistent` was added with
    no bounds restrictions &mdash; what restrictions should we use
    on these packages?
  * `rio >= 0.1.8.0` : is my starting point &mdash; can we relax the
    upper bound? What upper bound should we use?
  * To get `rio` to work with the current stack I am hiding parts of the
    `rio` logging system (I guess these will be addressed by
    [this work](https://github.com/yesodweb/yesod/issues/1602#issuecomment-496503671)).