### PR TITLE
Fix #135 Support https://keepachangelog.com/ initative

### DIFF
--- a/chrisdone.hsfiles
+++ b/chrisdone.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 library
@@ -66,6 +67,24 @@ import Lib
 main :: IO ()
 main = someFunc
 
+{-# START_FILE README.md #-}
+# {{name}}
+
+add description of {{name}} here
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
+
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}
 
@@ -97,7 +116,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-{-# START_FILE README.md #-}
-# {{name}}
-
-add description of {{name}} here

--- a/foundation.hsfiles
+++ b/foundation.hsfiles
@@ -11,6 +11,7 @@ category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  README.md
+                     ChangeLog.md
 
 executable {{name}}
   hs-source-dirs:      src
@@ -39,3 +40,16 @@ main = do
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD

--- a/franklinchen.hsfiles
+++ b/franklinchen.hsfiles
@@ -1,10 +1,3 @@
-{-# START_FILE README.md #-}
-# {{name}}
-
-[![Build Status](https://travis-ci.org/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}.png)](https://travis-ci.org/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}})
-
-TODO Description.
-
 {-# START_FILE {{name}}.cabal #-}
 name:                {{name}}
 version:             0.1.0.0
@@ -19,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Acme{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 tested-with:         GHC == 7.10.2
 
@@ -51,12 +45,6 @@ test-suite spec
 source-repository head
   type:     git
   location: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
-
-{-# START_FILE .gitignore #-}
-/dist/
-/.cabal-sandbox/
-/cabal.sandbox.config
-/.stack-work/
 
 {-# START_FILE Setup.hs #-}
 import Distribution.Simple
@@ -96,6 +84,7 @@ ourAdd :: Int  -- ^ left
        -> Int  -- ^ right
        -> Int  -- ^ sum
 ourAdd x y = x + y
+
 {-# START_FILE app/Main.hs #-}
 module Main where
 
@@ -105,6 +94,26 @@ import Text.Printf (printf)
 
 main :: IO ()
 main = printf "2 + 3 = %d\n" (ourAdd 2 3)
+
+{-# START_FILE README.md #-}
+# {{name}}
+
+[![Build Status](https://travis-ci.org/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}.png)](https://travis-ci.org/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}})
+
+TODO Description.
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}
@@ -137,6 +146,12 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+{-# START_FILE .gitignore #-}
+/dist/
+/.cabal-sandbox/
+/cabal.sandbox.config
+/.stack-work/
 
 {-# START_FILE .travis.yml #-}
 # Use new container infrastructure to enable caching

--- a/hakyll-template.hsfiles
+++ b/hakyll-template.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 executable {{name}}
@@ -20,29 +21,6 @@ executable {{name}}
   ghc-options:         -threaded
   build-depends:       base >= 4.7 && < 5,
                        hakyll
-
-{-# START_FILE .gitignore #-}
-# Created by https://www.gitignore.io/api/haskell
-
-### Haskell ###
-dist
-cabal-dev
-*.o
-*.hi
-*.chi
-*.chs.h
-*.dyn_o
-*.dyn_hi
-.hpc
-.hsenv
-.cabal-sandbox/
-cabal.sandbox.config
-*.prof
-*.aux
-*.hp
-.stack-work/
-_cache/
-_site/
 
 {-# START_FILE .ghci #-}
 :set -XOverloadedStrings
@@ -298,6 +276,19 @@ div.info {
 {-# START_FILE README.md #-}
 # {{name}}
 
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
+
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}
 
@@ -329,3 +320,26 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+{-# START_FILE .gitignore #-}
+# Created by https://www.gitignore.io/api/haskell
+
+### Haskell ###
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+.stack-work/
+_cache/
+_site/

--- a/haskeleton.hsfiles
+++ b/haskeleton.hsfiles
@@ -58,6 +58,7 @@ tests:
     dependencies:
     - base
     - {{ name }}
+    - hspec
     - tasty
     - tasty-hspec
     ghc-options:
@@ -65,11 +66,59 @@ tests:
     - -threaded
     - -with-rtsopts=-N
 
-{-# START_FILE .gitignore #-}
-# Stack uses this directory as scratch space.
-/.stack-work/
-# Stack generates the Cabal file from `package.yaml` through hpack.
-/*.cabal
+{-# START_FILE Setup.hs #-}
+-- This script is used to build and install your package. Typically you don't
+-- need to change it. The Cabal documentation has more information about this
+-- file: <https://www.haskell.org/cabal/users-guide/installing-packages.html>.
+import qualified Distribution.Simple
+
+main :: IO ()
+main = Distribution.Simple.defaultMain
+
+{-# START_FILE benchmark/Main.hs #-}
+-- You can benchmark your code quickly and effectively with Criterion. See its
+-- website for help: <http://www.serpentine.com/criterion/>.
+import Criterion.Main
+
+main :: IO ()
+main = defaultMain [bench "const" (whnf const ())]
+
+{-# START_FILE executable/Main.hs #-}
+-- It is generally a good idea to keep all your business logic in your library
+-- and only use it in the executable. Doing so allows others to use what you
+-- wrote in their libraries.
+import qualified Example
+
+main :: IO ()
+main = Example.main
+
+{-# START_FILE library/Example.hs #-}
+-- | An example module.
+module Example (main) where
+
+-- | An example function.
+main :: IO ()
+main = return ()
+
+{-# START_FILE test-suite/Main.hs #-}
+-- Tasty makes it easy to test your code. It is a test framework that can
+-- combine many different types of tests into one suite. See its website for
+-- help: <http://documentup.com/feuerbach/tasty>.
+import qualified Test.Tasty
+-- Hspec is one of the providers for Tasty. It provides a nice syntax for
+-- writing tests. Its website has more info: <https://hspec.github.io>.
+import Test.Tasty.Hspec
+import Test.Hspec
+
+main :: IO ()
+main = do
+    test <- testSpec "{{ name }}" spec
+    Test.Tasty.defaultMain test
+
+spec :: Spec
+spec = parallel $ do
+    it "is trivially true" $ do
+        True `shouldBe` True
 
 {-# START_FILE CHANGELOG.md #-}
 # Change log
@@ -79,31 +128,6 @@ The change log is available through the [releases on GitHub][].
 
 [Semantic Versioning]: http://semver.org/spec/v2.0.0.html
 [releases on GitHub]: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{ name }}/releases
-
-{-# START_FILE LICENSE.md #-}
-[The MIT License (MIT)][]
-
-Copyright (c) {{year}}{{^year}}2022{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-[The MIT License (MIT)]: https://opensource.org/licenses/MIT
 
 {-# START_FILE README.md #-}
 # [{{ name }}][]
@@ -155,55 +179,33 @@ Thanks again, and happy hacking!
 
 [{{ name }}]: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{ name }}
 
-{-# START_FILE Setup.hs #-}
--- This script is used to build and install your package. Typically you don't
--- need to change it. The Cabal documentation has more information about this
--- file: <https://www.haskell.org/cabal/users-guide/installing-packages.html>.
-import qualified Distribution.Simple
+{-# START_FILE LICENSE.md #-}
+[The MIT License (MIT)][]
 
-main :: IO ()
-main = Distribution.Simple.defaultMain
+Copyright (c) {{year}}{{^year}}2022{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}
 
-{-# START_FILE benchmark/Main.hs #-}
--- You can benchmark your code quickly and effectively with Criterion. See its
--- website for help: <http://www.serpentine.com/criterion/>.
-import Criterion.Main
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
 
-main :: IO ()
-main = defaultMain [bench "const" (whnf const ())]
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-{-# START_FILE executable/Main.hs #-}
--- It is generally a good idea to keep all your business logic in your library
--- and only use it in the executable. Doing so allows others to use what you
--- wrote in their libraries.
-import qualified Example
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
-main :: IO ()
-main = Example.main
+[The MIT License (MIT)]: https://opensource.org/licenses/MIT
 
-{-# START_FILE library/Example.hs #-}
--- | An example module.
-module Example (main) where
-
--- | An example function.
-main :: IO ()
-main = return ()
-
-{-# START_FILE test-suite/Main.hs #-}
--- Tasty makes it easy to test your code. It is a test framework that can
--- combine many different types of tests into one suite. See its website for
--- help: <http://documentup.com/feuerbach/tasty>.
-import qualified Test.Tasty
--- Hspec is one of the providers for Tasty. It provides a nice syntax for
--- writing tests. Its website has more info: <https://hspec.github.io>.
-import Test.Tasty.Hspec
-
-main :: IO ()
-main = do
-    test <- testSpec "{{ name }}" spec
-    Test.Tasty.defaultMain test
-
-spec :: Spec
-spec = parallel $ do
-    it "is trivially true" $ do
-        True `shouldBe` True
+{-# START_FILE .gitignore #-}
+# Stack uses this directory as scratch space.
+/.stack-work/
+# Stack generates the Cabal file from `package.yaml` through hpack.
+/*.cabal

--- a/hspec.hsfiles
+++ b/hspec.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 library
@@ -87,6 +88,24 @@ import Data.String.Strip
 main :: IO ()
 main = interact strip
 
+{-# START_FILE README.md #-}
+# {{name}}
+
+add description of {{name}} here
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
+
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}
 
@@ -118,7 +137,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-{-# START_FILE README.md #-}
-# {{name}}
-
-add description of {{name}} here

--- a/kurt.hsfiles
+++ b/kurt.hsfiles
@@ -11,6 +11,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 -- To avoid duplicated efforts in documentation and dealing with the
@@ -71,6 +72,19 @@ main = someFunc
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/new-template.hsfiles
+++ b/new-template.hsfiles
@@ -78,7 +78,15 @@ main = someFunc
 {-# START_FILE ChangeLog.md #-}
 # Changelog for {{name}}
 
-## Unreleased changes
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/protolude.hsfiles
+++ b/protolude.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 library
@@ -20,7 +21,7 @@ library
   exposed-modules:     Lib
   other-modules:       Lib.Prelude
   build-depends:       base >= 4.7 && < 5
-                     , protolude >= 0.1.6 && < 0.2
+                     , protolude >= 0.1.6 && < 0.4
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, NoImplicitPrelude
 
@@ -30,7 +31,7 @@ executable {{name}}-exe
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
                      , {{name}}
-                     , protolude >= 0.1.6 && < 0.2
+                     , protolude >= 0.1.6 && < 0.4
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, NoImplicitPrelude
 
@@ -40,7 +41,7 @@ test-suite {{name}}-test
   main-is:             Spec.hs
   build-depends:       base
                      , {{name}}
-                     , protolude >= 0.1.6 && < 0.2
+                     , protolude >= 0.1.6 && < 0.4
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings, NoImplicitPrelude
@@ -103,6 +104,24 @@ import Lib
 main :: IO ()
 main = someFunc
 
+{-# START_FILE README.md #-}
+# {{name}}
+
+add description of {{name}} here
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
+
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}
 
@@ -134,7 +153,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-{-# START_FILE README.md #-}
-# {{name}}
-
-add description of {{name}} here

--- a/quickcheck-test-framework.hsfiles
+++ b/quickcheck-test-framework.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 library
@@ -88,6 +89,19 @@ main = someFunc
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/readme-lhs.hsfiles
+++ b/readme-lhs.hsfiles
@@ -1,114 +1,12 @@
-{-# START_FILE readme.md #-}
-{{name}}
-===
-
-[![Build Status](https://travis-ci.org/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}.png)](https://travis-ci.org/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}})
-
-See https://{{github-username}}{{^github-username}}githubuser{{/github-username}}.github.io/{{name}}/index.html for project description.
-
-~~~
-stack build --test --exec "$(stack path --local-install-root)/bin/{{name}}-example" --exec "$(stack path --local-bin)/pandoc -f markdown+lhs -i app/example.lhs -t html -o index.html --filter pandoc-include --mathjax" --file-watch
-~~~
-
-{-# START_FILE app/example.lhs #-}
-```include
-other/header.md
-```
-
-{{name}}
-===
-
-[ghc options](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/flags.html#flag-reference)
----
-
-\begin{code}
-{-# OPTIONS_GHC -Wall #-}
-{-# OPTIONS_GHC -fno-warn-type-defaults #-}
-\end{code}
-
-[pragmas](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/lang.html)
----
-
-\begin{code}
--- doctest doesn't look at the cabal file, so you need pragmas here
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
-{-# LANGUAGE FlexibleInstances #-}
-\end{code}
-
-[libraries](https://www.stackage.org/)
----
-
-- [protolude](https://www.stackage.org/package/protolude)
-- [optparse-generic](https://www.stackage.org/package/optparse-generic)
-
-\begin{code}
-import Protolude
-import Options.Generic
-\end{code}
-
-code
----
-
-- [hoogle](https://www.stackage.org/package/hoogle)
-
-\begin{code}
-data Opts w = Opts
-    { number :: w ::: Maybe Integer <?> "The number you want to product to"
-    }
-    deriving (Generic)
-
-instance ParseRecord (Opts Wrapped)
-
-main :: IO ()
-main = do
-    o :: Opts Unwrapped <- unwrapRecord "an example app for readme-lhs"
-    let n = fromMaybe 10 (number o)
-    let answer = product [1..n]
-    putStrLn (show answer <> " 👍" :: Text)
-    writeFile "other/answer.md"
-        ("$\\prod_{i=1}^{" <> show n <> "} i = " <>
-         show answer <> "$")
-\end{code}
-
-output
----
-
-```include
-other/answer.md
-```
-
-tests
----
-
-- [doctest](https://www.stackage.org/package/doctest)
-
-\begin{code}
--- | doctests
--- >>> let n = 10
--- >>> product [1..n]
--- 3628800
-\end{code}
-
-***
-
-<div class="footer">
-Powered by [haskell](https://haskell-lang.org/), [stack](https://docs.haskellstack.org/en/stable/README/) and [pandoc](http://pandoc.org/).
-</div>
-
 {-# START_FILE {{name}}.cabal #-}
 name:
   {{name}}
 version:
   0.0.1
 synopsis:
-  See readme.md
+  See README.md
 description:
-  See readme.md for description.
+  See README.md for description.
 category:
   project
 homepage:
@@ -128,7 +26,8 @@ build-type:
 cabal-version:
   >=1.14
 extra-source-files:
-  readme.md
+  README.md
+  ChangeLog.md
   index.html
   stack.yaml
   other/lhs.css
@@ -286,17 +185,144 @@ source-repository head
   location:
     https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}
 
-{-# START_FILE .gitignore #-}
-/.stack-work/
-TAGS
-
-{-# START_FILE .gitattributes #-}
-other/* linguist-documentation
-index.html linguist-documentation
-
 {-# START_FILE Setup.hs #-}
 import Distribution.Simple
 main = defaultMain
+
+{-# START_FILE app/example.lhs #-}
+```include
+other/header.md
+```
+
+{{name}}
+===
+
+[ghc options](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/flags.html#flag-reference)
+---
+
+\begin{code}
+{-# OPTIONS_GHC -Wall #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
+\end{code}
+
+[pragmas](https://downloads.haskell.org/~ghc/latest/docs/html/users_guide/lang.html)
+---
+
+\begin{code}
+-- doctest doesn't look at the cabal file, so you need pragmas here
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE FlexibleInstances #-}
+\end{code}
+
+[libraries](https://www.stackage.org/)
+---
+
+- [protolude](https://www.stackage.org/package/protolude)
+- [optparse-generic](https://www.stackage.org/package/optparse-generic)
+
+\begin{code}
+import Protolude
+import Options.Generic
+\end{code}
+
+code
+---
+
+- [hoogle](https://www.stackage.org/package/hoogle)
+
+\begin{code}
+data Opts w = Opts
+    { number :: w ::: Maybe Integer <?> "The number you want to product to"
+    }
+    deriving (Generic)
+
+instance ParseRecord (Opts Wrapped)
+
+main :: IO ()
+main = do
+    o :: Opts Unwrapped <- unwrapRecord "an example app for readme-lhs"
+    let n = fromMaybe 10 (number o)
+    let answer = product [1..n]
+    putStrLn (show answer <> " 👍" :: Text)
+    writeFile "other/answer.md"
+        ("$\\prod_{i=1}^{" <> show n <> "} i = " <>
+         show answer <> "$")
+\end{code}
+
+output
+---
+
+```include
+other/answer.md
+```
+
+tests
+---
+
+- [doctest](https://www.stackage.org/package/doctest)
+
+\begin{code}
+-- | doctests
+-- >>> let n = 10
+-- >>> product [1..n]
+-- 3628800
+\end{code}
+
+***
+
+<div class="footer">
+Powered by [haskell](https://haskell-lang.org/), [stack](https://docs.haskellstack.org/en/stable/README/) and [pandoc](http://pandoc.org/).
+</div>
+
+{-# START_FILE test/test.hs #-}
+{-# OPTIONS_GHC -Wall #-}
+
+module Main where
+
+import Protolude
+import Test.Tasty (TestTree, testGroup, defaultMain)
+import Test.DocTest
+
+main :: IO ()
+main = do
+    doctest ["app/example.lhs"]
+    defaultMain tests
+
+tests :: TestTree
+tests =
+    testGroup ""
+    [
+    ]
+
+{-# START_FILE README.md #-}
+{{name}}
+===
+
+[![Build Status](https://travis-ci.org/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}.png)](https://travis-ci.org/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}})
+
+See https://{{github-username}}{{^github-username}}githubuser{{/github-username}}.github.io/{{name}}/index.html for project description.
+
+~~~
+stack build --test --exec "$(stack path --local-install-root)/bin/{{name}}-example" --exec "$(stack path --local-bin)/pandoc -f markdown+lhs -i app/example.lhs -t html -o index.html --filter pandoc-include --mathjax" --file-watch
+~~~
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.0.1 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}
@@ -329,6 +355,14 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+{-# START_FILE .gitignore #-}
+/.stack-work/
+TAGS
+
+{-# START_FILE .gitattributes #-}
+other/* linguist-documentation
+index.html linguist-documentation
 
 {-# START_FILE .travis.yml #-}
 # This is the simple Travis configuration, which is intended for use
@@ -499,23 +533,3 @@ body ul li:after {
 <script type="text/javascript" async
   src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
 </script>
-
-{-# START_FILE test/test.hs #-}
-{-# OPTIONS_GHC -Wall #-}
-
-module Main where
-
-import Protolude
-import Test.Tasty (TestTree, testGroup, defaultMain)
-import Test.DocTest
-
-main :: IO ()
-main = do
-    doctest ["app/example.lhs"]
-    defaultMain tests
-
-tests :: TestTree
-tests =
-    testGroup ""
-    [
-    ]

--- a/rio.hsfiles
+++ b/rio.hsfiles
@@ -1,96 +1,3 @@
-{-# START_FILE .gitignore #-}
-*~
-*.swp
-tarballs/
-.stack-work/
-
-{-# START_FILE ChangeLog.md #-}
-# Changelog for {{name}}
-
-## Unreleased changes
-
-{-# START_FILE LICENSE #-}
-Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-
-    * Neither the name of Author name here nor the names of other
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}{{/copyright}} HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}{{/copyright}}
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-{-# START_FILE README.md #-}
-# {{name}}
-
-## Execute
-
-* Run `stack exec -- {{name}}-exe` to see "We're inside the application!"
-* With `stack exec -- {{name}}-exe --verbose` you will see the same message, with more logging.
-
-## Run tests
-
-`stack test`
-
-{-# START_FILE Setup.hs #-}
-import Distribution.Simple
-main = defaultMain
-
-{-# START_FILE app/Main.hs #-}
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TemplateHaskell #-}
-module Main (main) where
-
-import Import
-import Run
-import RIO.Process
-import Options.Applicative.Simple
-import qualified Paths_{{name-as-varid}}
-
-main :: IO ()
-main = do
-  (options, ()) <- simpleOptions
-    $(simpleVersion Paths_{{name-as-varid}}.version)
-    "Header for command line arguments"
-    "Program description, also for command line arguments"
-    (Options
-       <$> switch ( long "verbose"
-                 <> short 'v'
-                 <> help "Verbose output?"
-                  )
-    )
-    empty
-  lo <- logOptionsHandle stderr (optionsVerbose options)
-  pc <- mkDefaultProcessContext
-  withLogFunc lo $ \lf ->
-    let app = App
-          { appLogFunc = lf
-          , appProcessContext = pc
-          , appOptions = options
-          }
-     in runRIO app run
-
 {-# START_FILE package.yaml #-}
 name:                {{name}}
 version:             0.1.0.0
@@ -154,6 +61,44 @@ tests:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+
+{-# START_FILE Setup.hs #-}
+import Distribution.Simple
+main = defaultMain
+
+{-# START_FILE app/Main.hs #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Main (main) where
+
+import Import
+import Run
+import RIO.Process
+import Options.Applicative.Simple
+import qualified Paths_{{name-as-varid}}
+
+main :: IO ()
+main = do
+  (options, ()) <- simpleOptions
+    $(simpleVersion Paths_{{name-as-varid}}.version)
+    "Header for command line arguments"
+    "Program description, also for command line arguments"
+    (Options
+       <$> switch ( long "verbose"
+                 <> short 'v'
+                 <> help "Verbose output?"
+                  )
+    )
+    empty
+  lo <- logOptionsHandle stderr (optionsVerbose options)
+  pc <- mkDefaultProcessContext
+  withLogFunc lo $ \lf ->
+    let app = App
+          { appLogFunc = lf
+          , appProcessContext = pc
+          , appOptions = options
+          }
+     in runRIO app run
 
 {-# START_FILE src/Import.hs #-}
 {-# LANGUAGE NoImplicitPrelude #-}
@@ -231,3 +176,66 @@ spec = do
     it "basic check" $ plus2 0 `shouldBe` 2
     it "overflow" $ plus2 maxBound `shouldBe` minBound + 1
     prop "minus 2" $ \i -> plus2 i - 2 `shouldBe` i
+
+{-# START_FILE README.md #-}
+# {{name}}
+
+## Execute
+
+* Run `stack exec -- {{name}}-exe` to see "We're inside the application!"
+* With `stack exec -- {{name}}-exe --verbose` you will see the same message, with more logging.
+
+## Run tests
+
+`stack test`
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
+
+{-# START_FILE LICENSE #-}
+Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Author name here nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}{{/copyright}} HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {{author-name}}{{^author-name}}Author name here{{/author-name}}{{/copyright}}
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+{-# START_FILE .gitignore #-}
+*~
+*.swp
+tarballs/
+.stack-work/

--- a/rubik.hsfiles
+++ b/rubik.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Development{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 library
@@ -43,7 +44,7 @@ test-suite style
   hs-source-dirs:      test
   main-is:             HLint.hs
   build-depends:       base  >=4.7 && <5
-                     , hlint ==1.*
+                     , hlint ==3.*
   default-language:    Haskell2010
   ghc-options:         -Wall
 
@@ -54,17 +55,6 @@ source-repository head
 {-# START_FILE Setup.hs #-}
 import Distribution.Simple
 main = defaultMain
-
-{-# START_FILE CHANGELOG.md #-}
-# Changelog
-
-This package uses [Semantic Versioning][1].
-
-## v0.1.0.0
-
--   Initially created.
-
-[1]: http://semver.org/spec/v2.0.0.html
 
 {-# START_FILE test/Spec.hs #-}
 main :: IO ()
@@ -106,6 +96,17 @@ main = someFunc
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog
+
+This package uses [Semantic Versioning][1].
+
+## v0.1.0.0
+
+-   Initially created.
+
+[1]: http://semver.org/spec/v2.0.0.html
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/scotty-hspec-wai.hsfiles
+++ b/scotty-hspec-wai.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 library
@@ -124,6 +125,19 @@ main = runApp
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/servant-docker.hsfiles
+++ b/servant-docker.hsfiles
@@ -9,6 +9,7 @@ copyright:           "{{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} 
 
 extra-source-files:
 - README.md
+- ChangeLog.md
 
 # Metadata used when publishing your package
 # synopsis:            Short description of your package
@@ -113,6 +114,19 @@ main = startApp
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/servant.hsfiles
+++ b/servant.hsfiles
@@ -9,6 +9,7 @@ copyright:           "{{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} 
 
 extra-source-files:
 - README.md
+- ChangeLog.md
 
 # Metadata used when publishing your package
 # synopsis:            Short description of your package
@@ -135,6 +136,19 @@ main = startApp
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/simple-hpack.hsfiles
+++ b/simple-hpack.hsfiles
@@ -11,6 +11,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 extra-source-files:
 - README.md
+- ChangeLog.md
 
 dependencies:
   - base >= 4.7 && < 5
@@ -33,6 +34,19 @@ main = do
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/simple-library.hsfiles
+++ b/simple-library.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 library
@@ -38,6 +39,19 @@ someFunc = putStrLn "someFunc"
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/simple.hsfiles
+++ b/simple.hsfiles
@@ -13,6 +13,7 @@ category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  README.md
+                     ChangeLog.md
 
 executable {{name}}
   hs-source-dirs:      src
@@ -26,6 +27,19 @@ main = defaultMain
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE src/Main.hs #-}
 module Main where

--- a/spock.hsfiles
+++ b/spock.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 executable {{name}}
@@ -59,6 +60,19 @@ app =
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/tasty-discover.hsfiles
+++ b/tasty-discover.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 executable {{name}}
@@ -64,6 +65,19 @@ extra-package-dbs: []
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2022{{/year}}

--- a/tasty-travis.hsfiles
+++ b/tasty-travis.hsfiles
@@ -19,6 +19,7 @@ cabal-version:       >=1.10
 
 extra-source-files:
   README.md
+  ChangeLog.md
   stack.yaml
 
 source-repository head
@@ -74,6 +75,10 @@ benchmark {{name}}-benchmark
                    , criterion >= 1.1
                    , {{name}}
 
+{-# START_FILE Setup.hs #-}
+import Distribution.Simple
+main = defaultMain
+
 {-# START_FILE src/Lib.hs #-}
 -- | Example of a library file. It is also used for testing the test suites.
 module Lib
@@ -105,10 +110,6 @@ import Lib (inc)
 
 main :: IO ()
 main = print . inc $ (41 :: Int)
-
-{-# START_FILE Setup.hs #-}
-import Distribution.Simple
-main = defaultMain
 
 {-# START_FILE src-test/Main.hs #-}
 import Test.Tasty
@@ -166,6 +167,28 @@ import Lib (inc)
 main :: IO ()
 main = defaultMain [bench "inc 41" (whnf inc (41 :: Int))]
 
+{-# START_FILE README.md #-}
+{{name}}
+==========
+
+New Haskell project using stack template `tasty-travis`.
+
+Please read file `tutorial.md` for first steps in using the template.
+
+{-# START_FILE ChangeLog.md #-}
+Change log
+==========
+
+{{name}} uses [Semantic Versioning][1].
+The change log is available [on GitHub][2].
+
+[1]: http://semver.org/spec/v2.0.0.html
+[2]: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}/releases
+
+## v0.1.0.0
+
+* Initially created.
+
 {-# START_FILE LICENSE #-}
 Copyright (c) {{year}}{{^year}}2022{{/year}}, {{author-name}}{{^author-name}}TODO:<Author name here>{{/author-name}}
 
@@ -180,14 +203,6 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-{-# START_FILE README.md #-}
-{{name}}
-==========
-
-New Haskell project using stack template `tasty-travis`.
-
-Please read file `tutorial.md` for first steps in using the template.
 
 {-# START_FILE .gitignore #-}
 /tutorial.md
@@ -229,20 +244,6 @@ script: stack $ARGS --no-terminal --install-ghc test
 cache:
   directories:
   - $HOME/.stack
-
-{-# START_FILE CHANGELOG.md #-}
-Change log
-==========
-
-{{name}} uses [Semantic Versioning][1].
-The change log is available [on GitHub][2].
-
-[1]: http://semver.org/spec/v2.0.0.html
-[2]: https://github.com/{{github-username}}{{^github-username}}githubuser{{/github-username}}/{{name}}/releases
-
-## v0.1.0.0
-
-* Initially created.
 
 {-# START_FILE tutorial.md #-}
 

--- a/template-info.yaml
+++ b/template-info.yaml
@@ -16,6 +16,9 @@ haskeleton:
 hspec:
   description: a testing framework for Haskell inspired by the Ruby library RSpec
 
+kurt:
+  description:
+
 new-template:
   description:
 
@@ -68,22 +71,4 @@ unicode-syntax-exe:
   description:
 
 unicode-syntax-lib:
-  description:
-
-yesod-minimal:
-  description:
-
-yesod-mongo:
-  description:
-
-yesod-mysql:
-  description:
-
-yesod-postgres:
-  description:
-
-yesod-simple:
-  description:
-
-yesod-sqlite:
   description:

--- a/unicode-syntax-exe.hsfiles
+++ b/unicode-syntax-exe.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Web{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 executable {{name}}
@@ -34,6 +35,19 @@ main = do
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENCE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} © {{year}}

--- a/unicode-syntax-lib.hsfiles
+++ b/unicode-syntax-lib.hsfiles
@@ -12,6 +12,7 @@ copyright:           {{copyright}}{{^copyright}}{{year}}{{^year}}2022{{/year}} {
 category:            {{category}}{{^category}}Data{{/category}}
 build-type:          Simple
 extra-source-files:  README.md
+                     ChangeLog.md
 cabal-version:       >=1.10
 
 library
@@ -39,6 +40,19 @@ data 𝕋 α β
 
 {-# START_FILE README.md #-}
 # {{name}}
+
+{-# START_FILE ChangeLog.md #-}
+# Changelog for {{name}}
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to the
+[Haskell Package Versioning Policy](https://pvp.haskell.org/).
+
+## Unreleased
+
+## 0.1.0.0 - YYYY-MM-DD
 
 {-# START_FILE LICENCE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} © {{year}}{{^year}}2022{{/year}}


### PR DESCRIPTION
Unless the template already contains an opinionated `ChangeLog.md`, adds or adapts the file to be consistent with the https://keepachangelog.com/.

Orders the content of .hsfiles more consistently (to facilitate comparison).

Also uses `README.md` consistently (`readme-lhs.hsfiles`).

Also updates script `test-templates.hs`. Makes some changes to templates to allow tests to pass.